### PR TITLE
[ENG-366] Add patient extensions to appointment print

### DIFF
--- a/src/components/Patient/TreatmentSummary.tsx
+++ b/src/components/Patient/TreatmentSummary.tsx
@@ -15,6 +15,7 @@ import PrintFooter from "@/components/Common/PrintFooter";
 import PrintTable from "@/components/Common/PrintTable";
 import QuestionnaireResponsesList from "@/components/Facility/ConsultationDetails/QuestionnaireResponsesList";
 import { usePermissions } from "@/context/PermissionContext";
+import usePatientExtensionData from "@/hooks/usePatientExtensionData";
 import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import allergyIntoleranceApi from "@/types/emr/allergyIntolerance/allergyIntoleranceApi";
 import diagnosisApi from "@/types/emr/diagnosis/diagnosisApi";
@@ -96,6 +97,8 @@ export default function TreatmentSummary({
     hasPermission,
     encounter?.permissions ?? [],
   );
+
+  const patientExtensionData = usePatientExtensionData(patient?.extensions);
 
   const canAccess = canReadEncounter || canViewClinicalData;
 
@@ -278,6 +281,18 @@ export default function TreatmentSummary({
                     </span>
                   </div>
                 )}
+                {patientExtensionData.map((field) => (
+                  <div
+                    key={field.name}
+                    className="grid grid-cols-[10rem_auto_1fr] md:grid-cols-[8rem_auto_1fr] items-center"
+                  >
+                    <span className="text-gray-600">{field.name}</span>
+                    <span className="text-gray-600">:</span>
+                    <span className="font-semibold break-words">
+                      {field.value}
+                    </span>
+                  </div>
+                ))}
               </div>
 
               {/* Right Column */}

--- a/src/hooks/usePatientExtensionData.ts
+++ b/src/hooks/usePatientExtensionData.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+
+import useExtensionSchemas from "@/hooks/useExtensionSchemas";
+import {
+  ExtensionEntityType,
+  NamespacedExtensionData,
+  getExtensionFieldsWithName,
+  getExtensionValue,
+} from "@/hooks/useExtensions";
+
+interface PatientExtensionField {
+  name: string;
+  value: string;
+}
+
+export default function usePatientExtensionData(
+  extensions: NamespacedExtensionData | undefined,
+): PatientExtensionField[] {
+  const { getExtensions } = useExtensionSchemas();
+
+  const allExtensions = getExtensions(ExtensionEntityType.patient, "retrieve");
+
+  const extensionFields = useMemo(
+    () => getExtensionFieldsWithName(allExtensions),
+    [allExtensions],
+  );
+
+  return useMemo(
+    () =>
+      extensionFields
+        .map((field) => {
+          const value = getExtensionValue(extensions, field);
+          return {
+            name: field.label,
+            value: value ? String(value) : "",
+          };
+        })
+        .filter((field) => field.value !== ""),
+    [extensionFields, extensions],
+  );
+}

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -22,12 +22,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { usePermissions } from "@/context/PermissionContext";
-import useExtensionSchemas from "@/hooks/useExtensionSchemas";
-import {
-  ExtensionEntityType,
-  getExtensionFieldsWithName,
-  getExtensionValue,
-} from "@/hooks/useExtensions";
+import usePatientExtensionData from "@/hooks/usePatientExtensionData";
 import { cn } from "@/lib/utils";
 import { formatSlotTimeRange } from "@/pages/Appointments/utils";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
@@ -48,8 +43,6 @@ import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/pa
 import { formatScheduleResourceName } from "@/types/scheduling/schedule";
 import scheduleApis from "@/types/scheduling/scheduleApi";
 import { renderTokenNumber } from "@/types/tokens/token/token";
-import { useMemo } from "react";
-
 interface Props {
   appointmentId: string;
 }
@@ -117,14 +110,7 @@ export default function AppointmentPrint(props: Props) {
   const patient = appointment?.patient;
   const token = appointment?.token;
 
-  const { getExtensions } = useExtensionSchemas();
-
-  const allExtensions = getExtensions(ExtensionEntityType.patient, "retrieve");
-
-  const extensionFields = useMemo(
-    () => getExtensionFieldsWithName(allExtensions),
-    [allExtensions],
-  );
+  const patientExtensionData = usePatientExtensionData(patient?.extensions);
 
   if (isLoading || !appointment || !facility) {
     return (
@@ -144,16 +130,6 @@ export default function AppointmentPrint(props: Props) {
       </PrintPreview>
     );
   }
-
-  const patientExtensionData = extensionFields
-    .map((field) => {
-      const value = getExtensionValue(patient?.extensions, field);
-      return {
-        name: field.label,
-        value: value ? String(value) : "",
-      };
-    })
-    .filter((field) => field.value !== undefined && field.value !== "");
 
   // Filter out excluded charge items and show all from the query
   const displayChargeItems = chargeItems?.results?.filter(

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -6,6 +6,9 @@ import { formatPhoneNumberIntl } from "react-phone-number-input";
 
 import PrintPreview from "@/CAREUI/misc/PrintPreview";
 
+import { add } from "@/Utils/decimal";
+import query from "@/Utils/request/query";
+import { formatName, formatPatientAge } from "@/Utils/utils";
 import { getPermissions } from "@/common/Permissions";
 import PrintFooter from "@/components/Common/PrintFooter";
 import TagBadge from "@/components/Tags/TagBadge";
@@ -19,6 +22,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { usePermissions } from "@/context/PermissionContext";
+import useExtensionSchemas from "@/hooks/useExtensionSchemas";
+import {
+  ExtensionEntityType,
+  getExtensionFieldsWithName,
+  getExtensionValue,
+} from "@/hooks/useExtensions";
 import { cn } from "@/lib/utils";
 import { formatSlotTimeRange } from "@/pages/Appointments/utils";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
@@ -39,9 +48,7 @@ import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/pa
 import { formatScheduleResourceName } from "@/types/scheduling/schedule";
 import scheduleApis from "@/types/scheduling/scheduleApi";
 import { renderTokenNumber } from "@/types/tokens/token/token";
-import { add } from "@/Utils/decimal";
-import query from "@/Utils/request/query";
-import { formatName, formatPatientAge } from "@/Utils/utils";
+import { useMemo } from "react";
 
 interface Props {
   appointmentId: string;
@@ -107,6 +114,18 @@ export default function AppointmentPrint(props: Props) {
     .map((q) => q.data)
     .filter((inv): inv is InvoiceRead => !!inv);
 
+  const patient = appointment?.patient;
+  const token = appointment?.token;
+
+  const { getExtensions } = useExtensionSchemas();
+
+  const allExtensions = getExtensions(ExtensionEntityType.patient, "retrieve");
+
+  const extensionFields = useMemo(
+    () => getExtensionFieldsWithName(allExtensions),
+    [allExtensions],
+  );
+
   if (isLoading || !appointment || !facility) {
     return (
       <PrintPreview
@@ -126,8 +145,15 @@ export default function AppointmentPrint(props: Props) {
     );
   }
 
-  const patient = appointment.patient;
-  const token = appointment.token;
+  const patientExtensionData = extensionFields
+    .map((field) => {
+      const value = getExtensionValue(patient?.extensions, field);
+      return {
+        name: field.label,
+        value: value ? String(value) : "",
+      };
+    })
+    .filter((field) => field.value !== undefined && field.value !== "");
 
   // Filter out excluded charge items and show all from the query
   const displayChargeItems = chargeItems?.results?.filter(
@@ -199,10 +225,21 @@ export default function AppointmentPrint(props: Props) {
         <div className="flex justify-between gap-3 mb-1.5">
           <div className="flex-1">
             <div className="text-xs leading-snug space-y-px">
-              <DetailRow
-                label={t("patient")}
-                value={`${patient?.name} | ${formatPatientAge(patient, true)}, ${t(`GENDER__${patient.gender}`)}`}
-              />
+              {patient && (
+                <>
+                  <DetailRow
+                    label={t("patient")}
+                    value={`${patient?.name} | ${formatPatientAge(patient, true)}, ${t(`GENDER__${patient.gender}`)}`}
+                  />
+                  {patientExtensionData.map((field) => (
+                    <DetailRow
+                      key={field.name}
+                      label={t(field.name)}
+                      value={field.value}
+                    />
+                  ))}
+                </>
+              )}
               <DetailRow
                 label={t("contact_system_phone")}
                 value={

--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useBreakpoints from "@/hooks/useBreakpoints";
+import usePatientExtensionData from "@/hooks/usePatientExtensionData";
 import { formatSlotTimeRange } from "@/pages/Appointments/utils";
 import { PatientRead } from "@/types/emr/patient/patient";
 import { FacilityRead } from "@/types/facility/facility";
@@ -58,6 +59,10 @@ const TokenCard = ({
 
   const appointmentTags = appointment?.tags ?? [];
 
+  const patientExtensionData = usePatientExtensionData(
+    appointment?.patient?.extensions,
+  );
+
   return (
     <Card
       id={id}
@@ -91,6 +96,16 @@ const TokenCard = ({
                   {formatPatientAge(patient, true)},{" "}
                   {t(`GENDER__${patient.gender}`)}
                 </p>
+                {patientExtensionData.map((data) => {
+                  return (
+                    <div key={data.name} className="hidden print:block">
+                      <Label className="text-gray-600 text-sm">
+                        {data.name}:
+                      </Label>
+                      <p className="font-semibold text-sm">{data.value}</p>
+                    </div>
+                  );
+                })}
                 {patientWithIdentifiers?.instance_identifiers
                   ?.filter(
                     (identifier) =>


### PR DESCRIPTION
## Proposed Changes

- [ENG-366]
- Add the patient extensions for both token and appointment print
    - only enabled for token print, not token card shown in appointment details page

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-366]: https://openhealthcarenetwork.atlassian.net/browse/ENG-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Appointment prints and token cards now show additional patient extension fields in the patient details section.
  - Patient views (including print output) display custom/extension fields alongside standard name/age/gender/identifiers.
  - Treatment summary and appointment screens present all available patient extension data as extra detail rows for clearer patient context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->