### PR TITLE
ENG-368 Update encounter locations UI for smaller or when the side bar in expanded.

### DIFF
--- a/src/components/Encounter/EncounterInfoCard.tsx
+++ b/src/components/Encounter/EncounterInfoCard.tsx
@@ -180,7 +180,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
         )}
       </CardContent>
 
-      <CardFooter className="flex flex-wrap justify-end items-center px-4 py-2 gap-x-4 gap-y-2 mt-auto">
+      <CardFooter className="flex flex-wrap justify-end items-center px-2 py-2 gap-x-1 gap-y-2 mt-auto">
         <Button variant="link" aria-label={t("patient_home")} asChild>
           <Link
             basePath="/"

--- a/src/components/Encounter/EncounterInfoCard.tsx
+++ b/src/components/Encounter/EncounterInfoCard.tsx
@@ -57,10 +57,10 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
       )}
     >
       <CardHeader className="bg-gray-100 px-4 pt-2 pb-1">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex flex-1 flex-col sm:flex-row items-start sm:items-center gap-2 justify-between">
-            <div className="flex-1 min-w-0">
-              <h3 className="text-lg font-semibold text-gray-950 truncate">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-1 min-w-0 flex-wrap items-center gap-x-2 gap-y-1 justify-between">
+            <div className="min-w-0 flex-1 basis-full sm:basis-auto">
+              <h3 className="text-lg font-semibold text-gray-950 break-words">
                 {encounter.patient.name}
               </h3>
               <p className="text-sm text-gray-700">
@@ -68,7 +68,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
                 {t(`GENDER__${encounter.patient.gender}`)}
               </p>
             </div>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2 shrink-0">
               {encounter.patient.deceased_datetime && (
                 <Badge variant="destructive">{t("deceased")}</Badge>
               )}
@@ -180,7 +180,7 @@ export default function EncounterInfoCard(props: EncounterInfoCardProps) {
         )}
       </CardContent>
 
-      <CardFooter className="flex justify-end items-center px-4 py-2 gap-4 mt-auto">
+      <CardFooter className="flex flex-wrap justify-end items-center px-4 py-2 gap-x-4 gap-y-2 mt-auto">
         <Button variant="link" aria-label={t("patient_home")} asChild>
           <Link
             basePath="/"

--- a/src/pages/Facility/locations/LocationContent.tsx
+++ b/src/pages/Facility/locations/LocationContent.tsx
@@ -54,7 +54,7 @@ function OccupiedBedSheet({ location, facilityId }: OccupiedBedSheetProps) {
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <div className="flex flex-col items-center justify-center py-8 h-auto">
+      <div className="flex flex-col items-center justify-center py-8 h-auto px-2">
         <div className="rounded-full bg-yellow-100 p-3 mb-3">
           <Lock className="size-6 text-yellow-700" />
         </div>


### PR DESCRIPTION
## Proposed Changes
Fix: [ENG-368]

<img width="1763" height="448" alt="image" src="https://github.com/user-attachments/assets/6948ce1a-47d3-464b-a327-eb1ca5e4a103" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-368]: https://openhealthcarenetwork.atlassian.net/browse/ENG-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved patient information card layout to allow names and gender info to wrap instead of truncating, improving readability for long entries.
  * Adjusted header and footer spacing and horizontal padding for better multi-line support and visual alignment.
  * Added horizontal padding to the occupied-bed view wrapper for more consistent spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->