### PR TITLE
[ENG-474] fix: improve stale chunk error handling for lazy imports

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,12 +32,13 @@ if ("serviceWorker" in navigator) {
 }
 
 // Handle stale chunk errors from lazy imports after deployments.
-// Only reload once per session to prevent infinite loops on network failures.
+// Reload once per session, but only if the failed chunk is from our own origin
+// (skip cross-origin plugin/federation chunks — those are handled by their callers).
 window.addEventListener("vite:preloadError", (event) => {
-  const reloaded = sessionStorage.getItem("vite-chunk-reload");
-  if (!reloaded) {
+  event.preventDefault();
+  const isOwnChunk = event.payload.message.includes(location.origin);
+  if (isOwnChunk && !sessionStorage.getItem("vite-chunk-reload")) {
     sessionStorage.setItem("vite-chunk-reload", "1");
-    event.preventDefault();
     window.location.reload();
   }
 });


### PR DESCRIPTION
## Proposed Changes

Reload the page once per session, but only if the failed chunk is from our own origin. Skip cross-origin plugin/federation chunks, as those are handled by their callers.

Fixes ENG-474

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
