### PR TITLE
Make all role selects searchable

### DIFF
--- a/src/components/Common/RoleSelect.tsx
+++ b/src/components/Common/RoleSelect.tsx
@@ -47,8 +47,6 @@ export function RoleSelect({
         const selectedRole = roles?.results.find((r) => r.id === selectedId);
         if (selectedRole) {
           onChange(selectedRole);
-        } else {
-          onChange(undefined as any);
         }
       }}
       onSearch={setSearchTerm}

--- a/src/components/Common/RoleSelect.tsx
+++ b/src/components/Common/RoleSelect.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import Autocomplete from "@/components/ui/autocomplete";
+
+import query from "@/Utils/request/query";
+import { mergeAutocompleteOptions } from "@/Utils/utils";
+import { Role } from "@/types/emr/role/role";
+import roleApi from "@/types/emr/role/roleApi";
+
+interface RoleSelectProps {
+  value?: Role;
+  onChange: (value: Role) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function RoleSelect({
+  value,
+  onChange,
+  disabled,
+  className,
+}: RoleSelectProps) {
+  const { t } = useTranslation();
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const { data: roles, isLoading } = useQuery({
+    queryKey: ["roles", searchTerm],
+    queryFn: query.debounced(roleApi.listRoles, {
+      queryParams: { name: searchTerm },
+    }),
+  });
+
+  const options = mergeAutocompleteOptions(
+    roles?.results.map((role) => ({
+      label: role.name,
+      value: role.id,
+    })) || [],
+    value ? { label: value.name, value: value.id } : undefined,
+  );
+
+  return (
+    <Autocomplete
+      value={value?.id || ""}
+      onChange={(selectedId) => {
+        const selectedRole = roles?.results.find((r) => r.id === selectedId);
+        if (selectedRole) {
+          onChange(selectedRole);
+        } else {
+          onChange(undefined as any);
+        }
+      }}
+      onSearch={setSearchTerm}
+      options={options}
+      isLoading={isLoading}
+      placeholder={t("select_role")}
+      inputPlaceholder={t("search_roles")}
+      noOptionsMessage={t("no_roles_found")}
+      disabled={disabled}
+      className={className}
+      closeOnSelect
+    />
+  );
+}

--- a/src/components/Common/RoleSelect.tsx
+++ b/src/components/Common/RoleSelect.tsx
@@ -45,9 +45,7 @@ export function RoleSelect({
       value={value?.id || ""}
       onChange={(selectedId) => {
         const selectedRole = roles?.results.find((r) => r.id === selectedId);
-        if (selectedRole) {
-          onChange(selectedRole);
-        }
+        selectedRole && onChange(selectedRole);
       }}
       onSearch={setSearchTerm}
       options={options}

--- a/src/components/Patient/PatientDetailsTab/PatientUsers.tsx
+++ b/src/components/Patient/PatientDetailsTab/PatientUsers.tsx
@@ -21,13 +21,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -38,6 +31,7 @@ import {
 import { TooltipComponent } from "@/components/ui/tooltip";
 
 import { Avatar } from "@/components/Common/Avatar";
+import { RoleSelect } from "@/components/Common/RoleSelect";
 import UserSelector from "@/components/Common/UserSelector";
 
 import { getPermissions } from "@/common/Permissions";
@@ -47,7 +41,7 @@ import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
 import { usePermissions } from "@/context/PermissionContext";
 import patientApi from "@/types/emr/patient/patientApi";
-import roleApi from "@/types/emr/role/roleApi";
+import { Role } from "@/types/emr/role/role";
 import { UserBase } from "@/types/user/user";
 
 import { PatientProps } from ".";
@@ -61,13 +55,7 @@ function AddUserSheet({ patientId }: AddUserSheetProps) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserBase>();
-  const [selectedRole, setSelectedRole] = useState<string>("");
-
-  const { data: roles } = useQuery({
-    queryKey: ["roles"],
-    queryFn: query(roleApi.listRoles),
-    enabled: open,
-  });
+  const [selectedRole, setSelectedRole] = useState<Role>();
 
   const { mutate: assignUser } = useMutation({
     mutationFn: (body: { user: string; role: string }) =>
@@ -82,7 +70,7 @@ function AddUserSheet({ patientId }: AddUserSheetProps) {
       toast.success("User added to patient successfully");
       setOpen(false);
       setSelectedUser(undefined);
-      setSelectedRole("");
+      setSelectedRole(undefined);
     },
     onError: (error) => {
       const errorData = error.cause as { errors: { msg: string }[] };
@@ -100,13 +88,13 @@ function AddUserSheet({ patientId }: AddUserSheetProps) {
 
     assignUser({
       user: selectedUser.id,
-      role: selectedRole,
+      role: selectedRole.id,
     });
   };
 
   const handleUserChange = (user: UserBase) => {
     setSelectedUser(user);
-    setSelectedRole("");
+    setSelectedRole(undefined);
   };
 
   return (
@@ -187,25 +175,9 @@ function AddUserSheet({ patientId }: AddUserSheetProps) {
                 <label className="text-sm font-medium">
                   {t("select_role")}
                 </label>
-                <Select value={selectedRole} onValueChange={setSelectedRole}>
-                  <SelectTrigger data-cy="patient-user-role-select">
-                    <SelectValue placeholder={t("select_role")} />
-                  </SelectTrigger>
-                  <SelectContent className="w-[var(--radix-select-trigger-width)]">
-                    {roles?.results?.map((role) => (
-                      <SelectItem key={role.id} value={role.id}>
-                        <div className="flex flex-col items-start">
-                          <span>{role.name}</span>
-                          {role.description && (
-                            <span className="text-xs text-gray-500">
-                              {role.description}
-                            </span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <div data-cy="patient-user-role-select">
+                  <RoleSelect value={selectedRole} onChange={setSelectedRole} />
+                </div>
               </div>
 
               <Button

--- a/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -19,13 +19,6 @@ import {
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -35,12 +28,12 @@ import {
 } from "@/components/ui/sheet";
 
 import { Avatar } from "@/components/Common/Avatar";
+import { RoleSelect } from "@/components/Common/RoleSelect";
 import { UserStatusIndicator } from "@/components/Users/UserListAndCard";
 
 import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
-import roleApi from "@/types/emr/role/roleApi";
+import { Role } from "@/types/emr/role/role";
 import { FacilityOrganizationUserRole } from "@/types/facilityOrganization/facilityOrganization";
 import facilityOrganizationApi from "@/types/facilityOrganization/facilityOrganizationApi";
 
@@ -59,14 +52,8 @@ export default function EditUserRoleSheet({
 }: Props) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<string>(userRole.role.id);
+  const [selectedRole, setSelectedRole] = useState<Role>();
   const { t } = useTranslation();
-
-  const { data: roles } = useQuery({
-    queryKey: ["roles"],
-    queryFn: query(roleApi.listRoles),
-    enabled: open,
-  });
 
   const { mutate: updateRole } = useMutation({
     mutationFn: (body: { user: string; role: string }) =>
@@ -118,14 +105,14 @@ export default function EditUserRoleSheet({
   });
 
   const handleUpdateRole = () => {
-    if (selectedRole === userRole.role.id) {
+    if (!selectedRole || selectedRole.id === userRole.role.id) {
       toast.error(t("select_diff_role"));
       return;
     }
 
     updateRole({
       user: userRole.user.id,
-      role: selectedRole,
+      role: selectedRole.id,
     });
   };
 
@@ -186,32 +173,20 @@ export default function EditUserRoleSheet({
             <Label className="text-sm font-medium">
               {t("select_new_role")}
             </Label>
-            <Select value={selectedRole} onValueChange={setSelectedRole}>
-              <SelectTrigger className="h-12" data-cy="select-updated-role">
-                <SelectValue placeholder={t("select_role")} />
-              </SelectTrigger>
-              <SelectContent className="w-[var(--radix-select-trigger-width)]">
-                {roles?.results?.map((role) => (
-                  <SelectItem key={role.id} value={role.id}>
-                    <div className="flex flex-col text-left">
-                      <span>{role.name}</span>
-                      {role.description && (
-                        <span className="text-xs text-gray-500">
-                          {role.description}
-                        </span>
-                      )}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <div data-cy="select-updated-role">
+              <RoleSelect
+                value={selectedRole}
+                onChange={setSelectedRole}
+                className="h-12"
+              />
+            </div>
           </div>
 
           <div className="flex flex-col gap-2">
             <Button
               className="w-full"
               onClick={handleUpdateRole}
-              disabled={selectedRole === userRole.role.id}
+              disabled={!selectedRole || selectedRole.id === userRole.role.id}
               data-cy="update-user-role"
             >
               {t("update_role")}

--- a/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet.tsx
@@ -174,11 +174,7 @@ export default function EditUserRoleSheet({
               {t("select_new_role")}
             </Label>
             <div data-cy="select-updated-role">
-              <RoleSelect
-                value={selectedRole}
-                onChange={setSelectedRole}
-                className="h-12"
-              />
+              <RoleSelect value={selectedRole} onChange={setSelectedRole} />
             </div>
           </div>
 

--- a/src/pages/Facility/settings/organizations/components/LinkFacilityUserSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/LinkFacilityUserSheet.tsx
@@ -179,11 +179,7 @@ export default function LinkFacilityUserSheet({
                   {t("select_role")}
                 </label>
                 <div data-cy="select-role-dropdown">
-                  <RoleSelect
-                    value={selectedRole}
-                    onChange={setSelectedRole}
-                    className="h-12"
-                  />
+                  <RoleSelect value={selectedRole} onChange={setSelectedRole} />
                 </div>
               </div>
 

--- a/src/pages/Facility/settings/organizations/components/LinkFacilityUserSheet.tsx
+++ b/src/pages/Facility/settings/organizations/components/LinkFacilityUserSheet.tsx
@@ -8,13 +8,6 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -24,12 +17,13 @@ import {
 } from "@/components/ui/sheet";
 
 import { Avatar } from "@/components/Common/Avatar";
+import { RoleSelect } from "@/components/Common/RoleSelect";
 import UserSelector from "@/components/Common/UserSelector";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
-import roleApi from "@/types/emr/role/roleApi";
+import { Role } from "@/types/emr/role/role";
 import facilityOrganizationApi from "@/types/facilityOrganization/facilityOrganizationApi";
 import { UserBase } from "@/types/user/user";
 import UserApi from "@/types/user/userApi";
@@ -52,7 +46,7 @@ export default function LinkFacilityUserSheet({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [selectedUser, setSelectedUser] = useState<UserBase>();
-  const [selectedRole, setSelectedRole] = useState<string>("");
+  const [selectedRole, setSelectedRole] = useState<Role>();
 
   const { data: preSelectedUser } = useQuery({
     queryKey: ["user", preSelectedUsername],
@@ -68,12 +62,6 @@ export default function LinkFacilityUserSheet({
     }
   }, [preSelectedUser]);
 
-  const { data: roles } = useQuery({
-    queryKey: ["roles"],
-    queryFn: query(roleApi.listRoles),
-    enabled: open,
-  });
-
   const { mutate: assignUser } = useMutation({
     mutationFn: (body: { user: string; role: string }) =>
       mutate(facilityOrganizationApi.assignUser, {
@@ -87,7 +75,7 @@ export default function LinkFacilityUserSheet({
       toast.success("User added to organization successfully");
       setOpen(false);
       setSelectedUser(undefined);
-      setSelectedRole("");
+      setSelectedRole(undefined);
     },
     onError: (error) => {
       const errorData = error.cause as { errors: { msg: string }[] };
@@ -105,13 +93,13 @@ export default function LinkFacilityUserSheet({
 
     assignUser({
       user: selectedUser.id,
-      role: selectedRole,
+      role: selectedRole.id,
     });
   };
 
   const handleUserChange = (user: UserBase) => {
     setSelectedUser(user);
-    setSelectedRole("");
+    setSelectedRole(undefined);
   };
 
   return (
@@ -190,34 +178,13 @@ export default function LinkFacilityUserSheet({
                 <label className="text-sm font-medium">
                   {t("select_role")}
                 </label>
-                <Select value={selectedRole} onValueChange={setSelectedRole}>
-                  <SelectTrigger
+                <div data-cy="select-role-dropdown">
+                  <RoleSelect
+                    value={selectedRole}
+                    onChange={setSelectedRole}
                     className="h-12"
-                    data-cy="select-role-dropdown"
-                  >
-                    <SelectValue placeholder={t("select_role")} />
-                  </SelectTrigger>
-                  <SelectContent
-                    position="popper"
-                    className="max-h-[calc(100vh-60vh)] w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] overflow-y-auto"
-                    sideOffset={4}
-                    side="bottom"
-                    avoidCollisions={true}
-                  >
-                    {roles?.results?.map((role) => (
-                      <SelectItem key={role.id} value={role.id}>
-                        <div className="flex flex-col text-left">
-                          <span>{role.name}</span>
-                          {role.description && (
-                            <span className="text-xs text-gray-500">
-                              {role.description}
-                            </span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  />
+                </div>
               </div>
 
               <Button

--- a/src/pages/Organization/components/EditUserRoleSheet.tsx
+++ b/src/pages/Organization/components/EditUserRoleSheet.tsx
@@ -176,11 +176,7 @@ export default function EditUserRoleSheet({
               <Label className="text-sm font-medium">
                 {t("select_new_role")}
               </Label>
-              <RoleSelect
-                value={selectedRole}
-                onChange={setSelectedRole}
-                className="h-12"
-              />
+              <RoleSelect value={selectedRole} onChange={setSelectedRole} />
             </div>
 
             <div className="flex flex-col gap-2">

--- a/src/pages/Organization/components/EditUserRoleSheet.tsx
+++ b/src/pages/Organization/components/EditUserRoleSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -19,13 +19,6 @@ import {
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -35,14 +28,14 @@ import {
 } from "@/components/ui/sheet";
 
 import { Avatar } from "@/components/Common/Avatar";
+import { RoleSelect } from "@/components/Common/RoleSelect";
 import { UserStatusIndicator } from "@/components/Users/UserListAndCard";
 
 import useAuthUser from "@/hooks/useAuthUser";
 
 import mutate from "@/Utils/request/mutate";
-import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
-import roleApi from "@/types/emr/role/roleApi";
+import { Role } from "@/types/emr/role/role";
 import { OrganizationUserRole } from "@/types/organization/organization";
 import organizationApi from "@/types/organization/organizationApi";
 
@@ -61,16 +54,10 @@ export default function EditUserRoleSheet({
 }: Props) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<string>(userRole.role.id);
+  const [selectedRole, setSelectedRole] = useState<Role>();
   const [showEditUserSheet, setShowEditUserSheet] = useState(false);
   const authUser = useAuthUser();
   const { t } = useTranslation();
-
-  const { data: roles } = useQuery({
-    queryKey: ["roles"],
-    queryFn: query(roleApi.listRoles),
-    enabled: open,
-  });
 
   const { mutate: updateRole } = useMutation({
     mutationFn: (body: { user: string; role: string }) =>
@@ -114,14 +101,14 @@ export default function EditUserRoleSheet({
   });
 
   const handleUpdateRole = () => {
-    if (selectedRole === userRole.role.id) {
+    if (!selectedRole || selectedRole.id === userRole.role.id) {
       toast.error(t("select_diff_role"));
       return;
     }
 
     updateRole({
       user: userRole.user.id,
-      role: selectedRole,
+      role: selectedRole.id,
     });
   };
   const canEditUser =
@@ -189,32 +176,18 @@ export default function EditUserRoleSheet({
               <Label className="text-sm font-medium">
                 {t("select_new_role")}
               </Label>
-              <Select value={selectedRole} onValueChange={setSelectedRole}>
-                <SelectTrigger className="h-12">
-                  <SelectValue placeholder={t("select_role")} />
-                </SelectTrigger>
-                <SelectContent className="w-[var(--radix-select-trigger-width)]">
-                  {roles?.results?.map((role) => (
-                    <SelectItem key={role.id} value={role.id}>
-                      <div className="flex flex-col text-left">
-                        <span>{role.name}</span>
-                        {role.description && (
-                          <span className="text-xs text-gray-500">
-                            {role.description}
-                          </span>
-                        )}
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <RoleSelect
+                value={selectedRole}
+                onChange={setSelectedRole}
+                className="h-12"
+              />
             </div>
 
             <div className="flex flex-col gap-2">
               <Button
                 className="w-full"
                 onClick={handleUpdateRole}
-                disabled={selectedRole === userRole.role.id}
+                disabled={!selectedRole || selectedRole.id === userRole.role.id}
               >
                 {t("update_role")}
               </Button>

--- a/src/pages/Organization/components/LinkUserSheet.tsx
+++ b/src/pages/Organization/components/LinkUserSheet.tsx
@@ -178,11 +178,7 @@ export default function LinkUserSheet({
                   {t("select_role")}
                 </Label>
                 <div data-cy="select-role-dropdown">
-                  <RoleSelect
-                    value={selectedRole}
-                    onChange={setSelectedRole}
-                    className="h-12"
-                  />
+                  <RoleSelect value={selectedRole} onChange={setSelectedRole} />
                 </div>
               </div>
               <Button

--- a/src/pages/Organization/components/LinkUserSheet.tsx
+++ b/src/pages/Organization/components/LinkUserSheet.tsx
@@ -9,13 +9,6 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -25,12 +18,13 @@ import {
 } from "@/components/ui/sheet";
 
 import { Avatar } from "@/components/Common/Avatar";
+import { RoleSelect } from "@/components/Common/RoleSelect";
 import UserSelector from "@/components/Common/UserSelector";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { formatName } from "@/Utils/utils";
-import roleApi from "@/types/emr/role/roleApi";
+import { Role } from "@/types/emr/role/role";
 import organizationApi from "@/types/organization/organizationApi";
 import { UserBase } from "@/types/user/user";
 import UserApi from "@/types/user/userApi";
@@ -51,7 +45,7 @@ export default function LinkUserSheet({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [selectedUser, setSelectedUser] = useState<UserBase>();
-  const [selectedRole, setSelectedRole] = useState<string>("");
+  const [selectedRole, setSelectedRole] = useState<Role>();
 
   const { data: preSelectedUser } = useQuery({
     queryKey: ["user", preSelectedUsername],
@@ -67,12 +61,6 @@ export default function LinkUserSheet({
     }
   }, [preSelectedUser]);
 
-  const { data: roles } = useQuery({
-    queryKey: ["roles"],
-    queryFn: query(roleApi.listRoles),
-    enabled: open,
-  });
-
   const { mutate: assignUser } = useMutation({
     mutationFn: (body: { user: string; role: string }) =>
       mutate(organizationApi.assignUser, {
@@ -86,7 +74,7 @@ export default function LinkUserSheet({
       toast.success("User added to organization successfully");
       setOpen(false);
       setSelectedUser(undefined);
-      setSelectedRole("");
+      setSelectedRole(undefined);
     },
     onError: (error) => {
       const errorData = error.cause as { errors: { msg: string }[] };
@@ -104,13 +92,13 @@ export default function LinkUserSheet({
 
     assignUser({
       user: selectedUser.id,
-      role: selectedRole,
+      role: selectedRole.id,
     });
   };
 
   const handleUserChange = (value: UserBase) => {
     setSelectedUser(value);
-    setSelectedRole("");
+    setSelectedRole(undefined);
   };
 
   return (
@@ -189,28 +177,13 @@ export default function LinkUserSheet({
                 <Label className="text-sm font-medium">
                   {t("select_role")}
                 </Label>
-                <Select value={selectedRole} onValueChange={setSelectedRole}>
-                  <SelectTrigger
+                <div data-cy="select-role-dropdown">
+                  <RoleSelect
+                    value={selectedRole}
+                    onChange={setSelectedRole}
                     className="h-12"
-                    data-cy="select-role-dropdown"
-                  >
-                    <SelectValue placeholder={t("select_role")} />
-                  </SelectTrigger>
-                  <SelectContent className="w-[var(--radix-select-trigger-width)]">
-                    {roles?.results?.map((role) => (
-                      <SelectItem key={role.id} value={role.id}>
-                        <div className="flex flex-col text-left">
-                          <span>{role.name}</span>
-                          {role.description && (
-                            <span className="text-xs text-gray-500">
-                              {role.description}
-                            </span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  />
+                </div>
               </div>
               <Button
                 className="w-full"


### PR DESCRIPTION
## Proposed Changes

- Make all role selects searchable as we were so far able to see only first 14 roles in the existing selects due to pagination

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Ensure that UI text is placed in I18n files.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new role selection component with autocomplete and improved user experience for selecting roles.

* **Refactor**
  * Updated multiple user management and settings screens to use the new role selection component, streamlining the UI and simplifying role assignment workflows.
  * Changed internal state management for selected roles from string IDs to full role objects, enhancing consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->