### PR TITLE
ci: integrate Trunk Flaky Tests for Playwright runs (MVP)

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -204,7 +204,7 @@ jobs:
         uses: trunk-io/analytics-uploader@v1
         with:
           junit-paths: test-results/junit.xml
-          org-slug: ${{ vars.TRUNK_ORG_URL_SLUG }}
+          org-slug: open-healthcare-network-foundation
           token: ${{ secrets.TRUNK_API_TOKEN }}
 
       - name: Upload test results

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -198,6 +198,15 @@ jobs:
         run: |
           echo "::error::Playwright tests failed in shard ${{ matrix.shard }}/${{ env.TEST_SHARDS }}"
 
+      - name: Upload results to Trunk Flaky Tests
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: test-results/junit.xml
+          org-slug: ${{ vars.TRUNK_ORG_URL_SLUG }}
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,12 @@ export default defineConfig({
   workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? [["html"], ["json", { outputFile: "test-results.json" }], ["list"]]
+    ? [
+        ["html"],
+        ["json", { outputFile: "test-results.json" }],
+        ["junit", { outputFile: "test-results/junit.xml" }],
+        ["list"],
+      ]
     : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,9 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
 
-  retries: process.env.CI ? 2 : 0,
+  /* Retries are disabled so Trunk Flaky Tests can accurately detect flakes.
+   * Flaky tests are managed via Trunk's Quarantining feature instead. */
+  retries: 0,
   /* CI workers are controlled per-phase in the workflow (setup=1, chromium=4).
    * Locally, use all available cores. */
   workers: undefined,


### PR DESCRIPTION
## Why

Our Playwright suite is our only pre-merge confidence signal, but we have no view on:
- Which tests are intermittently failing (flaky vs. genuinely broken)
- Test health trends over time
- Per-PR test impact at a glance

[Trunk Flaky Tests](https://trunk.io/products/flaky-tests) solves all three with a hosted dashboard, PR comments, automatic flake classification and quarantine — and is **free for OSS up to 5M test spans/month**, well above our current load (~900K spans/month).

## What this PR does (MVP scope)

1. **JUnit reporter** added to `playwright.config.ts` (CI only): emits `test-results/junit.xml` alongside the existing JSON/HTML reporters. No impact on local runs.
2. **Retries disabled** (was `process.env.CI ? 2 : 0`). [Trunk's framework guide](https://docs.trunk.io/flaky-tests/get-started/frameworks/playwright) is explicit: retries mask flakiness. Flaky tests should be handled by [Trunk's Quarantining](https://docs.trunk.io/flaky-tests/quarantining) feature instead — they'll still run, but won't fail CI.
3. **`trunk-io/analytics-uploader@v1`** step added to `.github/workflows/playwright.yaml` for each test shard.
   - `if: ${{ !cancelled() }}` and `continue-on-error: true` — **cannot block CI** if Trunk is down or the token is missing.
   - Uploads from each shard independently; Trunk merges by run ID.
   - `org-slug: open-healthcare-network-foundation` is hardcoded (per Trunk docs, only the token is a secret).

## Local validation (per Trunk's instructions)

```
$ ./trunk-analytics-cli validate --junit-paths "test-results/junit.xml"

1 test suites, 4 test cases, 0 errors, 1 warnings
 ⚠️  Warnings:
  report has test cases with missing file or filepath
```

**0 errors, 1 warning.** The warning is a Playwright JUnit reporter limitation (file paths are encoded in `classname=` rather than a separate `file=` attribute). It only affects CODEOWNERS auto-correlation of flaky tests to owners — flake detection itself works fine. Can be addressed in a follow-up if needed.

## Required setup (before merge)

The maintainer needs to:
1. Sign in to https://app.trunk.io and connect the GitHub org `open-healthcare-network-foundation`.
2. Add the org API token to `Settings → Secrets and variables → Actions`:
   - **Secret:** `TRUNK_API_TOKEN` (from Trunk Settings → Organization → Manage → Organization API Token)

If the secret isn't set, the upload step fails silently (`continue-on-error: true`) and the rest of the workflow runs unchanged.

## What we'll get after merge

- Dashboard at `app.trunk.io/open-healthcare-network-foundation/care_fe`: per-test health, trend lines, top offenders.
- **PR comments** flagging known-flaky failures so reviewers don't waste cycles on noise.
- **Auto-quarantine** for chronic flakes (opt-in, configured in the Trunk UI).
- Optional Slack alerts on test-state transitions.

## What this PR does NOT do (intentionally)

- Does **not** add Allure or other per-failure debug UI — existing `playwright-results-shard-*` artifacts already provide traces/videos.
- Does **not** modify any test code.
- Does **not** enable quarantine wrapping yet — that's a separate, opt-in change once we see baseline flake data.

## References

- Trunk pricing (OSS-friendly, 5M spans/mo free): https://trunk.io/pricing
- Playwright integration: https://docs.trunk.io/flaky-tests/get-started/frameworks/playwright
- GitHub Actions integration: https://docs.trunk.io/flaky-tests/get-started/ci-providers/github-actions
- Uploader action: https://github.com/trunk-io/analytics-uploader


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test result reporting with improved flaky test tracking to ensure better test reliability and diagnostics.
  * Optimized test failure handling in CI environments for more accurate identification of genuine test issues versus intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->