### PR TITLE
fix: wait for facility option to be visible before clicking in resource request test

### DIFF
--- a/tests/facility/patient/patientDetails/request/requestCreate.spec.ts
+++ b/tests/facility/patient/patientDetails/request/requestCreate.spec.ts
@@ -55,6 +55,7 @@ test.describe("Resource Request Creation", () => {
       );
       await page.getByPlaceholder("Search option...").fill("fac");
       await facilitySearchResponse;
+      await page.getByRole("option").first().waitFor({ state: "visible" });
       await page.getByRole("option").first().click();
       await page
         .getByRole("textbox", { name: "Name of Contact Person at" })


### PR DESCRIPTION
## Proposed Changes

- Fixes timeout in resource request creation Playwright test on CI
- The test was failing because it attempted to click the first facility option before it was rendered in the DOM
- Added `waitFor({ state: "visible" })` before clicking to ensure the option is present after the API response

## Context

The facility combobox uses a 500ms debounced API call + async rendering. On CI, the option may not be immediately available after the API response resolves due to React render cycles.

Tagging: @ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of the resource request form automation by changing the category selection to wait for the first visible option before interacting. This reduces timing-related flakiness in dropdown handling and makes automated request creation more reliable across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->