### PR TITLE
[ENG-501] fix: conditionally render QR code for patient ID in AppointmentPrint

### DIFF
--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -132,8 +132,7 @@ export default function AppointmentPrint(props: Props) {
   }
 
   // Filter out excluded charge items and show all from the query
-  const patient = appointment.patient;
-  const token = appointment.token;
+  const { patient, token } = appointment;
 
   const displayChargeItems = chargeItems?.results?.filter(
     (item) => !EXCLUDED_CHARGE_ITEM_STATUSES.includes(item.status),
@@ -163,8 +162,8 @@ export default function AppointmentPrint(props: Props) {
     ? add(...allPayments.map((p) => p.amount)).toString()
     : undefined;
 
-  const patientTags = patient.instance_tags ?? [];
-  const appointmentTags = appointment.tags ?? [];
+  const patientTags = patient.instance_tags;
+  const appointmentTags = appointment.tags;
 
   return (
     <PrintPreview
@@ -220,7 +219,7 @@ export default function AppointmentPrint(props: Props) {
                 value={formatPhoneNumberIntl(patient.phone_number)}
               />
               {patient.instance_identifiers
-                ?.filter(
+                .filter(
                   (identifier) =>
                     identifier.config.config.use ===
                     PatientIdentifierUse.official,
@@ -232,7 +231,9 @@ export default function AppointmentPrint(props: Props) {
                     value={identifier.value}
                   />
                 ))}
-              <DetailRow label={t("address")} value={patient.address} />
+              {patient.address?.trim() && (
+                <DetailRow label={t("address")} value={patient.address} />
+              )}
             </div>
           </div>
           <div className="flex items-start gap-3">

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -255,7 +255,7 @@ export default function AppointmentPrint(props: Props) {
                 </p>
               </div>
             )}
-            <QRCodeSVG size={80} value={patient?.id || ""} />
+            {patient?.id && <QRCodeSVG size={80} value={patient.id} />}
           </div>
         </div>
 

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -107,11 +107,8 @@ export default function AppointmentPrint(props: Props) {
     .map((q) => q.data)
     .filter((inv): inv is InvoiceRead => !!inv);
 
-  const patient = appointment?.patient;
-  const token = appointment?.token;
-
   const patientExtensionData = usePatientExtensionData(
-    patient?.extensions,
+    appointment?.patient?.extensions,
     "appointment_print",
   );
 
@@ -135,6 +132,9 @@ export default function AppointmentPrint(props: Props) {
   }
 
   // Filter out excluded charge items and show all from the query
+  const patient = appointment.patient;
+  const token = appointment.token;
+
   const displayChargeItems = chargeItems?.results?.filter(
     (item) => !EXCLUDED_CHARGE_ITEM_STATUSES.includes(item.status),
   );
@@ -163,8 +163,8 @@ export default function AppointmentPrint(props: Props) {
     ? add(...allPayments.map((p) => p.amount)).toString()
     : undefined;
 
-  const patientTags = patient?.instance_tags ?? [];
-  const appointmentTags = appointment?.tags ?? [];
+  const patientTags = patient.instance_tags ?? [];
+  const appointmentTags = appointment.tags ?? [];
 
   return (
     <PrintPreview
@@ -204,31 +204,22 @@ export default function AppointmentPrint(props: Props) {
         <div className="flex justify-between gap-3 mb-1.5">
           <div className="flex-1">
             <div className="text-xs leading-snug space-y-px">
-              {patient && (
-                <>
-                  <DetailRow
-                    label={t("patient")}
-                    value={`${patient?.name} | ${formatPatientAge(patient, true)}, ${t(`GENDER__${patient.gender}`)}`}
-                  />
-                  {patientExtensionData.map((field) => (
-                    <DetailRow
-                      key={field.name}
-                      label={t(field.name)}
-                      value={field.value}
-                    />
-                  ))}
-                </>
-              )}
+              <DetailRow
+                label={t("patient")}
+                value={`${patient.name} | ${formatPatientAge(patient, true)}, ${t(`GENDER__${patient.gender}`)}`}
+              />
+              {patientExtensionData.map((field) => (
+                <DetailRow
+                  key={field.name}
+                  label={t(field.name)}
+                  value={field.value}
+                />
+              ))}
               <DetailRow
                 label={t("contact_system_phone")}
-                value={
-                  patient?.phone_number
-                    ? formatPhoneNumberIntl(patient.phone_number) ||
-                      patient.phone_number
-                    : undefined
-                }
+                value={formatPhoneNumberIntl(patient.phone_number)}
               />
-              {patient?.instance_identifiers
+              {patient.instance_identifiers
                 ?.filter(
                   (identifier) =>
                     identifier.config.config.use ===
@@ -241,9 +232,7 @@ export default function AppointmentPrint(props: Props) {
                     value={identifier.value}
                   />
                 ))}
-              {patient?.address?.trim() && (
-                <DetailRow label={t("address")} value={patient.address} />
-              )}
+              <DetailRow label={t("address")} value={patient.address} />
             </div>
           </div>
           <div className="flex items-start gap-3">
@@ -255,7 +244,7 @@ export default function AppointmentPrint(props: Props) {
                 </p>
               </div>
             )}
-            {patient?.id && <QRCodeSVG size={80} value={patient.id} />}
+            <QRCodeSVG size={80} value={patient.id} />
           </div>
         </div>
 


### PR DESCRIPTION
## Proposed Changes

There was a possibility for the appointment to print an empty string value QR. 

Fixes ENG-501


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patient details are now always rendered on the appointment print page.
  * Contact phone displays the internationally formatted number (no raw-number fallback).
  * Address is shown in the patient section when present.
  * QR code generation now relies on the patient ID directly to ensure correct output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->