### PR TITLE
fix: preserve customized bed names when bed count changes

### DIFF
--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -147,7 +147,7 @@ export default function LocationForm({
       numberOfBeds &&
       locationName
     ) {
-      if (!customizeNames || bedFields.length === 0 || locationName) {
+      if (!customizeNames || bedFields.length === 0) {
         resetToDefaultNames();
       } else {
         const newCount = Number.parseInt(numberOfBeds ?? "0", 10);

--- a/tests/facility/settings/locations/locationCreation.spec.ts
+++ b/tests/facility/settings/locations/locationCreation.spec.ts
@@ -239,6 +239,45 @@ test.describe("Facility Location Creation", () => {
     });
   });
 
+  test("preserves a customized bed name when the bed count changes", async ({
+    page,
+  }) => {
+    const bedBaseName = faker.word.words(1);
+    const customBedName = `ICU-${faker.string.alpha(5)}`;
+
+    await test.step("Open parent location", async () => {
+      await page.locator('[data-slot="table-body"] tr').first().click();
+    });
+
+    await test.step("Set up bulk beds and customize the first bed name", async () => {
+      await page.getByRole("button", { name: "Add Location" }).click();
+      await page.getByRole("combobox", { name: "Location Form" }).click();
+      await page.getByRole("option", { name: "Bed" }).click();
+      await page.getByRole("textbox", { name: "Name" }).fill(bedBaseName);
+      await page
+        .getByRole("checkbox", { name: "Create Multiple Beds" })
+        .click();
+      await page.getByRole("combobox", { name: "Number of beds" }).click();
+      await page.getByRole("option", { name: "3 Beds", exact: true }).click();
+      await page
+        .getByRole("checkbox", { name: "Customize individual bed names" })
+        .click();
+      await page
+        .getByRole("textbox", { name: /^Bed Number 1\b/i })
+        .fill(customBedName);
+    });
+
+    await test.step("Change the bed count; custom name must be kept", async () => {
+      await page.getByRole("combobox", { name: "Number of beds" }).click();
+      await page.getByRole("option", { name: "4 Beds", exact: true }).click();
+
+      // Changing the count must not reset user-customized names to defaults.
+      await expect(
+        page.getByRole("textbox", { name: /^Bed Number 1\b/i }),
+      ).toHaveValue(customBedName);
+    });
+  });
+
   test("Verify error when creating bed in root location", async ({ page }) => {
     await test.step("Attempt to create bed at root", async () => {
       await page.getByRole("button", { name: "Add Location" }).click();


### PR DESCRIPTION
## Proposed Changes

In the **bulk bed creation** flow (Facility → Settings → Locations → add a *Bed* with "Create Multiple Beds"), enabling **"Customize individual bed names"**, editing a bed name, and then changing the bed count **silently reverts the edited names** to the auto-generated defaults.

The effect that keeps bed names in sync guards its name-preserving branch with:

```ts
if (!customizeNames || bedFields.length === 0 || locationName) {
  resetToDefaultNames();
} else {
  // resize while preserving user-entered names  ← unreachable
}
```

The enclosing block already requires a truthy `locationName`, so the extra `|| locationName` makes the condition **always true**. `resetToDefaultNames()` therefore runs on every change and the `else` branch — which grows/shrinks the list while keeping existing custom names — can never run.

**Fix:** drop the redundant `|| locationName` so customized names are preserved when only the count changes.

```ts
if (!customizeNames || bedFields.length === 0) {
```

- One-line fix in `LocationForm.tsx`.
- Adds a Playwright regression test to `locationCreation.spec.ts`: set up bulk beds, enable name customization, rename the first bed, change the count, and assert the custom name is retained. Verified **fail-before / pass-after** (on the old condition the name reverts to the default).

### Reproduce

1. Facility → Settings → Locations → open a parent location → **Add Location** → Form: **Bed**.
2. Enter a name, enable **Create Multiple Beds**, set **Number of beds** = 3.
3. Enable **Customize individual bed names**, rename **Bed Number 1** to e.g. `ICU-A`.
4. Change **Number of beds** to 4.
5. Before: `ICU-A` reverts to `<name> 1`. After: `ICU-A` is kept.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature. *(Playwright regression test, verified fail-then-pass.)*
- [ ] Update [product documentation](https://docs.ohc.network). *(N/A — behavioral bug fix, no doc change.)*
- [x] Ensure that UI text is placed in I18n files. *(No new strings; existing keys only.)*
- [ ] Prepare a screenshot or demo video for the changelog entry. *(N/A — repro steps documented above.)*
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices. *(Covered by automated E2E; manual device QA not performed.)*
- [ ] Complete QA on desktop devices. *(Covered by automated E2E; manual device QA not performed.)*
- [x] Add or update Playwright tests for related changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where custom bed names were unexpectedly reset when changing the number of beds during bulk bed creation in facility location settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->