### PR TITLE
ci(playwright): set geo org min level for E2E build

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -69,6 +69,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+          REACT_PATIENT_REG_MIN_GEO_ORG_LEVELS_REQUIRED: "1"
 
       - name: Cache build
         uses: actions/cache@v4


### PR DESCRIPTION
## Proposed Changes

Sets `REACT_PATIENT_REG_MIN_GEO_ORG_LEVELS_REQUIRED=1` during the CI build step so only the first geo-organization level is mandatory in patient registration tests.

This matches the E2E test behavior which selects one level and submits — without this, all levels are required and the test would need to drill down to the leaf organization.

## Merge Checklist

- [x] Config change only
- [x] Linting Complete
- [ ] Any other necessary step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved patient creation resilience with automatic retry logic and dynamic phone number generation
  * Updated test configuration to disable automatic retries
  * Enhanced navigation waiting in service request tests for better stability
  * Optimized charge item creation test timing for search indexing delays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->