### PR TITLE
fix: honor caller-supplied moreText in formatTruncatedList (#16377)

### DIFF
--- a/src/Utils/utils.ts
+++ b/src/Utils/utils.ts
@@ -429,7 +429,7 @@ export function formatTruncatedList<T>(
   const displayedItems = items.slice(0, maxItems);
   const remainingCount = items.length - maxItems;
 
-  return `${displayedItems.map(getDisplayValue).join(", ")} ... +${remainingCount} ${t("more") || moreText}`;
+  return `${displayedItems.map(getDisplayValue).join(", ")} ... +${remainingCount} ${moreText || t("more")}`;
 }
 
 export function deepFreeze<T>(obj: T): T {


### PR DESCRIPTION
## Proposed Changes

Fixes #16377

- `formatTruncatedList()` in `src/Utils/utils.ts` documented a `moreText` parameter but never used it. The trailing expression was `t("more") || moreText` — since `t("more")` always returns a truthy string (the translated value, or the key `"more"` as a fallback), the `|| moreText` branch was unreachable and the caller-supplied label was silently ignored.
- Flipped the precedence to `moreText || t("more")` so a caller-supplied `moreText` is used when provided, falling back to the translation otherwise — matching the documented behavior.
- The only current caller (`clinical-history-overview.tsx`) does not pass `moreText`, so there is **no user-visible change** today. This is a correctness fix that makes the documented parameter functional and removes a latent footgun for future callers.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

---

### Notes for reviewers

- **No test added:** the repo has no unit-test framework (only Playwright E2E), and an end-to-end test for a pure string utility would be inappropriate. The change is a one-line operand swap; behavior of the sole existing caller is unchanged.
- Verified locally: Prettier ✓, ESLint ✓, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom labels for truncated list displays. Custom labels now take priority over default labels, ensuring user-provided text is displayed as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->