### PR TITLE
fix: prevent crash on Encounter Plots tab when plot config is empty

### DIFF
--- a/src/pages/Encounters/tabs/plots.tsx
+++ b/src/pages/Encounters/tabs/plots.tsx
@@ -37,7 +37,7 @@ export const EncounterPlotsTab = () => {
     return <Loading />;
   }
 
-  const currentTabId = qParams.plot || data[0].id;
+  const currentTabId = qParams.plot || data[0]?.id;
   const currentTab = data.find((tab) => tab.id === currentTabId);
 
   if (!currentTab) {

--- a/tests/facility/patient/encounter/encounterPlots.spec.ts
+++ b/tests/facility/patient/encounter/encounterPlots.spec.ts
@@ -8,7 +8,7 @@ test.use({ storageState: "tests/.auth/user.json" });
 test.describe("Encounter Plots Tab", () => {
   let plotsUrl: string;
 
-  test.beforeEach(async () => {
+  test.beforeEach(() => {
     const facilityId = getFacilityId();
     const patientId = getPatientId();
     const encounterId = getEncounterId();
@@ -25,7 +25,7 @@ test.describe("Encounter Plots Tab", () => {
     });
 
     await test.step("Stub the plots config endpoint with an empty array", async () => {
-      await page.route("**/config/plots.json", (route) =>
+      await page.route("**/config/plots.json*", (route) =>
         route.fulfill({
           status: 200,
           contentType: "application/json",

--- a/tests/facility/patient/encounter/encounterPlots.spec.ts
+++ b/tests/facility/patient/encounter/encounterPlots.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Encounter Plots Tab", () => {
+  let plotsUrl: string;
+
+  test.beforeEach(async () => {
+    const facilityId = getFacilityId();
+    const patientId = getPatientId();
+    const encounterId = getEncounterId();
+
+    plotsUrl = `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/plots`;
+  });
+
+  test("renders empty state without crashing when plots config is empty", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => {
+      pageErrors.push(error);
+    });
+
+    await test.step("Stub the plots config endpoint with an empty array", async () => {
+      await page.route("**/config/plots.json", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "[]",
+        }),
+      );
+    });
+
+    await test.step("Navigate to the Plots tab", async () => {
+      await page.goto(plotsUrl);
+      await expect(page.getByRole("tab", { name: "Plots" })).toHaveAttribute(
+        "data-state",
+        "active",
+      );
+    });
+
+    await test.step("Verify the empty state renders", async () => {
+      await expect(page.getByText("No plots configured")).toBeVisible();
+    });
+
+    await test.step("Verify the tab did not crash", async () => {
+      expect(pageErrors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes

The Encounter **Plots** tab (`src/pages/Encounters/tabs/plots.tsx`) crashes when the plots configuration resolves to an empty array.

The component picks a default tab with `data[0].id` **before** the existing "no plots configured" guard can run:

```ts
if (isLoading || !data) return <Loading />;

const currentTabId = qParams.plot || data[0].id;   // ← throws when data === []
const currentTab = data.find((tab) => tab.id === currentTabId);
if (!currentTab) return <div>{t("no_plots_configured")}</div>;  // intended empty state, never reached
```

The guard only checks `!data`, which is `false` for an empty array. When `careConfig.plotsConfigUrl` (default `/config/plots.json`, overridable via `REACT_OBSERVATION_PLOTS_CONFIG_URL`) returns `[]`, `data[0]` is `undefined` and reading `.id` throws a `TypeError`, crashing the tab — the `no_plots_configured` empty state that already exists is never shown.

**Fix:** use optional chaining so `currentTabId` is `undefined` for an empty config; `data.find(...)` then returns `undefined` and the existing empty state renders as intended.

```ts
const currentTabId = qParams.plot || data[0]?.id;
```

- One-line, root-cause fix in `plots.tsx`.
- Adds a Playwright regression test (`tests/facility/patient/encounter/encounterPlots.spec.ts`) that stubs `/config/plots.json` with `[]` and asserts the empty state renders without a page error. Verified **fail-before / pass-after**: it fails on `data[0].id` and passes with `data[0]?.id`.

### Reproduce

1. Point the plots config at an empty array (set `REACT_OBSERVATION_PLOTS_CONFIG_URL` to a JSON file containing `[]`, or serve `/config/plots.json` as `[]`).
2. Open any encounter's **Plots** tab → the tab crashes.
3. With this change, the tab shows "No plots configured" instead.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. *(Playwright regression test, verified fail-then-pass.)*
- [ ] Update [product documentation](https://docs.ohc.network). *(N/A — internal crash fix, no behavioral/doc change.)*
- [x] Ensure that UI text is placed in I18n files. *(Reuses the existing `no_plots_configured` key; no new strings.)*
- [ ] Prepare a screenshot or demo video for the changelog entry. *(N/A — fix prevents a crash on an edge-case config; repro steps documented above.)*
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices. *(Covered by automated E2E; manual device QA not performed.)*
- [ ] Complete QA on desktop devices. *(Covered by automated E2E; manual device QA not performed.)*
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Encounters Plots tab stability by handling loading and empty-configuration states to prevent errors during initial render and when switching plots.

* **Tests**
  * Added an automated test that verifies the Plots tab becomes active, displays the “No plots configured” empty state, and emits no page errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->