### PR TITLE
Fix: Responsibilities Page: Fixed Mobile Clear Button

### DIFF
--- a/src/pages/Admin/organizations/AdminOrganizationList.tsx
+++ b/src/pages/Admin/organizations/AdminOrganizationList.tsx
@@ -70,8 +70,12 @@ export default function AdminOrganizationList({
   });
 
   const handleOrganizationSelect = useCallback(
-    (organization: Organization) => {
-      navigate(`/admin/organizations/${organizationType}/${organization.id}`);
+    (organization?: Organization) => {
+      navigate(
+        organization
+          ? `/admin/organizations/${organizationType}/${organization.id}`
+          : `/admin/organizations/${organizationType}`,
+      );
     },
     [organizationType],
   );
@@ -134,9 +138,7 @@ export default function AdminOrganizationList({
           <div className="md:hidden">
             <OrgSelect
               value={organizationId}
-              onChange={(selectedOrg) => {
-                if (selectedOrg) handleOrganizationSelect(selectedOrg);
-              }}
+              onChange={handleOrganizationSelect}
               orgType={organizationType as OrgType}
               placeholder={
                 isRoleOrg


### PR DESCRIPTION
## Proposed Changes

Fixes #16237
- Extracted logic to a handler
- Navigating back to `/admin/organizations/role` route upon clearing 

https://github.com/user-attachments/assets/1b7545b5-d160-4d9d-abe0-3a7c2565f525


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Facility-scoped practitioner selection is now cached and restored, improving queue selection persistence.
* **Bug Fixes**
  * Clearing an organization on mobile returns to the organizations list.
  * Selected organization reliably appears among selection options.
* **UI**
  * Print layout updated (wider labels, added patient phone and bill ID).
  * Global toggle for monetary components now applies only to discount-type components.
* **Localization**
  * Added English label for bill ID.
* **Chores**
  * Practitioner cache cleared during login and full cache clears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->