### PR TITLE
ENG-304 Expand address in patient by default

### DIFF
--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -397,11 +397,11 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
             <Accordion
               type="multiple"
               className="flex flex-col gap-6"
-              defaultValue={
-                quickRegistration
-                  ? ["patient-basics"]
-                  : ["patient-basics", "additional-details"]
-              }
+              defaultValue={[
+                "patient-basics",
+                "additional-details",
+                "extensions",
+              ]}
             >
               <PLUGIN_Component
                 __name="PatientRegistrationForm"
@@ -433,7 +433,7 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
                 <AccordionTrigger className="flex justify-between">
                   <div className="flex gap-3 items-center w-full">
                     <h5 className="text-lg font-semibold">
-                      2: {t("additional_details")}{" "}
+                      2: {t("address")}{" "}
                       {quickRegistration && `(${t("optional")})`}
                     </h5>
                     {/* TODO: add progress bar */}
@@ -441,9 +441,25 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
                 </AccordionTrigger>
                 <AccordionContent className="px-1 flex flex-col gap-6">
                   <AdditionalDetailsContent form={form} />
-                  {extensions.fields}
                 </AccordionContent>
               </AccordionItem>
+              {extensions.hasFields && (
+                <AccordionItem
+                  value="extensions"
+                  className="bg-white flex flex-col gap-4 p-6 shadow rounded-md"
+                >
+                  <AccordionTrigger className="flex justify-between">
+                    <div className="flex gap-3 items-center w-full">
+                      <h5 className="text-lg font-semibold">
+                        3: {t("additional_details")}
+                      </h5>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-1 flex flex-col gap-6">
+                    {extensions.fields}
+                  </AccordionContent>
+                </AccordionItem>
+              )}
             </Accordion>
             <div className="w-full border-t border-gray-200 py-6 mt-6">
               <div className="max-w-2xl mx-auto flex justify-end">

--- a/src/components/Patient/PatientRegistration.tsx
+++ b/src/components/Patient/PatientRegistration.tsx
@@ -397,11 +397,7 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
             <Accordion
               type="multiple"
               className="flex flex-col gap-6"
-              defaultValue={[
-                "patient-basics",
-                "additional-details",
-                "extensions",
-              ]}
+              defaultValue={["patient-basics", "additional-details"]}
             >
               <PLUGIN_Component
                 __name="PatientRegistrationForm"
@@ -433,7 +429,7 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
                 <AccordionTrigger className="flex justify-between">
                   <div className="flex gap-3 items-center w-full">
                     <h5 className="text-lg font-semibold">
-                      2: {t("address")}{" "}
+                      2: {t("additional_details")}{" "}
                       {quickRegistration && `(${t("optional")})`}
                     </h5>
                     {/* TODO: add progress bar */}
@@ -441,25 +437,9 @@ export const PatientRegistration = ({ patientId }: { patientId?: string }) => {
                 </AccordionTrigger>
                 <AccordionContent className="px-1 flex flex-col gap-6">
                   <AdditionalDetailsContent form={form} />
+                  {extensions.fields}
                 </AccordionContent>
               </AccordionItem>
-              {extensions.hasFields && (
-                <AccordionItem
-                  value="extensions"
-                  className="bg-white flex flex-col gap-4 p-6 shadow rounded-md"
-                >
-                  <AccordionTrigger className="flex justify-between">
-                    <div className="flex gap-3 items-center w-full">
-                      <h5 className="text-lg font-semibold">
-                        3: {t("additional_details")}
-                      </h5>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent className="px-1 flex flex-col gap-6">
-                    {extensions.fields}
-                  </AccordionContent>
-                </AccordionItem>
-              )}
             </Accordion>
             <div className="w-full border-t border-gray-200 py-6 mt-6">
               <div className="max-w-2xl mx-auto flex justify-end">


### PR DESCRIPTION
## Proposed Changes
- Made Additional details section as always expanded
- [ENG-304]

<img width="1055" height="1161" alt="image" src="https://github.com/user-attachments/assets/7fa6ae6a-9616-430b-a998-5712766af28c" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-304]: https://openhealthcarenetwork.atlassian.net/browse/ENG-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Patient registration accordion now opens multiple sections (basics, additional details, extensions) by default to surface more form options and reduce navigation when completing registrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16354)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->