### PR TITLE
fix: treat whitespace-only title as empty in Charge Item Definition form

### DIFF
--- a/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
+++ b/src/pages/Facility/settings/chargeItemDefinitions/ChargeItemDefinitionForm.tsx
@@ -122,7 +122,10 @@ export function ChargeItemDefinitionForm({
     t: (key: string, options?: Record<string, unknown>) => string,
   ) =>
     z.object({
-      title: z.string().min(1, { message: t("title_is_required") }),
+      title: z
+        .string()
+        .trim()
+        .min(1, { message: t("title_is_required") }),
       slug_value: z
         .string()
         .trim()

--- a/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsCreate.spec.ts
+++ b/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsCreate.spec.ts
@@ -48,6 +48,22 @@ test.describe("Charge Item Definition Creation", () => {
     await expect(page.getByText(/base price.*required/i)).toBeVisible();
   });
 
+  test("rejects a whitespace-only title", async ({ page }) => {
+    await page.getByRole("button", { name: /add definition/i }).click();
+    // Title is only spaces; slug and base price are valid, so the title
+    // validation is the only thing that can block creation.
+    await page.getByRole("textbox", { name: /title/i }).fill("   ");
+    await page.getByRole("textbox", { name: /slug/i }).fill(slug);
+    await page.getByRole("textbox", { name: /base price/i }).fill(basePrice);
+    await page.getByRole("button", { name: /create/i }).click();
+
+    // A whitespace-only title must be treated as empty: required error, no creation.
+    await expect(page.getByText(/title.*required/i)).toBeVisible();
+    await expect(
+      page.getByText(/charge item definition.*created successfully/i),
+    ).toHaveCount(0);
+  });
+
   test("create charge item definition with required fields only", async ({
     page,
   }) => {


### PR DESCRIPTION
## Proposed Changes

In the **Charge Item Definition** create/edit form, the `title` field used `z.string().min(1)`, which accepts a value made up entirely of spaces. A whitespace-only title (e.g. `"   "`) therefore passes validation, letting a charge item definition be created with an effectively blank title.

The sibling `slug_value` field in the same schema already uses `.trim()`, so this is an internal inconsistency as much as a data-integrity bug.

**Fix** — add `.trim()` to the title schema so a whitespace-only value is treated as empty and surfaces the existing **"Title is required"** error, matching the convention already used by `slug_value` (and elsewhere in the codebase, e.g. `FacilityForm`, `ValueSetForm`).

```ts
title: z.string().trim().min(1, { message: t("title_is_required") }),
```

- One-line schema change in `ChargeItemDefinitionForm.tsx`.
- Adds a Playwright regression test to the existing `chargeItemDefinitionsCreate.spec.ts`: it submits a whitespace-only title alongside an otherwise-valid slug and base price and asserts creation is blocked with the required error. Verified **fail-before / pass-after** — on the previous `min(1)` the whitespace title is accepted and the definition is created; with `.trim()` it is rejected.

### Reproduce

1. Facility → Settings → Charge Item Definitions → a category → **Add definition**.
2. Enter only spaces in **Title**, a valid slug, and a base price → **Create**.
3. Before: the definition is created with a blank title. After: "Title is required" is shown and creation is blocked.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. *(Playwright regression test, verified fail-then-pass.)*
- [ ] Update [product documentation](https://docs.ohc.network). *(N/A — validation fix, no behavioral/doc change.)*
- [x] Ensure that UI text is placed in I18n files. *(Reuses the existing `title_is_required` key; no new strings.)*
- [ ] Prepare a screenshot or demo video for the changelog entry. *(N/A — input-validation fix; repro steps documented above.)*
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices. *(Covered by automated E2E; manual device QA not performed.)*
- [ ] Complete QA on desktop devices. *(Covered by automated E2E; manual device QA not performed.)*
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation to reject charge item definition titles containing only whitespace characters.

* **Tests**
  * Added test case verifying that whitespace-only titles are properly rejected with appropriate validation messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->