### PR TITLE
Make Payment sheet url accessible in Account & Invoice

### DIFF
--- a/src/Routers/routes/FacilityRoutes.tsx
+++ b/src/Routers/routes/FacilityRoutes.tsx
@@ -100,48 +100,24 @@ const FacilityRoutes: AppRoutes = {
   }) => (
     <AccountShow facilityId={facilityId} accountId={accountId} tab="invoices" />
   ),
-  "/facility/:facilityId/billing/account/:accountId/invoices": ({
-    facilityId,
-    accountId,
-  }) => (
-    <AccountShow facilityId={facilityId} accountId={accountId} tab="invoices" />
-  ),
-  "/facility/:facilityId/billing/account/:accountId/charge_items": ({
-    facilityId,
-    accountId,
-  }) => (
-    <AccountShow
-      facilityId={facilityId}
-      accountId={accountId}
-      tab="charge_items"
-    />
-  ),
   "/facility/:facilityId/billing/account/:accountId/charge_items/print": ({
     facilityId,
     accountId,
   }) => <PrintChargeItems facilityId={facilityId} accountId={accountId} />,
-  "/facility/:facilityId/billing/account/:accountId/payments": ({
+  "/facility/:facilityId/billing/account/:accountId/:tab": ({
     facilityId,
     accountId,
-  }) => (
-    <AccountShow facilityId={facilityId} accountId={accountId} tab="payments" />
-  ),
-  "/facility/:facilityId/billing/account/:accountId/reports": ({
-    facilityId,
-    accountId,
-  }) => (
-    <AccountShow facilityId={facilityId} accountId={accountId} tab="reports" />
-  ),
-  "/facility/:facilityId/billing/account/:accountId/bed_charge_items": ({
-    facilityId,
-    accountId,
-  }) => (
-    <AccountShow
-      facilityId={facilityId}
-      accountId={accountId}
-      tab="bed_charge_items"
-    />
-  ),
+    tab,
+  }) => <AccountShow facilityId={facilityId} accountId={accountId} tab={tab} />,
+  "/facility/:facilityId/billing/account/:accountId/:tab/payment/:paymentType":
+    ({ facilityId, accountId, tab, paymentType }) => (
+      <AccountShow
+        facilityId={facilityId}
+        accountId={accountId}
+        tab={tab}
+        paymentType={paymentType}
+      />
+    ),
   "/facility/:facilityId/billing/account/:accountId/invoices/create": ({
     facilityId,
     accountId,
@@ -153,6 +129,16 @@ const FacilityRoutes: AppRoutes = {
     facilityId,
     invoiceId,
   }) => <InvoiceShow facilityId={facilityId} invoiceId={invoiceId} />,
+  "/facility/:facilityId/billing/invoices/:invoiceId/pay": ({
+    facilityId,
+    invoiceId,
+  }) => (
+    <InvoiceShow
+      facilityId={facilityId}
+      invoiceId={invoiceId}
+      paymentType="pay"
+    />
+  ),
   "/facility/:facilityId/billing/invoice/:invoiceId/print": ({
     facilityId,
     invoiceId,

--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -92,7 +92,7 @@ export const ACCOUNT_TABS = [
 ] as const;
 export type AccountTab = (typeof ACCOUNT_TABS)[number];
 
-export const ACCOUNT_PAYMENT_TYPES = ["advance", "credit_note"] as const;
+export const ACCOUNT_PAYMENT_TYPES = ["pay", "credit_note"] as const;
 export type AccountPaymentType = (typeof ACCOUNT_PAYMENT_TYPES)[number];
 
 const closedStatusText = {
@@ -390,10 +390,7 @@ export function AccountShow({
                 {t("create_invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button
-                variant="primary"
-                onClick={() => openPaymentSheet("advance")}
-              >
+              <Button variant="primary" onClick={() => openPaymentSheet("pay")}>
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("add_credit_payment")}
                 <ShortcutBadge actionId="credit-payment-account" />
@@ -415,10 +412,7 @@ export function AccountShow({
                 {t("invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button
-                variant="primary"
-                onClick={() => openPaymentSheet("advance")}
-              >
+              <Button variant="primary" onClick={() => openPaymentSheet("pay")}>
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("credit")}
                 <ShortcutBadge actionId="record-payment-account" />

--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -109,22 +109,29 @@ export function AccountShow({
 }) {
   const { t } = useTranslation();
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [qParams, setQueryParams] = useQueryParams<{ payment?: string }>();
-  const paymentSheet = {
-    isOpen: qParams.payment === "advance" || qParams.payment === "credit",
-    isCreditNote: qParams.payment === "credit",
-  };
-  const setPaymentSheet = (next: {
-    isOpen: boolean;
-    isCreditNote: boolean;
-  }) => {
-    const { payment: _payment, ...rest } = qParams;
+  const [qParams, setQueryParams] = useQueryParams<{
+    is_payment?: string;
+    is_credit_note?: string;
+  }>();
+  const isPaymentSheetOpen = qParams.is_payment === "true";
+  const isCreditNote = qParams.is_credit_note === "true";
+  const openPaymentSheet = (creditNote: boolean) => {
     setQueryParams(
-      next.isOpen
-        ? { ...rest, payment: next.isCreditNote ? "credit" : "advance" }
-        : rest,
+      {
+        ...qParams,
+        is_payment: "true",
+        ...(creditNote && { is_credit_note: "true" }),
+      },
       { replace: true },
     );
+  };
+  const closePaymentSheet = () => {
+    const {
+      is_payment: _isPayment,
+      is_credit_note: _isCreditNote,
+      ...rest
+    } = qParams;
+    setQueryParams(rest, { replace: true });
   };
   const [transferPaymentOpen, setTransferPaymentOpen] = useState(false);
   const queryClient = useQueryClient();
@@ -389,15 +396,7 @@ export function AccountShow({
                 {t("create_invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button
-                variant="primary"
-                onClick={() =>
-                  setPaymentSheet({
-                    isOpen: true,
-                    isCreditNote: false,
-                  })
-                }
-              >
+              <Button variant="primary" onClick={() => openPaymentSheet(false)}>
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("add_credit_payment")}
                 <ShortcutBadge actionId="credit-payment-account" />
@@ -419,15 +418,7 @@ export function AccountShow({
                 {t("invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button
-                variant="primary"
-                onClick={() =>
-                  setPaymentSheet({
-                    isOpen: true,
-                    isCreditNote: false,
-                  })
-                }
-              >
+              <Button variant="primary" onClick={() => openPaymentSheet(false)}>
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("credit")}
                 <ShortcutBadge actionId="record-payment-account" />
@@ -460,14 +451,7 @@ export function AccountShow({
                       {t("settle_close")}
                       <ShortcutBadge actionId="settle-close-account" />
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() =>
-                        setPaymentSheet({
-                          isOpen: true,
-                          isCreditNote: true,
-                        })
-                      }
-                    >
+                    <DropdownMenuItem onClick={() => openPaymentSheet(true)}>
                       <CareIcon icon="l-plus" className="mr-2 size-4" />
                       {t("record_credit_note")}
                     </DropdownMenuItem>
@@ -744,11 +728,13 @@ export function AccountShow({
       />
 
       <PaymentReconciliationSheet
-        open={paymentSheet.isOpen}
-        onOpenChange={(isOpen) => setPaymentSheet({ ...paymentSheet, isOpen })}
+        open={isPaymentSheetOpen}
+        onOpenChange={(open) =>
+          open ? openPaymentSheet(isCreditNote) : closePaymentSheet()
+        }
         facilityId={facilityId}
         accountId={accountId}
-        isCreditNote={paymentSheet.isCreditNote}
+        isCreditNote={isCreditNote}
         account={account}
       />
 

--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -2,7 +2,7 @@ import { DialogDescription } from "@radix-ui/react-dialog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Hash, MoreVertical } from "lucide-react";
-import { Link, navigate, useQueryParams } from "raviger";
+import { Link, navigate } from "raviger";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -83,12 +83,17 @@ function formatDate(date?: string) {
   });
 }
 
-type tab =
-  | "charge_items"
-  | "invoices"
-  | "payments"
-  | "bed_charge_items"
-  | "reports";
+export const ACCOUNT_TABS = [
+  "invoices",
+  "charge_items",
+  "payments",
+  "reports",
+  "bed_charge_items",
+] as const;
+export type AccountTab = (typeof ACCOUNT_TABS)[number];
+
+export const ACCOUNT_PAYMENT_TYPES = ["advance", "credit_note"] as const;
+export type AccountPaymentType = (typeof ACCOUNT_PAYMENT_TYPES)[number];
 
 const closedStatusText = {
   [AccountBillingStatus.closed_baddebt]: "close_account_help_closed_baddebt",
@@ -102,36 +107,25 @@ export function AccountShow({
   facilityId,
   accountId,
   tab,
+  paymentType,
 }: {
   facilityId: string;
   accountId: string;
-  tab: tab;
+  tab: string;
+  paymentType?: string;
 }) {
   const { t } = useTranslation();
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [qParams, setQueryParams] = useQueryParams<{
-    is_payment?: string;
-    is_credit_note?: string;
-  }>();
-  const isPaymentSheetOpen = qParams.is_payment === "true";
-  const isCreditNote = qParams.is_credit_note === "true";
-  const openPaymentSheet = (creditNote: boolean) => {
-    setQueryParams(
-      {
-        ...qParams,
-        is_payment: "true",
-        ...(creditNote && { is_credit_note: "true" }),
-      },
+  const openPaymentSheet = (type: AccountPaymentType) => {
+    navigate(
+      `/facility/${facilityId}/billing/account/${accountId}/${tab}/payment/${type}`,
       { replace: true },
     );
   };
   const closePaymentSheet = () => {
-    const {
-      is_payment: _isPayment,
-      is_credit_note: _isCreditNote,
-      ...rest
-    } = qParams;
-    setQueryParams(rest, { replace: true });
+    navigate(`/facility/${facilityId}/billing/account/${accountId}/${tab}`, {
+      replace: true,
+    });
   };
   const [transferPaymentOpen, setTransferPaymentOpen] = useState(false);
   const queryClient = useQueryClient();
@@ -396,7 +390,10 @@ export function AccountShow({
                 {t("create_invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button variant="primary" onClick={() => openPaymentSheet(false)}>
+              <Button
+                variant="primary"
+                onClick={() => openPaymentSheet("advance")}
+              >
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("add_credit_payment")}
                 <ShortcutBadge actionId="credit-payment-account" />
@@ -418,7 +415,10 @@ export function AccountShow({
                 {t("invoice")}
                 <ShortcutBadge actionId="create-invoice" />
               </Button>
-              <Button variant="primary" onClick={() => openPaymentSheet(false)}>
+              <Button
+                variant="primary"
+                onClick={() => openPaymentSheet("advance")}
+              >
                 <CareIcon icon="l-plus" className="size-4" />
                 {t("credit")}
                 <ShortcutBadge actionId="record-payment-account" />
@@ -451,7 +451,9 @@ export function AccountShow({
                       {t("settle_close")}
                       <ShortcutBadge actionId="settle-close-account" />
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => openPaymentSheet(true)}>
+                    <DropdownMenuItem
+                      onClick={() => openPaymentSheet("credit_note")}
+                    >
                       <CareIcon icon="l-plus" className="mr-2 size-4" />
                       {t("record_credit_note")}
                     </DropdownMenuItem>
@@ -728,13 +730,11 @@ export function AccountShow({
       />
 
       <PaymentReconciliationSheet
-        open={isPaymentSheetOpen}
-        onOpenChange={(open) =>
-          open ? openPaymentSheet(isCreditNote) : closePaymentSheet()
-        }
+        open={paymentType !== undefined}
+        onOpenChange={(open) => !open && closePaymentSheet()}
         facilityId={facilityId}
         accountId={accountId}
-        isCreditNote={isCreditNote}
+        isCreditNote={paymentType === "credit_note"}
         account={account}
       />
 

--- a/src/pages/Facility/billing/account/AccountShow.tsx
+++ b/src/pages/Facility/billing/account/AccountShow.tsx
@@ -2,7 +2,7 @@ import { DialogDescription } from "@radix-ui/react-dialog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Hash, MoreVertical } from "lucide-react";
-import { Link, navigate } from "raviger";
+import { Link, navigate, useQueryParams } from "raviger";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -109,10 +109,23 @@ export function AccountShow({
 }) {
   const { t } = useTranslation();
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [paymentSheet, setPaymentSheet] = useState<{
+  const [qParams, setQueryParams] = useQueryParams<{ payment?: string }>();
+  const paymentSheet = {
+    isOpen: qParams.payment === "advance" || qParams.payment === "credit",
+    isCreditNote: qParams.payment === "credit",
+  };
+  const setPaymentSheet = (next: {
     isOpen: boolean;
     isCreditNote: boolean;
-  }>({ isOpen: false, isCreditNote: false });
+  }) => {
+    const { payment: _payment, ...rest } = qParams;
+    setQueryParams(
+      next.isOpen
+        ? { ...rest, payment: next.isCreditNote ? "credit" : "advance" }
+        : rest,
+      { replace: true },
+    );
+  };
   const [transferPaymentOpen, setTransferPaymentOpen] = useState(false);
   const queryClient = useQueryClient();
   const [closeAccountStatus, setCloseAccountStatus] = useState<{

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -108,7 +108,9 @@ export function InvoiceShow({
   const isPaymentSheetOpen = qParams.is_payment === "true";
   const setIsPaymentSheetOpen = (open: boolean) => {
     const { is_payment: _isPayment, ...rest } = qParams;
-    setQueryParams(open ? { ...rest, is_payment: "true" } : rest, {});
+    setQueryParams(open ? { ...rest, is_payment: "true" } : rest, {
+      replace: true,
+    });
   };
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedChargeItems, setSelectedChargeItems] = useState<

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -101,14 +101,14 @@ export function InvoiceShow({
 }) {
   const { t } = useTranslation();
   const [qParams, setQueryParams] = useQueryParams<{
-    payment?: string;
+    is_payment?: string;
     sourceUrl?: string;
     relatedInvoices?: string;
   }>();
-  const isPaymentSheetOpen = qParams.payment === "open";
+  const isPaymentSheetOpen = qParams.is_payment === "true";
   const setIsPaymentSheetOpen = (open: boolean) => {
-    const { payment: _payment, ...rest } = qParams;
-    setQueryParams(open ? { ...rest, payment: "open" } : rest, {});
+    const { is_payment: _isPayment, ...rest } = qParams;
+    setQueryParams(open ? { ...rest, is_payment: "true" } : rest, {});
   };
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedChargeItems, setSelectedChargeItems] = useState<

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -100,7 +100,16 @@ export function InvoiceShow({
   invoiceId: string;
 }) {
   const { t } = useTranslation();
-  const [isPaymentSheetOpen, setIsPaymentSheetOpen] = useState(false);
+  const [qParams, setQueryParams] = useQueryParams<{
+    payment?: string;
+    sourceUrl?: string;
+    relatedInvoices?: string;
+  }>();
+  const isPaymentSheetOpen = qParams.payment === "open";
+  const setIsPaymentSheetOpen = (open: boolean) => {
+    const { payment: _payment, ...rest } = qParams;
+    setQueryParams(open ? { ...rest, payment: "open" } : rest, {});
+  };
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedChargeItems, setSelectedChargeItems] = useState<
     ChargeItemRead[]
@@ -338,7 +347,7 @@ export function InvoiceShow({
     invoice?.status !== InvoiceStatus.entered_in_error &&
     invoice?.status !== InvoiceStatus.cancelled;
 
-  const [{ sourceUrl, relatedInvoices }] = useQueryParams();
+  const { sourceUrl, relatedInvoices } = qParams;
 
   const alertButtonText = (() => {
     if (sourceUrl?.includes("medication_return")) {

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -95,21 +95,27 @@ import { toast } from "sonner";
 export function InvoiceShow({
   facilityId,
   invoiceId,
+  paymentType,
 }: {
   facilityId: string;
   invoiceId: string;
+  paymentType?: "pay";
 }) {
   const { t } = useTranslation();
-  const [qParams, setQueryParams] = useQueryParams<{
-    is_payment?: string;
+  const [qParams] = useQueryParams<{
     sourceUrl?: string;
     relatedInvoices?: string;
   }>();
-  const isPaymentSheetOpen = qParams.is_payment === "true";
-  const setIsPaymentSheetOpen = (open: boolean) => {
-    const { is_payment: _isPayment, ...rest } = qParams;
-    setQueryParams(open ? { ...rest, is_payment: "true" } : rest, {
+  const openPaymentSheet = () => {
+    navigate(`/facility/${facilityId}/billing/invoices/${invoiceId}/pay`, {
       replace: true,
+      query: qParams,
+    });
+  };
+  const closePaymentSheet = () => {
+    navigate(`/facility/${facilityId}/billing/invoices/${invoiceId}`, {
+      replace: true,
+      query: qParams,
     });
   };
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -319,7 +325,7 @@ export function InvoiceShow({
       updateInvoice(data, {
         onSuccess: () => {
           if (status === InvoiceStatus.issued) {
-            setIsPaymentSheetOpen(true);
+            openPaymentSheet();
           }
         },
       });
@@ -492,10 +498,7 @@ export function InvoiceShow({
             )}
             {invoice.status === InvoiceStatus.issued && (
               <ButtonGroup className="w-full">
-                <Button
-                  className="w-full"
-                  onClick={() => setIsPaymentSheetOpen(true)}
-                >
+                <Button className="w-full" onClick={() => openPaymentSheet()}>
                   <CareIcon icon="l-plus" className="mr-2 size-4" />
                   {invoice.is_refund
                     ? t("record_credit_note")
@@ -1509,8 +1512,8 @@ export function InvoiceShow({
         </div>
 
         <PaymentReconciliationSheet
-          open={isPaymentSheetOpen}
-          onOpenChange={setIsPaymentSheetOpen}
+          open={paymentType === "pay"}
+          onOpenChange={(open) => !open && closePaymentSheet()}
           facilityId={facilityId}
           invoice={invoice}
           accountId={invoice.account.id}

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -102,7 +102,7 @@ import {
   ReceiptIcon,
   SendIcon,
 } from "lucide-react";
-import { Link, useQueryParams } from "raviger";
+import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -298,25 +298,7 @@ function InvoiceCard({
 }: InvoiceCardProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [qParams, setQueryParams] = useQueryParams<{
-    is_payment?: string;
-    payment_invoice_id?: string;
-  }>();
-  const paymentSheetOpen =
-    qParams.is_payment === "true" && qParams.payment_invoice_id === invoice.id;
-  const setPaymentSheetOpen = (open: boolean) => {
-    const {
-      is_payment: _isPayment,
-      payment_invoice_id: _paymentInvoiceId,
-      ...rest
-    } = qParams;
-    setQueryParams(
-      open
-        ? { ...rest, is_payment: "true", payment_invoice_id: invoice.id }
-        : rest,
-      { replace: true },
-    );
-  };
+  const [paymentSheetOpen, setPaymentSheetOpen] = useState(false);
   const [cancelInvoiceDialogOpen, setCancelInvoiceDialogOpen] = useState(false);
   const [cancelPaymentId, setCancelPaymentId] = useState<string | null>(null);
 

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -298,13 +298,24 @@ function InvoiceCard({
 }: InvoiceCardProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [qParams, setQueryParams] = useQueryParams<{ payment?: string }>();
-  const paymentSheetOpen = qParams.payment === invoice.id;
+  const [qParams, setQueryParams] = useQueryParams<{
+    is_payment?: string;
+    payment_invoice_id?: string;
+  }>();
+  const paymentSheetOpen =
+    qParams.is_payment === "true" && qParams.payment_invoice_id === invoice.id;
   const setPaymentSheetOpen = (open: boolean) => {
-    const { payment: _payment, ...rest } = qParams;
-    setQueryParams(open ? { ...rest, payment: invoice.id } : rest, {
-      replace: true,
-    });
+    const {
+      is_payment: _isPayment,
+      payment_invoice_id: _paymentInvoiceId,
+      ...rest
+    } = qParams;
+    setQueryParams(
+      open
+        ? { ...rest, is_payment: "true", payment_invoice_id: invoice.id }
+        : rest,
+      { replace: true },
+    );
   };
   const [cancelInvoiceDialogOpen, setCancelInvoiceDialogOpen] = useState(false);
   const [cancelPaymentId, setCancelPaymentId] = useState<string | null>(null);

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -102,7 +102,7 @@ import {
   ReceiptIcon,
   SendIcon,
 } from "lucide-react";
-import { Link } from "raviger";
+import { Link, useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -298,7 +298,14 @@ function InvoiceCard({
 }: InvoiceCardProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [paymentSheetOpen, setPaymentSheetOpen] = useState(false);
+  const [qParams, setQueryParams] = useQueryParams<{ payment?: string }>();
+  const paymentSheetOpen = qParams.payment === invoice.id;
+  const setPaymentSheetOpen = (open: boolean) => {
+    const { payment: _payment, ...rest } = qParams;
+    setQueryParams(open ? { ...rest, payment: invoice.id } : rest, {
+      replace: true,
+    });
+  };
   const [cancelInvoiceDialogOpen, setCancelInvoiceDialogOpen] = useState(false);
   const [cancelPaymentId, setCancelPaymentId] = useState<string | null>(null);
 


### PR DESCRIPTION
## Proposed Changes
ENG-255

https://openhealthcarenetwork.atlassian.net/browse/ENG-255
Make Payment sheet url accessible to enable redirect to invoice view with payment sheet open.
Minor routes cleanup of the same

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Billing pages now use URL-driven navigation for payment flows instead of local component state.
  * Account pages consolidated to generic tab-based routes with nested payment-type segments.
* **New Features**
  * Direct invoice "Pay" URLs open the payment sheet, preserving query parameters and improving back/forward navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->