### PR TITLE
feat: read fixture IDs from backend manifest instead of UI navigation

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -113,6 +113,9 @@ jobs:
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.local.env
           echo MAX_QUESTIONNAIRE_TEXT_RESPONSE_SIZE=500 >> docker/.local.env
           make docker_config_file=docker-compose.local.yaml up load-fixtures
+          # Copy fixture manifest from backend container so FE tests can read IDs directly
+          mkdir -p ../tests/.auth
+          docker compose cp backend:/app/fixture_manifest.json ../tests/.auth/fixture_manifest.json || echo "Warning: fixture_manifest.json not found in container"
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -115,7 +115,7 @@ jobs:
           make docker_config_file=docker-compose.local.yaml up load-fixtures
           # Copy fixture manifest from backend container so FE tests can read IDs directly
           mkdir -p ../tests/.auth
-          docker compose cp backend:/app/fixture_manifest.json ../tests/.auth/fixture_manifest.json || echo "Warning: fixture_manifest.json not found in container"
+          docker compose -f docker-compose.yaml -f docker-compose.local.yaml cp backend:/app/fixture_manifest.json ../tests/.auth/fixture_manifest.json || echo "Warning: fixture_manifest.json not found in container"
           cd ..
         env:
           JWKS_BASE64: ${{ secrets.JWKS_BASE64 }}

