### PR TITLE
disable collect speciment if request pending

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -5454,7 +5454,7 @@
   "username_max_length_validation": "Use at most <strong>16 characters</strong>",
   "username_min_length_validation": "Use at least <strong>4 characters</strong>",
   "username_not_available": "Username is not available",
-  "username_not_valid": "username is not valid",
+  "username_not_valid": "Username is not valid",
   "username_start_end_validation": "Must start and end with a <strong>letter</strong> or <strong>number</strong>",
   "username_success_message": "All set! Your username is strong",
   "username_userdetails_not_found": "Unable to fetch details as username or user details not found",

--- a/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
+++ b/src/pages/Facility/services/serviceRequests/components/SpecimenForm.tsx
@@ -92,7 +92,7 @@ export function SpecimenForm({
     },
   });
 
-  const { mutate: updateSpecimen } = useMutation({
+  const { mutate: updateSpecimen, isPending } = useMutation({
     mutationFn: mutate(specimenApi.updateSpecimen, {
       pathParams: {
         facilityId,
@@ -529,10 +529,15 @@ export function SpecimenForm({
             </div>
 
             <div className="flex justify-end gap-2 pt-2">
-              <Button type="button" variant="outline" onClick={onCancel}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onCancel}
+                disabled={isPending}
+              >
                 {t("cancel")}
               </Button>
-              <Button type="submit" disabled={disableEdit}>
+              <Button type="submit" disabled={disableEdit || isPending}>
                 {t("collect")}
               </Button>
             </div>


### PR DESCRIPTION
## Proposed Changes

- disable collect speciment if request pending

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Specimen form buttons are now disabled during collection and update operations to prevent duplicate submissions and provide clearer feedback.

* **Localization**
  * Improved English message text for username validation to use proper capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->