### PR TITLE
Add `built_at` timestamp to build meta JSON

### DIFF
--- a/scripts/generate-build-version.js
+++ b/scripts/generate-build-version.js
@@ -7,6 +7,7 @@ const appVersion = uuidv4();
 
 const jsonData = {
   version: appVersion,
+  built_at: new Date().toISOString(),
 };
 
 const jsonContent = JSON.stringify(jsonData);

--- a/src/lib/appVersion.ts
+++ b/src/lib/appVersion.ts
@@ -18,6 +18,7 @@ export interface AppVersionInfo {
 
 export interface BuildMeta {
   version: string;
+  built_at: string;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- Add `built_at` timestamp to build meta JSON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Build metadata now includes a timestamp indicating when the build was created, improving version tracking and deployment debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->