### PR TITLE
feat: implement lazy loading with retry mechanism for routers and clear stale chunk flags on load

### DIFF
--- a/src/Routers/index.tsx
+++ b/src/Routers/index.tsx
@@ -1,12 +1,11 @@
-import { lazy } from "react";
-
 import PublicRouter from "@/Routers/PublicRouter";
+import { lazyWithRetry } from "@/Utils/lazyWithRetry";
 
 // Lazy load routers based on auth state to improve initial bundle size
 // PatientRouter only loads when user is OTP authorized
-const PatientRouter = lazy(() => import("@/Routers/PatientRouter"));
+const PatientRouter = lazyWithRetry(() => import("@/Routers/PatientRouter"));
 // AppRouter only loads when user is fully authorized
-const AppRouter = lazy(() => import("@/Routers/AppRouter"));
+const AppRouter = lazyWithRetry(() => import("@/Routers/AppRouter"));
 
 const routers = { PatientRouter, PublicRouter, AppRouter };
 

--- a/src/Utils/lazyWithRetry.ts
+++ b/src/Utils/lazyWithRetry.ts
@@ -1,0 +1,39 @@
+import { performAppUpdate } from "@/lib/appVersion";
+import { lazy } from "react";
+
+/**
+ * A wrapper around React.lazy that handles stale chunk errors after deployments.
+ * When a dynamically imported chunk fails to load (e.g., because the server has
+ * a newer build), it reloads the page once. A per-chunk sessionStorage key
+ * prevents infinite reload loops.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function lazyWithRetry<T extends React.ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+) {
+  return lazy(() =>
+    factory().catch((err: Error) => {
+      const isChunkError =
+        err?.name === "ChunkLoadError" ||
+        /loading chunk/i.test(err?.message ?? "") ||
+        /failed to fetch dynamically imported module/i.test(err?.message ?? "");
+
+      if (isChunkError) {
+        const reloadKey = `chunk_reload_${btoa(err.message).slice(0, 20)}`;
+        if (!sessionStorage.getItem(reloadKey)) {
+          sessionStorage.setItem(reloadKey, "1");
+          performAppUpdate("unknown");
+        }
+      }
+
+      throw err;
+    }),
+  );
+}
+
+/** Clear all chunk reload flags after a successful app boot */
+export function clearChunkReloadFlags() {
+  Object.keys(sessionStorage)
+    .filter((key) => key.startsWith("chunk_reload_"))
+    .forEach((key) => sessionStorage.removeItem(key));
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import App from "@/App";
 import { AuthContextType, AuthUserContext } from "@/hooks/useAuthUser";
 import { initI18n } from "@/i18n";
 import { PlugConfigMeta } from "@/types/plugConfig";
+import { clearChunkReloadFlags } from "@/Utils/lazyWithRetry";
 import careConfig from "@careConfig";
 import React, { Context } from "react";
 import { createRoot } from "react-dom/client";
@@ -37,6 +38,9 @@ if (import.meta.env.PROD) {
     dsn: "https://8801155bd0b848a09de9ebf6f387ebc8@sentry.io/5183632",
   });
 }
+
+// Clear stale chunk reload flags on successful page load
+clearChunkReloadFlags();
 
 // Initialize i18n with namespaces from API before rendering the app
 initI18n()


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of app section loading with automatic retry mechanism for failed chunk loads.
  * Enhanced recovery from temporary loading failures to prevent infinite reload loops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->