### PR TITLE
fix: use caller-provided moreText in formatTruncatedList

### DIFF
--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -429,7 +429,7 @@ export function formatTruncatedList<T>(
   const displayedItems = items.slice(0, maxItems);
   const remainingCount = items.length - maxItems;
 
-  return `${displayedItems.map(getDisplayValue).join(", ")} ... +${remainingCount} ${t("more") || moreText}`;
+  return `${displayedItems.map(getDisplayValue).join(", ")} ... +${remainingCount} ${moreText || t("more")}`;
 }
 
 export function deepFreeze<T>(obj: T): T {


### PR DESCRIPTION
## Proposed Changes

Fixes #16377

- `formatTruncatedList()` in `src/Utils/utils.ts` had `t("more") || moreText` as its trailing label. Because `t("more")` always returns a truthy string, the documented `moreText` parameter was unreachable and silently ignored.
- Swapped to `moreText || t("more")` so a caller-provided label is used, falling back to the translated default when none is given — matching the parameter's documentation.

```ts
// before: caller's `moreText` never used
`... +${remainingCount} ${t("more") || moreText}`
// after: caller override, else translated default
`... +${remainingCount} ${moreText || t("more")}`
```

**Impact:** Low — the only current caller (`clinical-history-overview.tsx`) does not pass `moreText`, so there is no user-visible change today. This is a correctness fix that makes the documented parameter functional and removes a latent footgun.

**Verification:** `npx tsc --noEmit` (clean), `npm run lint` (clean), `npx prettier --check` (clean), `npm run build` (passes).

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature. — N/A: pure utility function; the repo has no unit-test harness for `src/Utils`, verified via type-check/lint/build.
- [ ] Update [product documentation](https://docs.ohc.network). — N/A: internal utility, no product-facing behavior change.
- [x] Ensure that UI text is placed in I18n files. — `t("more")` (i18next) is preserved as the fallback.
- [ ] Prepare a screenshot or demo video for the changelog entry. — N/A: no visible change for current callers.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices. — N/A: no UI change.
- [ ] Complete QA on desktop devices. — N/A: no UI change.
- [ ] Add or update Playwright tests for related changes. — N/A: pure logic fix, no E2E surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truncated list display by prioritizing custom text values over default translations when generating item count indicators, ensuring user-provided text is consistently respected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->