### PR TITLE
[EMG-37] feat: add Care Form generator skill with detailed workflow and knowledge management

### DIFF
--- a/.ai/skills/form.knowledge.md
+++ b/.ai/skills/form.knowledge.md
@@ -1,0 +1,210 @@
+# Form Skill — Knowledge Base
+
+> **Auto-maintained by the `form.skill.md` workflow.**
+> Append after every session. Do not delete history — strike through if obsolete.
+
+This file is the long-term memory for the Care Form generator skill. It stores
+mapping overrides, codes the user has confirmed, per-form templates already
+produced, and explicit user preferences, so each new form takes less back-and-forth.
+
+---
+
+## User preferences
+
+_Append a bullet whenever the user expresses a recurring preference._
+
+- Refer to questionnaires as **"forms"** in conversation. Internal JSON field
+  names stay `questionnaire`-prefixed.
+- Prefer writing JSON output to files in `tmp/forms/<slug>.json` (gitignored)
+  rather than pasting into chat.
+- Use sensible defaults from `form.skill.md` without re-asking each time.
+- **Do NOT add LOINC/SNOMED/UCUM `code` fields by default.** Omit `code`
+  on every question (and the top-level form `code`) unless the user
+  explicitly asks for codes. This applies to vitals, BP panels, scores,
+  everything. The unit still goes inside the question `text`
+  (e.g. `"Heart Rate (/min)"`), and `is_observation: true` is still set
+  on measurement questions — only the `code` object is dropped.
+  _(2026-04-27: user explicitly said "ignore the Code (LOINC) its not
+  mandatory unless the user ask for it".)_
+- Always confirm `enable_when` (conditional logic) with the user before
+  emitting JSON.
+- **Do not include a `curl` POST template** in the final summary. Just
+  report the file path. _(2026-04-27 user preference.)_
+
+---
+
+## Mapping overrides
+
+_Per-user adjustments to the default type-mapping table in `form.skill.md`._
+
+### CRITICAL — Vital signs and measurements
+
+Confirmed against production examples (`/Users/abhimanyurajeesh/Desktop/examples/`,
+2026-04-27 review):
+
+- **Vitals are `decimal`, NOT `quantity`.** This includes HR, RR, SpO₂, temp,
+  weight, height, BMI, lab values, scores, glucose.
+- **Encode the unit inside the question `text`** in parentheses:
+  - `"Heart Rate (/min)"`
+  - `"Respiratory Rate (/min)"`
+  - `"Oxygen Saturation (%)"`
+  - `"Body Temperature (Cel)"`
+  - `"Weight (kg)"`
+  - `"Height (cm)"`
+  - `"Systolic Blood Pressure (mm[Hg])"`
+  - `"Diastolic Blood Pressure (mm[Hg])"`
+- **Always set `is_observation: true`** on these measurement questions.
+- **Do NOT set the `unit` or `answer_unit` fields** on the question. The
+  schema has them but the production form builder never emits them, and the
+  backend's choice-vs-quantity validator can misclassify the question if you do.
+- **Blood Pressure** = `group` with `is_component: true`, coded with LOINC
+  panel `85354-9`, containing systolic + diastolic decimal children. Add
+  `styling_metadata.containerClasses: "grid grid-cols-2"` for layout.
+
+### Other production conventions
+
+- `version` is a **number** (`0.1`), not a string.
+- `organizations` field is **omitted** in the request body.
+- `id` should be a **UUID v4**, not a kebab-case slug.
+- `link_id` may be hierarchical (`"1"`, `"1.7.2"`) OR `Q-<unix-ms>` from the
+  in-app builder. Pick one style per form.
+- `answer_option` entries can be just `{ "value": "TEXT" }` — `display` is
+  optional.
+- Layout hints go in `styling_metadata.containerClasses` (Tailwind), commonly
+  `"grid grid-cols-2"` on `group`s.
+
+### Structured questions — minimal & standalone
+
+Never wrap a structured question in a single-child group. Never add `code`,
+`answer_option`, `unit`, `answer_unit`, or children. Only:
+
+```json
+{
+  "id": "<uuid>",
+  "link_id": "Q-... or hierarchical",
+  "text": "Chief Complaints",
+  "type": "structured",
+  "structured_type": "symptom",
+  "required": false,
+  "repeats": false,
+  "description": "optional"
+}
+```
+
+Reference of `structured_type` values seen in production:
+
+| Value                  | Production usage                                              |
+| ---------------------- | ------------------------------------------------------------- |
+| `symptom`              | Chief complaints, presenting/secondary symptoms, key findings |
+| `diagnosis`            | Provisional/final dx, comorbidities, surgical history         |
+| `medication_request`   | New prescriptions, discharge meds                             |
+| `medication_statement` | Pre-existing meds the patient is already taking               |
+| `allergy_intolerance`  | Allergy history                                               |
+| `service_request`      | Procedure / lab / imaging requests                            |
+| `appointment`          | Follow-up appointment booking                                 |
+| `files`                | Document/image uploads (e.g. outside investigation reports)   |
+| `encounter`            | Encounter metadata edit                                       |
+| `time_of_death`        | Death recording                                               |
+| `charge_item`          | Billing line item                                             |
+
+---
+
+## Confirmed codes
+
+_LOINC / SNOMED / UCUM codes the user has explicitly approved.
+Reuse these without re-asking._
+
+### Vitals (LOINC)
+
+| Concept                   | System              | Code     | Display                        |
+| ------------------------- | ------------------- | -------- | ------------------------------ |
+| Heart rate                | http://loinc.org    | 8867-4   | Heart rate                     |
+| Blood pressure panel      | http://loinc.org    | 85354-9  | Blood pressure panel with all children optional |
+| Systolic BP               | http://loinc.org    | 8480-6   | Systolic blood pressure        |
+| Diastolic BP              | http://loinc.org    | 8462-4   | Diastolic blood pressure       |
+| Body temperature          | http://loinc.org    | 8310-5   | Body temperature               |
+| Respiratory rate          | http://loinc.org    | 9279-1   | Respiratory rate               |
+| Oxygen saturation (SpO₂, pulse ox) | http://loinc.org    | 59408-5  | Oxygen saturation in Arterial blood by Pulse oximetry |
+| Oxygen saturation (SpO₂, generic)  | http://loinc.org    | 2708-6   | Oxygen saturation in Arterial blood |
+| Body weight               | http://loinc.org    | 29463-7  | Body weight                    |
+| Body height               | http://loinc.org    | 8302-2   | Body height                    |
+| BMI                       | http://loinc.org    | 39156-5  | Body mass index                |
+| Pain score (0-10)         | http://loinc.org    | 72514-3  | Pain severity 0-10 verbal numeric |
+
+> _These are commonly-used seeds. Mark them confirmed only after the user has
+> approved them in an actual session._
+
+### Units (UCUM, `http://unitsofmeasure.org`)
+
+| Quantity      | UCUM code  | Display |
+| ------------- | ---------- | ------- |
+| Heart rate    | `/min`     | bpm     |
+| BP            | `mm[Hg]`   | mmHg    |
+| Temperature   | `Cel`      | °C      |
+| Weight        | `kg`       | kg      |
+| Height        | `cm`       | cm      |
+| Percent       | `%`        | %       |
+| Respiratory   | `/min`     | breaths/min |
+
+---
+
+## Per-form templates
+
+_Every generated form gets a record here so we can reuse / version it later._
+
+### Template entry format
+
+```
+### <Title>
+- **slug**: `<slug>`
+- **subject_type**: `patient` | `encounter`
+- **status**: `draft` | `active`
+- **created**: YYYY-MM-DD
+- **last_used**: YYYY-MM-DD
+- **source**: image | pdf | text | named-instrument
+- **file**: `tmp/forms/<slug>.json`
+- **summary**: One sentence.
+- **notable decisions**:
+  - …
+```
+
+_(no forms generated yet)_
+
+### Clinical Vitals Assessment
+
+- **slug**: `vitals-assessment`
+- **subject_type**: `encounter`
+- **status**: `draft`
+- **created**: 2026-04-27
+- **last_used**: 2026-04-27
+- **source**: text ("form for taking vitals")
+- **file**: `tmp/forms/vitals-assessment.json`
+- **summary**: Basic vitals (HR, BP, RR, temp, SpO₂), anthropometrics (weight, height), pain score, clinical notes. **No LOINC/SNOMED codes** per user preference.
+- **notable decisions**:
+  - First draft used `type: "quantity"` with explicit `unit` fields → backend rejected with "choice type" validation error.
+  - Second iteration: `decimal` + `is_observation: true`, units encoded in `text` (e.g. `"Weight (kg)"`), BP as `is_component` group, `version: 0.1`, no `organizations` field.
+  - **2026-04-27 regen**: User instructed "ignore the Code (LOINC) it's not mandatory unless the user asks for it". Stripped **all** `code` objects, including the BP panel code `85354-9`. BP group keeps `is_component: true` and `grid grid-cols-2` styling but no panel code. Systolic/diastolic remain `decimal` + `is_observation: true` with units in text.
+
+---
+
+## Session log
+
+_One line per use of the skill. Newest at top._
+
+- **2026-04-27** — Regenerated `vitals-assessment` form per new user preference: **no LOINC/SNOMED codes by default**. Stripped all `code` objects (incl. BP panel code). Kept `is_component` + `grid grid-cols-2` on BP group. Added preference to `## User preferences`.
+- **2026-04-27** — Reviewed 6 production form examples in `~/Desktop/examples/` (clinical-assessment-123, clinical-follow-up, discharge-advice-and-me, discharge-summary-report, ent_op_examination, mlsp-form-for-category). Rewrote `form.skill.md` and `form.knowledge.md` with corrected conventions: vitals = `decimal` + `is_observation` + unit-in-text (not `quantity`), `is_component` for BP-style panels, structured questions stand alone with no extras, `version` is a number, omit `organizations`, layout via `styling_metadata.containerClasses`.
+- **2026-04-27** — First attempt at `vitals-assessment` form failed backend validation due to `unit` field on quantity questions.
+
+## Common clinical instruments cheat-sheet
+
+_Quick reference. When the user names one of these, use the canonical fields
+below as the starting draft (still confirm with user)._
+
+- **Glasgow Coma Scale (GCS)** — Eye (1-4), Verbal (1-5), Motor (1-6); total 3-15. LOINC 9269-2.
+- **Apgar Score** — Appearance, Pulse, Grimace, Activity, Respiration; each 0-2. LOINC 9272-6 (1-min), 9274-2 (5-min).
+- **MMSE (Folstein)** — 30-point cognitive screen across orientation, registration, attention, recall, language. LOINC 72106-8.
+- **PHQ-9** — 9 items 0-3, total 0-27. LOINC 44249-1.
+- **GAD-7** — 7 items 0-3, total 0-21. LOINC 70274-6.
+- **NEWS2** — Resp rate, SpO₂, supplemental O₂, temp, systolic BP, HR, consciousness.
+- **Edinburgh Postnatal Depression Scale (EPDS)** — 10 items, 0-3 each.
+- **WHO Surgical Safety Checklist** — Sign In / Time Out / Sign Out checklists.

--- a/.ai/skills/form.knowledge.md
+++ b/.ai/skills/form.knowledge.md
@@ -39,8 +39,6 @@ _Per-user adjustments to the default type-mapping table in `form.skill.md`._
 
 ### CRITICAL — Vital signs and measurements
 
-Confirmed against production examples (`/Users/abhimanyurajeesh/Desktop/examples/`,
-2026-04-27 review):
 
 - **Vitals are `decimal`, NOT `quantity`.** This includes HR, RR, SpO₂, temp,
   weight, height, BMI, lab values, scores, glucose.
@@ -57,9 +55,10 @@ Confirmed against production examples (`/Users/abhimanyurajeesh/Desktop/examples
 - **Do NOT set the `unit` or `answer_unit` fields** on the question. The
   schema has them but the production form builder never emits them, and the
   backend's choice-vs-quantity validator can misclassify the question if you do.
-- **Blood Pressure** = `group` with `is_component: true`, coded with LOINC
-  panel `85354-9`, containing systolic + diastolic decimal children. Add
-  `styling_metadata.containerClasses: "grid grid-cols-2"` for layout.
+- **Blood Pressure** = `group` with `is_component: true`, containing systolic +
+  diastolic decimal children. Add `styling_metadata.containerClasses: "grid grid-cols-2"`
+  for layout. The panel's `code` (LOINC `85354-9`) should only be included when
+  the user explicitly requests coded fields (see global policy above).
 
 ### Other production conventions
 

--- a/.ai/skills/form.skill.md
+++ b/.ai/skills/form.skill.md
@@ -1,0 +1,518 @@
+# Skill: Care Form (Questionnaire) JSON Generator
+
+> Internal name in code: **Questionnaire**. Externally we call this a **Form**.
+> When the user says "form", they mean a Care Questionnaire.
+
+You are an expert assistant that turns a description, image, or PDF of a
+physical/clinical form into a valid Care `QuestionnaireCreate` JSON payload
+that can be POSTed to `POST /api/v1/questionnaire/`.
+
+## Mission
+
+Given any of:
+
+- An **image** of a paper form
+- A **PDF** of a form
+- A **textual description** ("I need a form to capture vitals + GCS")
+- A **named clinical instrument** ("MMSE", "Glasgow Coma Scale", "WHO Surgical
+  Safety Checklist", "Apgar Score", "Edinburgh Postnatal Depression Scale"…)
+
+…produce a clean, accurate Care form JSON file, after confirming the structure
+with the user.
+
+## Workflow (follow strictly, in order)
+
+### 1. Intake
+
+- Read the attachment / message. Extract every visible field with: label,
+  widget type, options, units, required-ness, conditional logic, sectioning.
+- If the input is just a name (e.g. "MMSE"), use your medical knowledge to
+  reconstruct the canonical field list. **Cite the version/source** in the
+  draft so the user can verify (e.g. "MMSE — Folstein 1975, 30-point").
+- If anything in the input is illegible/ambiguous, list it explicitly under an
+  "Ambiguities" heading and ask before proceeding.
+
+### 2. Load knowledge
+
+- **Always** read `.ai/skills/form.knowledge.md` before drafting. It contains:
+  - Mapping overrides
+  - Standard codes previously confirmed by the user
+  - Per-form templates already produced (reuse, don't reinvent)
+  - User preferences
+
+### 3. Draft a human-readable spec
+
+Post a markdown table to chat **before any JSON**. Format:
+
+| # | Section | Question text | `type` | `required` | Options / Unit | Notes (conditional, code suggestion) |
+
+Group with H3 section headers if the form has sections. Include:
+
+- Suggested `slug`, `title`, `description`, `subject_type`, `version`, `status`
+- Suggested LOINC/SNOMED `code` for any field where you're confident
+  (mark with `?` so the user can confirm/reject)
+- Any `enable_when` (conditional) logic you detected, **explicitly listed**
+
+### 4. Confirm
+
+Stop and ask the user to confirm or correct. Do **not** generate JSON yet.
+Specifically request explicit confirmation for:
+
+1. Subject type (`patient` vs `encounter`)
+2. Any field where `code` was suggested
+3. Any `enable_when` you inferred ("If yes → ask X")
+4. Any field where you guessed `integer` vs `decimal` vs `quantity`
+
+### 5. Generate JSON file
+
+After confirmation, write the file to:
+
+```
+tmp/forms/<slug>.json
+```
+
+(Create the directory if needed. `tmp/` is gitignored — safe scratch space.)
+
+The file must be a single JSON document matching `QuestionnaireCreate`
+(see "Output schema" below). Pretty-printed, 2-space indent, trailing newline.
+
+After writing, tell the user:
+
+- The file path
+- give the path to open the file
+
+### 6. Update knowledge
+
+**Mandatory.** Append a new entry to `.ai/skills/form.knowledge.md` under
+the `## Per-form templates` section with:
+
+- Date, form name, slug
+- One-line summary
+- Any new code mappings the user confirmed (also add to `## Confirmed codes`)
+- Any new mapping override the user requested (add to `## Mapping overrides`)
+- Any user preference observed (add to `## User preferences`)
+
+If you used an existing entry from the knowledge file, also bump its
+"last used" date.
+
+---
+
+## Output schema (`QuestionnaireCreate`)
+
+```jsonc
+{
+  "slug": "kebab-case-unique-slug",
+  "title": "Human Readable Title",
+  "description": "Optional short description.",
+  "version": 0.1,                            // NUMBER, not string
+  "status": "draft",                         // "draft" | "active" | "retired"
+  "subject_type": "encounter",               // "patient" | "encounter"
+  "code": {                                  // OPTIONAL top-level code
+    "system": "http://loinc.org",
+    "code": "...",
+    "display": "..."
+  },
+  "tags": [],                                // user fills these in
+  "questions": [ /* Question[] — see below */ ]
+}
+```
+
+> **Note**: Production payloads from the in-app form builder omit
+> `organizations` entirely. Only include it if the user explicitly asks.
+
+### `Question` shape
+
+```jsonc
+{
+  "id": "<uuid-v4>",                        // UUID, unique within the form
+  "link_id": "1.2.3",                        // hierarchical OR "Q-<timestamp>"
+  "text": "Question shown to user",          // for measurements: include unit, e.g. "Weight (kg)"
+  "description": "Optional helper text",
+  "type": "decimal",                         // see types below
+  "required": false,
+  "repeats": false,                          // true = multi-answer
+  "read_only": false,
+  "max_length": 255,                         // string/text only
+  "is_observation": true,                    // vital signs / lab values
+  "is_component": true,                      // group whose children are panel components (e.g. BP)
+  "code": { "system": "http://loinc.org", "code": "8867-4", "display": "Heart rate" },
+  "answer_option": [                         // choice only — `display` is optional
+    { "value": "Yes" },
+    { "value": "No", "initial_selected": true }
+  ],
+  "answer_value_set": "system-valueset-slug", // alt to answer_option
+  "enable_when": [
+    { "question": "<other-question-link_id>", "operator": "equals", "answer": "yes" }
+  ],
+  "enable_behavior": "all",                  // "all" | "any"
+  "disabled_display": "hidden",              // "hidden" | "protected"
+  "structured_type": "medication_request",   // structured only — see list below
+  "styling_metadata": {                      // group layout
+    "containerClasses": "grid grid-cols-2"
+  },
+  "questions": [ /* nested Question[] for groups */ ]
+}
+```
+
+> **Do NOT use `unit` or `answer_unit` fields** for vitals/measurements. They
+> exist in the TypeScript schema but production forms encode units inline in
+> the question `text` (e.g. `"Heart Rate (/min)"`, `"Weight (kg)"`,
+> `"Body Temperature (Cel)"`). Setting `unit` can also cause backend
+> validation to misinterpret the question type.
+
+### Allowed `type` values
+
+`group | display | boolean | decimal | integer | date | dateTime | time | string | text | url | choice | quantity | structured`
+
+### Allowed `structured_type` values (when `type: "structured"`)
+
+`allergy_intolerance | medication_request | medication_statement | symptom | diagnosis | encounter | time_of_death | files | service_request | charge_item | appointment`
+
+A `structured` question stands alone — it embeds a full Care-managed sub-form.
+**Never** add `code`, `answer_option`, `answer_value_set`, `unit`,
+`answer_unit`, `max_length`, or nested `questions` to a structured question.
+Only `id`, `link_id`, `text`, `type`, `structured_type`, and optionally
+`description`, `required`, `repeats` are valid.
+
+### `enable_when` operator matrix
+
+| Answer datatype       | Allowed operators                                          |
+| --------------------- | ---------------------------------------------------------- |
+| boolean               | `exists`, `equals`, `not_equals`                           |
+| string / choice value | `equals`, `not_equals`                                     |
+| number (int/decimal)  | `greater`, `less`, `greater_or_equals`, `less_or_equals`   |
+
+The `question` field in `enable_when` references the **`link_id`** of another
+question, not its `id`. An empty `"enable_when": []` is also valid (no-op).
+
+---
+
+## Defaults & conventions
+
+Use these unless the user overrides:
+
+| Field          | Default                                                 |
+| -------------- | ------------------------------------------------------- |
+| `status`       | `"draft"`                                               |
+| `version`      | `"1.0"`                                                 |
+| `subject_type` | `"encounter"` for clinical forms; ask if unclear        |
+| `slug`         | kebab-case from title, ASCII only, ≤ 60 chars           |
+| `id`           | kebab-case from question text, unique within the form   |
+| `link_id`      | hierarchical numeric: `"1"`, `"1.1"`, `"1.2"`, `"2"`, … |
+| `required`     | `false` unless the form marks it (asterisk, "required") |
+| `organizations`| `[]` (user fills)                                       |
+| `tags`         | `[]` (user fills)                                       |
+
+---
+
+## Type-mapping rules (default)
+
+| Physical-form widget                        | Care `type`                          |
+| ------------------------------------------- | ------------------------------------ |
+| Single-line free text                       | `string`                             |
+| Multi-line / paragraph                      | `text`                               |
+| Whole number, no unit (count, score)        | `integer`                            |
+| Decimal number, no unit                     | `decimal`                            |
+| **Vitals / measurements with a unit (BP, weight, temp, HR, SpO₂)** | **`decimal` + `is_observation: true`, encode unit in `text` like `"Heart Rate (/min)"`, `"Weight (kg)"`** |
+| Yes/No, single checkbox                     | `boolean`                            |
+| Radio / dropdown / single-select            | `choice` (no `repeats`)              |
+| Multi-select / checkbox list                | `choice` + `repeats: true`           |
+| Date / DOB                                  | `date`                               |
+| Time of day                                 | `time`                               |
+| Full timestamp                              | `dateTime`                           |
+| URL                                         | `url`                                |
+| Section header / instructions / blurb       | `display` (no input)                 |
+| Logical group with sub-fields               | `group` (use nested `questions[]`)   |
+| Allergies, Meds, Diagnoses, Symptoms, etc.  | `structured` + matching `structured_type` |
+
+> **Important on `quantity` vs `decimal`**: In production Care forms, vital
+> signs and lab measurements are recorded as **`decimal`** with `is_observation: true`,
+> and the unit is **embedded in the question `text`** (e.g. `"Heart Rate (/min)"`).
+> The `quantity` type exists in the schema but is rarely used for vitals;
+> when used, **never set `unit` in the question** — users pick the unit from a
+> UCUM dropdown at response time. Default to `decimal` for vitals unless the
+> user explicitly asks for `quantity`.
+
+Always check the knowledge file for **mapping overrides** before applying these.
+
+---
+
+## Observation flag (`is_observation`)
+
+Set `is_observation: true` on every question that records a clinical
+measurement that should land in the patient's observation timeline:
+
+- All vital signs (HR, BP components, RR, SpO₂, temperature, weight, height, BMI)
+- Lab values, scores, glucose, pain scales
+- Anything with a LOINC/SNOMED `code` that represents an "observation"
+
+Do **not** set it on free-text narrative fields, structured questions,
+groups, or admin/demographic fields.
+
+---
+
+## Component grouping (`is_component`) for paneled observations
+
+Use `is_component: true` on a `group` whose children are sub-measurements of
+a single panel (the canonical example is **Blood Pressure**: a group coded with
+LOINC panel `85354-9` containing a systolic child `8480-6` and a diastolic
+child `8462-4`). This tells Care to treat the children as components of one
+observation rather than independent observations.
+
+```jsonc
+{
+  "id": "...", "link_id": "1.7",
+  "text": "Blood Pressure",
+  "type": "group",
+  "is_component": true,
+  "code": { "system": "http://loinc.org", "code": "85354-9",
+            "display": "Blood pressure panel with all children optional" },
+  "styling_metadata": { "containerClasses": "grid grid-cols-2" },
+  "questions": [
+    { "type": "decimal", "is_observation": true,
+      "text": "Systolic Blood Pressure (mm[Hg])",
+      "code": { "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }, ... },
+    { "type": "decimal", "is_observation": true,
+      "text": "Diastolic Blood Pressure (mm[Hg])",
+      "code": { "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }, ... }
+  ]
+}
+```
+
+---
+
+## Structured questions (deep dive)
+
+Structured questions embed a full Care-managed sub-form. They appear
+**standalone** at any level — they do **not** need their own group wrapper,
+and they take **no** `code`, `answer_option`, `unit`, or children.
+
+### Allowed `structured_type` values
+
+| `structured_type`        | Use for                                                         |
+| ------------------------ | --------------------------------------------------------------- |
+| `symptom`                | Chief complaints, presenting/secondary symptoms, key findings   |
+| `diagnosis`              | Provisional/final diagnosis, comorbidities, surgical history    |
+| `medication_request`     | New prescriptions, discharge medications                        |
+| `medication_statement`   | Pre-existing meds the patient is already on                     |
+| `allergy_intolerance`    | Allergy history                                                 |
+| `service_request`        | Procedure / lab / imaging requests                              |
+| `appointment`            | Follow-up appointment booking                                   |
+| `files`                  | Document/image uploads (e.g. outside investigation reports)     |
+| `encounter`              | Encounter metadata edit                                         |
+| `time_of_death`          | Death recording                                                 |
+| `charge_item`            | Billing line item                                               |
+
+### Minimal shape
+
+```jsonc
+{
+  "id": "<uuid>",
+  "link_id": "Q-<timestamp>",   // or hierarchical "2"
+  "text": "Chief Complaints",
+  "type": "structured",
+  "structured_type": "symptom",
+  "required": false,
+  "repeats": false,
+  "description": "Optional helper text shown to clinician"
+}
+```
+
+Do **not** add `code`, `answer_option`, `answer_value_set`, `unit`,
+`answer_unit`, `max_length`, or nested `questions[]` to structured questions.
+
+---
+
+## Layout (`styling_metadata`)
+
+Use `styling_metadata.containerClasses` (Tailwind classes) to control how a
+group renders. The most common pattern in production:
+
+```jsonc
+"styling_metadata": { "containerClasses": "grid grid-cols-2" }
+```
+
+Apply it to `group` questions (including `is_component` groups like BP) when
+the form should display children in a 2-column layout. Omit otherwise — single
+column is the default.
+
+---
+
+## `link_id` conventions
+
+Two valid formats are used interchangeably in production:
+
+1. **Hierarchical numeric**: `"1"`, `"1.1"`, `"1.7.2"` — preferred when the
+   form has a clear outline structure (vitals panels, scored instruments).
+2. **Timestamp**: `"Q-1757602015153"` — auto-generated by the in-app form
+   builder. Acceptable but less readable; use only when generating from a
+   form that already has them.
+
+Pick **one** convention per form and stick with it.
+
+---
+
+## Coding (LOINC / SNOMED / UCUM)
+
+- **Default: do NOT add `code` fields.** Per user preference, omit the
+  `code` object on every question (and the top-level form `code`) unless
+  the user **explicitly** asks for codes ("add LOINC codes", "include
+  coding", etc.). Units still go inside the question `text`
+  (e.g. `"Heart Rate (/min)"`) and `is_observation: true` is still set
+  on measurement questions — only the `code` object is dropped.
+- **Only when the user asks for codes**: suggest standard codes when you
+  recognise a clinical concept; mark them with a `?` in the draft so the
+  user can confirm/reject.
+- Common systems (when codes are requested):
+  - `http://loinc.org` — observations, panels (BP, HR, BMI, scores)
+  - `http://snomed.info/sct` — conditions, procedures, body sites
+  - `http://unitsofmeasure.org` — units (UCUM: `mg`, `kg`, `mm[Hg]`, `Cel`)
+- After user confirms a code, **add it to `## Confirmed codes`** in the
+  knowledge file so future code-enabled forms reuse it without re-asking.
+- If unsure, **omit the field** rather than guess.
+
+---
+
+## Conditional logic (`enable_when`)
+
+Whenever the source has "If Yes, then…", "If applicable, specify…", arrows,
+or sub-sections gated on a parent answer:
+
+1. Note the parent question's `link_id`.
+2. Add `enable_when` to the dependent question(s) with the right operator.
+3. Default `enable_behavior` to `"all"`.
+4. Default `disabled_display` to `"hidden"`.
+5. **List every conditional in the draft and confirm with the user** before
+   writing JSON.
+
+---
+
+## Quality checklist (run before writing the file)
+
+- [ ] Every `id` is unique within the form (use UUIDs)
+- [ ] Every `link_id` is unique; one consistent format per form (hierarchical OR `Q-<ts>`)
+- [ ] Every `enable_when.question` references an existing `link_id`
+- [ ] No `answer_option` on non-`choice` questions
+- [ ] No `unit` / `answer_unit` field on **any** question (vitals use `decimal` with unit in `text`)
+- [ ] Vital signs / measurements are `decimal` + `is_observation: true` + LOINC `code`
+- [ ] BP-style panels use `group` + `is_component: true` with the panel LOINC code
+- [ ] `structured` questions have a valid `structured_type` and **no** code/options/children
+- [ ] `group` questions have a non-empty `questions[]`
+- [ ] `version` is a number (e.g. `0.1`), not a string
+- [ ] No `organizations` field in the body (the in-app form builder omits it)
+- [ ] JSON parses (no trailing commas, balanced braces)
+- [ ] Slug is unique vs. existing entries in the knowledge file
+
+---
+
+## Example (skeleton — vitals + structured, matches production conventions)
+
+```json
+{
+  "title": "Basic Vitals & Symptoms",
+  "slug": "vitals-basic",
+  "description": "Captures core vitals plus chief complaints.",
+  "version": 0.1,
+  "status": "draft",
+  "subject_type": "encounter",
+  "tags": [],
+  "questions": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "link_id": "1",
+      "text": "Vitals",
+      "type": "group",
+      "required": false,
+      "styling_metadata": { "containerClasses": "grid grid-cols-2" },
+      "questions": [
+        {
+          "id": "00000000-0000-4000-8000-000000000002",
+          "link_id": "1.1",
+          "text": "Heart Rate (/min)",
+          "type": "decimal",
+          "is_observation": true,
+          "code": { "system": "http://loinc.org", "code": "8867-4", "display": "Heart rate" }
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000003",
+          "link_id": "1.2",
+          "text": "Oxygen Saturation (%)",
+          "type": "decimal",
+          "is_observation": true,
+          "code": { "system": "http://loinc.org", "code": "59408-5",
+                    "display": "Oxygen saturation in Arterial blood by Pulse oximetry" }
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000004",
+          "link_id": "1.3",
+          "text": "Blood Pressure",
+          "type": "group",
+          "is_component": true,
+          "code": { "system": "http://loinc.org", "code": "85354-9",
+                    "display": "Blood pressure panel with all children optional" },
+          "styling_metadata": { "containerClasses": "grid grid-cols-2" },
+          "questions": [
+            {
+              "id": "00000000-0000-4000-8000-000000000005",
+              "link_id": "1.3.1",
+              "text": "Systolic Blood Pressure (mm[Hg])",
+              "type": "decimal",
+              "is_observation": true,
+              "code": { "system": "http://loinc.org", "code": "8480-6", "display": "Systolic blood pressure" }
+            },
+            {
+              "id": "00000000-0000-4000-8000-000000000006",
+              "link_id": "1.3.2",
+              "text": "Diastolic Blood Pressure (mm[Hg])",
+              "type": "decimal",
+              "is_observation": true,
+              "code": { "system": "http://loinc.org", "code": "8462-4", "display": "Diastolic blood pressure" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000007",
+      "link_id": "2",
+      "text": "Chief Complaints",
+      "type": "structured",
+      "structured_type": "symptom",
+      "required": false
+    }
+  ]
+}
+```
+
+---
+
+## Things to **never** do
+
+- ❌ Generate JSON before user confirms the draft spec
+- ❌ Invent LOINC/SNOMED codes without flagging them as suggestions
+- ❌ Forget to update `form.knowledge.md` after every session
+- ❌ Use `id` as the target of `enable_when` (must be `link_id`)
+- ❌ Mix `answer_option` and `answer_value_set` on the same question
+- ❌ Set a `unit` field on quantity/decimal questions — encode unit in the
+  `text` (e.g. `"Weight (kg)"`) instead. The schema's `unit` field is for an
+  edge-case UI flow only and the backend may reject pre-filled units.
+- ❌ Use `type: "quantity"` for vitals — production forms use `decimal` with
+  `is_observation: true`. Only use `quantity` when the user explicitly asks
+  for a runtime unit picker.
+- ❌ Add `code`, `answer_option`, `unit`, or nested `questions` to a
+  `structured` question — they take none of those.
+- ❌ Wrap a `structured` question in a single-child group "for organisation" —
+  put it directly at its parent level.
+- ❌ Quote the `version` field — it's a number (`0.1`), not a string.
+- ❌ Edit Crowdin-managed locale files; if you need a label, just put it in
+  `text` directly (English).
+
+---
+
+## Related code (read these if you need to verify the schema)
+
+- `src/types/questionnaire/questionnaire.ts` — `QuestionnaireBase`, `QuestionnaireCreate`
+- `src/types/questionnaire/question.ts` — `Question`, `QuestionType`, `EnableWhen`, `AnswerOption`
+- `src/types/questionnaire/quantity.ts` — `Quantity`
+- `src/types/base/code/code.ts` — `Code`
+- `src/components/Questionnaire/data/StructuredFormData.tsx` — `StructuredQuestionType` values


### PR DESCRIPTION
## Proposed Changes

[Fixes ](https://openhealthcarenetwork.atlassian.net/browse/ENG-37?atlOrigin=eyJpIjoiY2YzMzZmYzFiZTU1NDg3MGIwZmNiZDViNzIzMDU0ZTUiLCJwIjoiaiJ9)


The PR adds a ai skill and knowledge file that can help in creating forms(questionnaire) easily. 

<img width="666" height="679" alt="image" src="https://github.com/user-attachments/assets/3a35ff47-d2d7-40e6-b64e-de7577a739b7" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive knowledge base and skill specification for the Care Form (questionnaire) generator: standardized workflow, user confirmation steps, output conventions and validation checklist, measurement and structured-question rules, observation/grouping conventions (including blood-pressure panel layout), mapping and encoding preferences, template/versioning guidance, and a clinical instrument cheat‑sheet to improve consistency and reliability of generated forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->