### PR TITLE
Managed responsibility dropdown issue:

### DIFF
--- a/src/components/Common/RoleSelect.tsx
+++ b/src/components/Common/RoleSelect.tsx
@@ -183,9 +183,14 @@ export function RoleSelect({
     </Button>
   );
 
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) setSearchTerm("");
+  };
+
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={setOpen}>
+      <Drawer open={open} onOpenChange={handleOpenChange}>
         <DrawerTrigger asChild>{renderTriggerButton()}</DrawerTrigger>
         <DrawerContent className="px-0 pt-2 min-h-[50vh] max-h-[85vh] rounded-t-lg">
           <div className="mt-3 pb-[env(safe-area-inset-bottom)] flex-1 overflow-y-auto">
@@ -206,9 +211,9 @@ export function RoleSelect({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={handleOpenChange} modal>
       <PopoverTrigger asChild>{renderTriggerButton()}</PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
         <RoleCommandContent
           setSearchTerm={setSearchTerm}
           rolesList={rolesList}


### PR DESCRIPTION
## Proposed Changes

Fixes #16238
Changes Made

Added a new handler in RoleSelect:

handleOpenChange(isOpen: boolean)
Updates the open state
Resets searchTerm to "" when the component is closed
Updated onOpenChange usage:
Drawer
from: onOpenChange={setOpen}
to: onOpenChange={handleOpenChange}
Popover
from: onOpenChange={setOpen}
to: onOpenChange={handleOpenChange}
🧩 Why This Fix Works
Root Cause:
searchTerm was persisting after closing the Drawer/Popover, leading to stale filtered results when reopened.
Fix Behavior:
On close → searchTerm is reset to ""
On reopen → component shows a fresh, unfiltered list
 **Result**
Eliminates stale search state
Ensures consistent UX across open/close cycles
Keeps component behavior predictable and clean

Tagging: @ohcnetwork/care-fe-code-reviewers




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role selection search term now clears when the popup is closed, providing a fresh start on the next open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->