### PR TITLE
Fix line-breaking differences across browsers when printing the treatment summary report

### DIFF
--- a/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
+++ b/src/components/Facility/ConsultationDetails/QuestionnaireResponsesList.tsx
@@ -231,7 +231,7 @@ function QuestionGroup({
       </h3>
       <div
         className={cn("w-full", {
-          "grid md:grid-cols-2 grid-cols-1 gap-4": shouldUseTwoColumns,
+          "grid sm:grid-cols-2 grid-cols-1 gap-4": shouldUseTwoColumns,
         })}
       >
         {leftQuestions.length > 0 && (
@@ -504,7 +504,7 @@ function ResponseCardContent({ item }: { item: QuestionnaireResponse }) {
       <div
         className={cn(
           "grid gap-3",
-          shouldUseTwoColumns ? "grid-cols-1 lg:grid-cols-2" : "grid-cols-1",
+          shouldUseTwoColumns ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1",
         )}
       >
         {/* Left Column */}


### PR DESCRIPTION
The responsive breakpoint behaves differently across browsers. Firefox and Chrome use the print page viewport logic, while Safari uses the actual viewport size.

To fix this issue, I changed the layout to use grid-cols-2 for all devices larger than the sm breakpoint. This ensures a consistent two-column layout across browsers when printing the treatment summary report
[ENG-365]

Chrome:
<img width="819" height="519" alt="image" src="https://github.com/user-attachments/assets/77b6d60e-a518-4cf6-a127-31d6253b42eb" />

Safari:
<img width="725" height="583" alt="image" src="https://github.com/user-attachments/assets/e7db520e-3ec9-4731-8825-d5f931ed29c0" />

Firefox:
<img width="1107" height="581" alt="image" src="https://github.com/user-attachments/assets/120a9902-080f-4faf-8f29-a7e6e17eea72" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-365]: https://openhealthcarenetwork.atlassian.net/browse/ENG-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layout for questionnaire displays. Multi-column layouts now activate on smaller screens, improving content organization and readability for mobile and tablet users. This ensures optimal display across all device sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->