### PR TITLE
fix: remove facility search and wait for option visibility in resource request test

### DIFF
--- a/tests/facility/patient/patientDetails/request/requestCreate.spec.ts
+++ b/tests/facility/patient/patientDetails/request/requestCreate.spec.ts
@@ -47,14 +47,7 @@ test.describe("Resource Request Creation", () => {
         .getByRole("combobox")
         .filter({ hasText: "Start typing to search..." })
         .click();
-      const facilitySearchResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes("/api/v1/getallfacilities/") &&
-          response.request().method() === "GET" &&
-          response.status() === 200,
-      );
-      await page.getByPlaceholder("Search option...").fill("fac");
-      await facilitySearchResponse;
+      await page.getByRole("option").first().waitFor({ state: "visible" });
       await page.getByRole("option").first().click();
       await page
         .getByRole("textbox", { name: "Name of Contact Person at" })


### PR DESCRIPTION
## Proposed Changes

- Removes the fragile facility search (`fill("fac")`) that was causing timeouts on CI when fixture facilities don't match the search term
- Instead, opens the combobox and waits for the first option to become visible before clicking
- This ensures the test works regardless of facility names in fixtures

## Context

The facility combobox loads all facilities on open (up to 50). There's no need to type a search term. The test now simply waits for the options to render and picks the first one.

Tagging: @ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Resource Request creation test with improved option selection logic for patient detail forms, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->