### PR TITLE
ENG-423 Forms: fix some responses not shown in print preview

### DIFF
--- a/src/components/Facility/ConsultationDetails/PrintAllQuestionnaireResponses.tsx
+++ b/src/components/Facility/ConsultationDetails/PrintAllQuestionnaireResponses.tsx
@@ -279,12 +279,6 @@ function QuestionGroup({
   }[];
   level?: number;
 }) {
-  const hasResponses = responses.some((r) =>
-    group.questions?.some((q) => q.id === r.question_id),
-  );
-
-  if (!hasResponses) return null;
-
   return (
     <div className={cn("space-y-2", group.styling_metadata?.classes)}>
       {!!level && group.text && (
@@ -375,7 +369,9 @@ export function ResponseCard({ item }: ResponseCardProps) {
               const response = item.responses.find(
                 (r) => r.question_id === question.id,
               );
-              if (!response) return null;
+              if (!response) {
+                return null;
+              }
 
               return (
                 <QuestionResponseValue


### PR DESCRIPTION
- ENG-423

## Proposed Changes

- There was an unintended/incorrect guard that prevented sub-question responses from being printed. It tried to match if there was a response for that group question. However, if it didn't, it'd not render. The guard doesn't check if sub-questions had a response. 

- The code has now been updated to be in sync with how the guards work in the questionnaire responses view itself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized questionnaire response rendering logic for improved performance and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care_fe/pull/16383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->