### PR TITLE
fix: reset future date when switching encounter status from planned

### DIFF
--- a/src/components/Encounter/CreateEncounterForm.tsx
+++ b/src/components/Encounter/CreateEncounterForm.tsx
@@ -300,7 +300,23 @@ export default function CreateEncounterForm({
                   <FormItem>
                     <FormLabel>{t("status")}</FormLabel>
                     <Select
-                      onValueChange={field.onChange}
+                      onValueChange={(value) => {
+                        field.onChange(value);
+                        if (value !== EncounterStatus.PLANNED) {
+                          const currentStartDate = form.getValues("start_date");
+                          const parsedDate = new Date(currentStartDate);
+                          if (
+                            !isNaN(parsedDate.getTime()) &&
+                            parsedDate > new Date()
+                          ) {
+                            form.setValue(
+                              "start_date",
+                              new Date().toISOString(),
+                              { shouldValidate: true },
+                            );
+                          }
+                        }
+                      }}
                       defaultValue={field.value}
                     >
                       <FormControl>


### PR DESCRIPTION
Fixes #16332        
  When a user selects a future date with Planned status and then switches to In Progress (or On Hold), the start date is now automatically reset
   to the current date/time.                                                                                                                    
  
  Previously the Zod validation would block submission, but there was no immediate feedback — the invalid state was silently reachable. This fix
   proactively clears the future date the moment the status changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the encounter creation form so that when the status is changed away from "Planned" and a future start date was selected, the start date is automatically reset to the current time and re-validated. The date picker and existing future-date validation continue to function as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->