### PR TITLE
[ENG-222] fix: pass in facilityId for category monetary sheet

### DIFF
--- a/src/components/Billing/CompactConditionEditor.tsx
+++ b/src/components/Billing/CompactConditionEditor.tsx
@@ -82,6 +82,7 @@ function TagSelector({
         onChange={handleChange}
         className="h-9 w-full"
         facilityId={facilityId}
+        align="end"
       />
     </div>
   );

--- a/src/components/Common/CategoryMonetaryComponentsSheet.tsx
+++ b/src/components/Common/CategoryMonetaryComponentsSheet.tsx
@@ -167,7 +167,7 @@ export function CategoryMonetaryComponentsSheet({
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent className="sm:max-w-xl overflow-y-auto">
+      <SheetContent className="sm:max-w-3xl overflow-y-auto">
         <SheetHeader>
           <SheetTitle>{t("set_monetary_components")}</SheetTitle>
           <SheetDescription>
@@ -200,6 +200,7 @@ export function CategoryMonetaryComponentsSheet({
               type={MonetaryComponentType.discount}
               showConditionsEditor
               availableMetrics={availableMetrics}
+              facilityId={facilityId}
             />
 
             <div className="flex gap-2 pt-4">

--- a/src/components/Tags/MultiFilterStyleTagSelector.tsx
+++ b/src/components/Tags/MultiFilterStyleTagSelector.tsx
@@ -51,6 +51,7 @@ interface MultiFilterStyleTagSelectorProps {
   disabled?: boolean;
   isTagMutationInProgress?: boolean;
   trigger?: React.ReactNode;
+  align?: "start" | "end";
 }
 
 // Clean, minimal tag selector matching multi-filter design
@@ -63,6 +64,7 @@ export function MultiFilterStyleTagSelector({
   disabled = false,
   isTagMutationInProgress = false,
   trigger,
+  align = "start",
 }: MultiFilterStyleTagSelectorProps) {
   const [open, setOpen] = useState(false);
   const [groupPopoverOpen, setGroupPopoverOpen] = useState<string | null>(null);
@@ -405,7 +407,7 @@ export function MultiFilterStyleTagSelector({
           <DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
           <DropdownMenuContent
             className="w-[calc(100vw)] max-w-[calc(100vw-3rem)] sm:max-w-xs p-0"
-            align="start"
+            align={align}
           >
             <div className="p-0">
               {/* Header */}


### PR DESCRIPTION
## Proposed Changes

- [ENG-222]
- Allows for facility level tags to show up in condition selector in discount configuration sheet for categories

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-222]: https://openhealthcarenetwork.atlassian.net/browse/ENG-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced dropdown and popover alignment controls for improved UI consistency.
  * Expanded monetary components sheet layout for better visibility and usability.
  * Added facility-specific context support to discount selector for more relevant filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->