### PR TITLE
fix(tests): improve patient registration E2E tests with faker, cascading geo org, and clock fix

### DIFF
--- a/tests/facility/patient/patientRegistration.spec.ts
+++ b/tests/facility/patient/patientRegistration.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { expect, Page, test } from "@playwright/test";
 import { getFacilityId } from "tests/support/facilityId";
 
@@ -8,27 +9,36 @@ test.use({ storageState: "tests/.auth/user.json" });
  * Test data generator for patient registration
  */
 function generatePatientData() {
-  const timestamp = Date.now();
   return {
-    name: `Test Patient ${timestamp}`,
-    phoneNumber: `9${Math.floor(Math.random() * 1000000000)
-      .toString()
-      .padStart(9, "0")}`,
-    gender: "Male",
+    name: faker.person.fullName(),
+    phoneNumber: `${faker.helpers.arrayElement([7, 8, 9])}${faker.string.numeric(9)}`,
+    gender: faker.helpers.arrayElement([
+      "Male",
+      "Female",
+      "Transgender",
+      "Non-binary",
+    ]),
     dateOfBirth: {
-      day: "16",
-      month: "06",
-      year: "2009",
+      day: faker.number.int({ min: 1, max: 28 }).toString().padStart(2, "0"),
+      month: faker.number.int({ min: 1, max: 12 }).toString().padStart(2, "0"),
+      year: faker.number.int({ min: 1950, max: 2009 }).toString(),
     },
-    bloodGroup: "A+",
+    bloodGroup: faker.helpers.arrayElement([
+      "A+",
+      "A-",
+      "B+",
+      "B-",
+      "O+",
+      "O-",
+      "AB+",
+      "AB-",
+    ]),
     state: "Rajasthan", //not used currently
-    pincode: "302020",
-    address: "123 Test Street, Test City",
+    pincode: faker.string.numeric(6),
+    address: faker.location.streetAddress({ useFullAddress: true }),
     emergencyContact: {
-      name: `Emergency Contact ${timestamp}`,
-      phoneNumber: `9${Math.floor(Math.random() * 1000000000)
-        .toString()
-        .padStart(9, "0")}`,
+      name: faker.person.fullName(),
+      phoneNumber: `${faker.helpers.arrayElement([7, 8, 9])}${faker.string.numeric(9)}`,
     },
   };
 }
@@ -68,7 +78,7 @@ async function fillDateOfBirth(
 async function selectBloodGroup(page: Page, bloodGroup: string) {
   await test.step("Select blood group", async () => {
     await page.getByRole("combobox", { name: /blood group/i }).click();
-    await page.getByRole("option", { name: bloodGroup }).click();
+    await page.getByRole("option", { name: bloodGroup, exact: true }).click();
   });
 }
 
@@ -98,15 +108,35 @@ async function fillAdditionalDetails(
       .getByRole("button", { name: /register patient/i })
       .scrollIntoViewIfNeeded();
 
-    const stateCombobox = page
-      .getByRole("region", { name: "Additional Details" })
-      .getByRole("combobox");
-    await stateCombobox.waitFor({ state: "visible" });
-    await stateCombobox.click();
+    // Geo org comboboxes are cascading — the next one only appears after selecting the previous
+    const geoRegion = page.getByRole("region", { name: "Additional Details" });
+    let previousCount = 0;
 
-    const stateOption = page.getByRole("option").first();
-    await stateOption.waitFor({ state: "visible" });
-    await stateOption.click();
+    while (true) {
+      const comboboxes = geoRegion.getByRole("combobox");
+      const count = await comboboxes.count();
+      if (count === previousCount) break;
+
+      const combobox = comboboxes.nth(count - 1);
+      await combobox.waitFor({ state: "visible" });
+      await combobox.click();
+
+      const option = page.getByRole("option").first();
+      await option.waitFor({ state: "visible" });
+      await option.click();
+
+      previousCount = count;
+      // Wait for either a new combobox to appear (more levels) or timeout (no more levels)
+      try {
+        await geoRegion
+          .getByRole("combobox")
+          .nth(count)
+          .waitFor({ state: "visible", timeout: 3000 });
+      } catch {
+        // No new combobox appeared — we've filled all required levels
+        break;
+      }
+    }
   });
 }
 
@@ -117,7 +147,7 @@ async function submitRegistration(page: Page) {
       page
         .locator("li[data-sonner-toast]")
         .getByText(/patient registered successfully/i),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15000 });
   });
 }
 