--- a/tests/support/encounterId.ts
+++ b/tests/support/encounterId.ts
@@ -2,16 +2,27 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
+import { getEncounterIdFromManifest } from "./fixtureManifest";
+
 const META_PATH = path.resolve("tests/.auth/encounterMeta.json");
 let cachedId: string | null = null;
 
 /**
- * Returns the encounterId saved during setup.
- * Auto-runs the setup if the meta file is missing or invalid.
+ * Returns the encounterId.
+ * Prefers the backend fixture manifest (written by load_fixtures --output-json).
+ * Falls back to the legacy meta file written by patient.setup.ts.
  */
 export function getEncounterId(): string {
   if (cachedId) return cachedId;
 
+  // Try manifest first
+  const manifestId = getEncounterIdFromManifest();
+  if (manifestId) {
+    cachedId = manifestId;
+    return manifestId;
+  }
+
+  // Fall back to legacy meta file
   if (!fs.existsSync(META_PATH)) {
     console.warn("⚠️ Encounter meta missing — running encounter setup...");
     try {

--- a/tests/support/facilityId.ts
+++ b/tests/support/facilityId.ts
@@ -2,16 +2,27 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
+import { getFacilityIdFromManifest } from "./fixtureManifest";
+
 const META_PATH = path.resolve("tests/.auth/facilityMeta.json");
 let cachedId: string | null = null;
 
 /**
- * Returns the facilityId saved during setup.
- * Auto-runs the setup if the meta file is missing or invalid.
+ * Returns the facilityId.
+ * Prefers the backend fixture manifest (written by load_fixtures --output-json).
+ * Falls back to the legacy meta file written by facility.setup.ts.
  */
 export function getFacilityId(): string {
   if (cachedId) return cachedId;
 
+  // Try manifest first
+  const manifestId = getFacilityIdFromManifest();
+  if (manifestId) {
+    cachedId = manifestId;
+    return manifestId;
+  }
+
+  // Fall back to legacy meta file
   if (!fs.existsSync(META_PATH)) {
     console.warn("⚠️ Facility meta missing — running facility setup...");
     try {

--- a/tests/support/fixtureManifest.ts
+++ b/tests/support/fixtureManifest.ts
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Shape of the fixture manifest written by the backend's
+ * `manage.py load_fixtures --output-json`.
+ */
+interface FixtureManifest {
+  admin: { username: string; password: string };
+  facility: { id: string; name: string };
+  geo_organization_id: string;
+  facility_organization_id: string;
+  patients: Array<{
+    id: string;
+    name: string;
+    encounters: Array<{ id: string }>;
+  }>;
+  users: Array<{ username: string; password: string; role: string }>;
+  locations: Array<{ id: string; name: string }>;
+  devices: Array<{ id: string; name: string }>;
+}
+
+const MANIFEST_PATH = path.resolve("tests/.auth/fixture_manifest.json");
+let cached: FixtureManifest | null = null;
+
+/**
+ * Returns the fixture manifest written by the backend.
+ * Falls back to individual meta files if the manifest doesn't exist
+ * (backwards-compatible with the old UI-extraction approach).
+ */
+export function getFixtureManifest(): FixtureManifest | null {
+  if (cached) return cached;
+
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    return null;
+  }
+
+  const raw = fs.readFileSync(MANIFEST_PATH, "utf8");
+  cached = JSON.parse(raw) as FixtureManifest;
+  return cached;
+}
+
+/**
+ * Returns the facility ID from the manifest, or null if unavailable.
+ */
+export function getFacilityIdFromManifest(): string | null {
+  const manifest = getFixtureManifest();
+  return manifest?.facility?.id ?? null;
+}
+
+/**
+ * Returns the first patient ID from the manifest, or null if unavailable.
+ */
+export function getPatientIdFromManifest(): string | null {
+  const manifest = getFixtureManifest();
+  return manifest?.patients?.[0]?.id ?? null;
+}
+
+/**
+ * Returns the first encounter ID from the manifest, or null if unavailable.
+ */
+export function getEncounterIdFromManifest(): string | null {
+  const manifest = getFixtureManifest();
+  return manifest?.patients?.[0]?.encounters?.[0]?.id ?? null;
+}

--- a/tests/support/fixtureManifest.ts
+++ b/tests/support/fixtureManifest.ts
@@ -24,9 +24,8 @@ const MANIFEST_PATH = path.resolve("tests/.auth/fixture_manifest.json");
 let cached: FixtureManifest | null = null;
 
 /**
- * Returns the fixture manifest written by the backend.
- * Falls back to individual meta files if the manifest doesn't exist
- * (backwards-compatible with the old UI-extraction approach).
+ * Returns the fixture manifest written by the backend, or null if
+ * unavailable. Callers fall back to individual meta files when null.
  */
 export function getFixtureManifest(): FixtureManifest | null {
   if (cached) return cached;
@@ -36,8 +35,15 @@ export function getFixtureManifest(): FixtureManifest | null {
   }
 
   const raw = fs.readFileSync(MANIFEST_PATH, "utf8");
-  cached = JSON.parse(raw) as FixtureManifest;
-  return cached;
+  try {
+    cached = JSON.parse(raw) as FixtureManifest;
+    return cached;
+  } catch (error) {
+    console.warn(
+      `Invalid fixture_manifest.json at ${MANIFEST_PATH}: ${error instanceof Error ? error.message : String(error)}. Falling back to legacy meta files.`,
+    );
+    return null;
+  }
 }
 
 /**

--- a/tests/support/patientId.ts
+++ b/tests/support/patientId.ts
@@ -2,16 +2,27 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
+import { getPatientIdFromManifest } from "./fixtureManifest";
+
 const META_PATH = path.resolve("tests/.auth/patientMeta.json");
 let cachedId: string | null = null;
 
 /**
- * Returns the patientId saved during setup.
- * Auto-runs the setup if the meta file is missing or invalid.
+ * Returns the patientId.
+ * Prefers the backend fixture manifest (written by load_fixtures --output-json).
+ * Falls back to the legacy meta file written by patient.setup.ts.
  */
 export function getPatientId(): string {
   if (cachedId) return cachedId;
 
+  // Try manifest first
+  const manifestId = getPatientIdFromManifest();
+  if (manifestId) {
+    cachedId = manifestId;
+    return manifestId;
+  }
+
+  // Fall back to legacy meta file
   if (!fs.existsSync(META_PATH)) {
     console.warn("⚠️ Patient meta missing — running patient setup...");
     try {


### PR DESCRIPTION
Add fixtureManifest.ts that reads the JSON manifest written by the
backend's load_fixtures --output-json. Update facilityId, patientId,
and encounterId support modules to try manifest first, falling back to
the legacy UI-navigation approach for backwards compatibility. Update
CI workflow to copy manifest from backend container.

https://claude.ai/code/session_011i8in4FLq4renAvgodeJJu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test fixture provisioning in CI so frontend tests reliably receive backend-generated fixture manifests.
  * Prefer manifest-sourced IDs with robust caching and graceful fallback to legacy meta files.

* **Tests**
  * Added utilities to read and query backend fixture manifests, making test data lookup more reliable and reducing flaky test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->