### PR TITLE
fix: add edit button to patient info card on patient home page

### DIFF
--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -16,7 +16,17 @@ import {
 } from "@/types/emr/tagConfig/tagConfig";
 import { Pencil, SettingsIcon } from "lucide-react";
 import { Link } from "raviger";
-import { useTranslation } from "react-i18next";
+
+interface PatientInfoCardProps {
+  patient: PublicPatientRead | PatientListRead | PatientRead;
+  tags: TagConfig[];
+  facilityId: string;
+  onTagsUpdate: () => void;
+  children?: React.ReactNode;
+  tagEntityType: TagEntityType;
+  tagEntityId: string;
+  editUrl?: string;
+}
 
 export const PatientInfoCard = ({
   patient,
@@ -27,18 +37,7 @@ export const PatientInfoCard = ({
   tagEntityType,
   tagEntityId,
   editUrl,
-}: {
-  patient: PublicPatientRead | PatientListRead | PatientRead;
-  tags: TagConfig[];
-  facilityId: string;
-  onTagsUpdate: () => void;
-  children?: React.ReactNode;
-  tagEntityType: TagEntityType;
-  tagEntityId: string;
-  editUrl?: string;
-}) => {
-  const { t } = useTranslation();
-
+}: PatientInfoCardProps) => {
   return (
     <>
       <Card className="bg-white shadow-sm rounded-md">
@@ -46,12 +45,12 @@ export const PatientInfoCard = ({
           <div className="flex items-center gap-2">
             <PatientHoverCard patient={patient} facilityId={facilityId} />
             {editUrl && (
-              <Link href={editUrl}>
-                <Button variant="outline" size="sm">
+              <Button asChild variant="outline" size="sm">
+                <Link href={editUrl}>
                   <Pencil className="h-4 w-4 mr-1" />
                   {t("edit")}
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             )}
           </div>
           {children}

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/types/emr/tagConfig/tagConfig";
 import { Pencil, SettingsIcon } from "lucide-react";
 import { Link } from "raviger";
+import { useTranslation } from "react-i18next";
+
 interface PatientInfoCardProps {
   patient: PublicPatientRead | PatientListRead | PatientRead;
   tags: TagConfig[];
@@ -38,6 +40,7 @@ export const PatientInfoCard = ({
   editUrl,
 }: PatientInfoCardProps) => {
   const { t } = useTranslation();
+
   return (
     <>
       <Card className="bg-white shadow-sm rounded-md">
@@ -72,7 +75,6 @@ export const PatientInfoCard = ({
                 </span>
               )}
             </div>
-
             <TagAssignmentSheet
               entityType={tagEntityType}
               entityId={tagEntityId}

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -37,6 +37,7 @@ export const PatientInfoCard = ({
   tagEntityId,
   editUrl,
 }: PatientInfoCardProps) => {
+  const { t } = useTranslation();
   return (
     <>
       <Card className="bg-white shadow-sm rounded-md">

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -14,7 +14,8 @@ import {
   getTagHierarchyDisplay,
   TagConfig,
 } from "@/types/emr/tagConfig/tagConfig";
-import { SettingsIcon } from "lucide-react";
+import { Pencil, SettingsIcon } from "lucide-react";
+import { Link } from "raviger";
 import { useTranslation } from "react-i18next";
 
 export const PatientInfoCard = ({
@@ -25,6 +26,7 @@ export const PatientInfoCard = ({
   children,
   tagEntityType,
   tagEntityId,
+  editUrl,
 }: {
   patient: PublicPatientRead | PatientListRead | PatientRead;
   tags: TagConfig[];
@@ -33,6 +35,7 @@ export const PatientInfoCard = ({
   children?: React.ReactNode;
   tagEntityType: TagEntityType;
   tagEntityId: string;
+  editUrl?: string;
 }) => {
   const { t } = useTranslation();
 
@@ -40,8 +43,16 @@ export const PatientInfoCard = ({
     <>
       <Card className="bg-white shadow-sm rounded-md">
         <CardHeader className="pb-4 flex flex-col sm:flex-row sm:items-center justify-between px-2">
-          <div className="space-y-4">
+          <div className="flex items-center gap-2">
             <PatientHoverCard patient={patient} facilityId={facilityId} />
+            {editUrl && (
+              <Link href={editUrl}>
+                <Button variant="outline" size="sm">
+                  <Pencil className="h-4 w-4 mr-1" />
+                  {t("edit")}
+                </Button>
+              </Link>
+            )}
           </div>
           {children}
         </CardHeader>

--- a/src/components/Patient/PatientInfoCard.tsx
+++ b/src/components/Patient/PatientInfoCard.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/types/emr/tagConfig/tagConfig";
 import { Pencil, SettingsIcon } from "lucide-react";
 import { Link } from "raviger";
-
 interface PatientInfoCardProps {
   patient: PublicPatientRead | PatientListRead | PatientRead;
   tags: TagConfig[];

--- a/src/pages/Patient/PatientHome.tsx
+++ b/src/pages/Patient/PatientHome.tsx
@@ -124,6 +124,7 @@ export default function PatientHome() {
                   tagEntityId={patientData.id}
                   patient={patientData}
                   facilityId={facilityId}
+                  editUrl={`/facility/${facilityId}/patient/${patientData.id}/update`}
                   onTagsUpdate={() => {
                     queryClient.invalidateQueries({
                       queryKey: [


### PR DESCRIPTION
## Proposed Changes
Fixes #16183
- Added optional `editUrl` prop to `PatientInfoCard` component
- When `editUrl` is provided, an Edit button renders next to the patient name
- Passed the edit URL from `PatientHome.tsx` to `/facility/:facilityId/patient/:id/update`
- Other pages using `PatientInfoCard` (AppointmentDetail, EncounterShow) are unaffected since `editUrl` is not passed there

**Before:** patient name → view profile → edit (3 clicks)  
**After:** Edit button directly on patient home page (1 click)

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patient Info Card shows an optional "Edit" pencil button that links to the patient edit page when an edit link is available.
  * Patient Home now supplies the edit link so the button appears for applicable patients.

* **UI/Layout**
  * Header layout refined to group the profile hover card and edit action into a single inline row for improved alignment and spacing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16345)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->