@@ -196,6 +226,68 @@ test.describe("Patient Registration", () => {
       await expect(
         page.getByText(/entered phone number is not valid/i).first(),
       ).toBeVisible();
+    });
+  });
+
+  test("should show validation error when only first geo org level is selected", async ({
+    page,
+  }) => {
+    const patientData = generatePatientData();
+    await startRegistration(page);
+    await fillBasicInfo(page, patientData);
+    await fillDateOfBirth(page, patientData.dateOfBirth);
+    await selectBloodGroup(page, patientData.bloodGroup);
+
+    await test.step("Open additional details and fill only first state", async () => {
+      const additionalDetailsSection = page.getByRole("button", {
+        name: "Additional Details",
+      });
+      const additionalDetailsSectionText =
+        await additionalDetailsSection.textContent();
+
+      if (additionalDetailsSectionText?.toLowerCase().includes("optional")) {
+        await additionalDetailsSection.click();
+      }
+
+      await page
+        .getByRole("textbox", { name: "Address" })
+        .fill(patientData.address);
+      await page
+        .getByRole("spinbutton", { name: "PIN Code" })
+        .fill(patientData.pincode);
+
+      await page
+        .getByRole("button", { name: /register patient/i })
+        .scrollIntoViewIfNeeded();
+
+      // Select only the first geo org level
+      const geoRegion = page.getByRole("region", {
+        name: "Additional Details",
+      });
+      const firstCombobox = geoRegion.getByRole("combobox").first();
+      await firstCombobox.waitFor({ state: "visible" });
+      await firstCombobox.click();
+
+      const option = page.getByRole("option").first();
+      await option.waitFor({ state: "visible" });
+      await option.click();
+    });
+
+    await test.step("Submit and verify validation error", async () => {
+      await page.getByRole("button", { name: /register patient/i }).click();
+
+      await expect(
+        page
+          .getByText(/geo organization is required when nationality is india/i)
+          .first(),
+      ).toBeVisible();
+
+      // Should NOT show success toast
+      await expect(
+        page
+          .locator("li[data-sonner-toast]")
+          .getByText(/patient registered successfully/i),
+      ).not.toBeVisible();
     });
   });
 
@@ -293,6 +385,8 @@ test.describe("DOB timezone validation", () => {
     await fillDateOfBirth(page, TODAY_IST);
     await selectBloodGroup(page, patientData.bloodGroup);
     await fillAdditionalDetails(page, patientData);
+    // Resume clock before submit so API calls and toast timers work normally
+    await page.clock.resume();
     await submitRegistration(page);
   });
 
@@ -304,6 +398,8 @@ test.describe("DOB timezone validation", () => {
     await fillDateOfBirth(page, TOMORROW_IST);
     await selectBloodGroup(page, patientData.bloodGroup);
     await fillAdditionalDetails(page, patientData);
+    // Resume clock before submit so form submission and toast work
+    await page.clock.resume();
 
     await page.getByRole("button", { name: /register patient/i }).click();
 

--- a/tests/facility/patient/patientRegistration.spec.ts
+++ b/tests/facility/patient/patientRegistration.spec.ts
@@ -33,7 +33,6 @@ function generatePatientData() {
       "AB+",
       "AB-",
     ]),
-    state: "Rajasthan", //not used currently
     pincode: faker.string.numeric(6),
     address: faker.location.streetAddress({ useFullAddress: true }),
     emergencyContact: {


### PR DESCRIPTION
## Changes

Improves the patient registration Playwright E2E tests to be more robust and less flaky:

- **Faker integration**: Use `@faker-js/faker` for dynamic test data generation (names, phones, addresses, DOBs) to avoid collisions on re-runs
- **Cascading geo org comboboxes**: Handle the dynamic cascading combobox pattern with a try/catch timeout loop that stops when no more levels appear
- **Validation test**: Add test for partial geo org selection (only first level selected) to verify the "Geo organization is required" error
- **Blood group fix**: Use `{ exact: true }` for blood group option selection to prevent "B-" matching "AB-"
- **DOB timezone fix**: Resume clock before API submission so frozen `Date.now()` doesn't break auth/API calls
- **Timeout increase**: Increase submit registration toast timeout to 15s for slower environments

All 15 tests pass reliably in both serial (`--workers=1`) and parallel modes.