### PR TITLE
[ENG-518]  feat: add form completion validation for Payment Reconciliation Sheet

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -231,6 +231,16 @@ export function PaymentReconciliationSheet({
   // Watch for amount changes
   const amount = form.watch("amount");
   const tenderedAmount = form.watch("tendered_amount");
+  const reconciliationType = form.watch("reconciliation_type");
+  const paymentDatetime = form.watch("payment_datetime");
+
+  // Determine if all required fields are filled
+  const isFormComplete =
+    !!paymentMethod &&
+    !!amount &&
+    isPositive(amount) &&
+    !!paymentDatetime &&
+    (isCreditNote || !!reconciliationType);
 
   // Calculate returned amount when tender amount, amount or payment method changes
   useEffect(() => {
@@ -707,7 +717,7 @@ export function PaymentReconciliationSheet({
 
                 <Button
                   type="submit"
-                  disabled={isPending || isExtensionsLoading}
+                  disabled={isPending || isExtensionsLoading || !isFormComplete}
                   aria-label={
                     isCreditNote ? t("record_credit_note") : t("record_payment")
                   }

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -242,6 +242,8 @@ export function PaymentReconciliationSheet({
     isPositive(amount) &&
     !!paymentDatetime &&
     !!reconciliationType &&
+    (!isCashPayment ||
+      (!!tenderedAmount && isGreaterThanOrEqual(tenderedAmount, amount))) &&
     (!careConfig.paymentLocationRequired || !!location);
 
   // Calculate returned amount when tender amount, amount or payment method changes

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -233,6 +233,7 @@ export function PaymentReconciliationSheet({
   const tenderedAmount = form.watch("tendered_amount");
   const reconciliationType = form.watch("reconciliation_type");
   const paymentDatetime = form.watch("payment_datetime");
+  const location = form.watch("location");
 
   // Determine if all required fields are filled
   const isFormComplete =
@@ -241,7 +242,7 @@ export function PaymentReconciliationSheet({
     isPositive(amount) &&
     !!paymentDatetime &&
     (isCreditNote || !!reconciliationType) &&
-    (!careConfig.paymentLocationRequired || !!form.watch("location"));
+    (!careConfig.paymentLocationRequired || !!location);
 
   // Calculate returned amount when tender amount, amount or payment method changes
   useEffect(() => {
@@ -718,6 +719,8 @@ export function PaymentReconciliationSheet({
 
                 <Button
                   type="submit"
+                  variant="primary"
+                  className="disabled:bg-gray-500"
                   disabled={isPending || isExtensionsLoading || !isFormComplete}
                   aria-label={
                     isCreditNote ? t("record_credit_note") : t("record_payment")

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -240,7 +240,8 @@ export function PaymentReconciliationSheet({
     !!amount &&
     isPositive(amount) &&
     !!paymentDatetime &&
-    (isCreditNote || !!reconciliationType);
+    (isCreditNote || !!reconciliationType) &&
+    (!careConfig.paymentLocationRequired || !!form.watch("location"));
 
   // Calculate returned amount when tender amount, amount or payment method changes
   useEffect(() => {

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -241,7 +241,7 @@ export function PaymentReconciliationSheet({
     !!amount &&
     isPositive(amount) &&
     !!paymentDatetime &&
-    (isCreditNote || !!reconciliationType) &&
+    !!reconciliationType &&
     (!careConfig.paymentLocationRequired || !!location);
 
   // Calculate returned amount when tender amount, amount or payment method changes

--- a/tests/facility/billing/paymentReconciliation.spec.ts
+++ b/tests/facility/billing/paymentReconciliation.spec.ts
@@ -111,22 +111,40 @@ test.describe("Payment Reconciliation", () => {
     await expect(dialog).toBeVisible();
   });
 
-  test("should show validation error when submitting empty payment", async ({
+  test("should disable submit button when required fields are empty", async ({
     page,
   }) => {
     // Open Record Payment
     await page.getByRole("button", { name: /advance/i }).click();
 
-    // Click Record Payment without filling anything
-    await page.getByRole("button", { name: /record payment/i }).click();
+    // Verify submit button is disabled when form is incomplete
+    const submitButton = page.getByRole("button", {
+      name: /record payment/i,
+    });
+    await expect(submitButton).toBeDisabled();
 
-    // Verify validation error is shown
-    const paymentAmountSection = page
-      .locator("div")
-      .filter({ hasText: /^Amount Paid/ })
-      .filter({ hasText: /Must be a valid number$/ });
+    // Fill required fields and verify button becomes enabled
+    await page.locator("label").filter({ hasText: "Cash" }).click();
+    await page
+      .locator("label")
+      .filter({ hasText: /^Payment$/ })
+      .click();
 
-    await expect(paymentAmountSection).toBeVisible();
+    await page
+      .getByRole("combobox")
+      .filter({ hasText: "Select Location" })
+      .click();
+    await page
+      .locator('[data-slot="command-item"]')
+      .filter({ hasText: "Bio-Chemistry Lab" })
+      .click();
+
+    const paymentAmount = faker.number.int({ min: 100, max: 5000 }).toString();
+    await page
+      .getByRole("textbox", { name: "Amount Paid" })
+      .fill(paymentAmount);
+
+    await expect(submitButton).toBeEnabled();
   });
 
   test("should record payment twice without refreshing page with location cache", async ({

--- a/tests/facility/billing/paymentReconciliation.spec.ts
+++ b/tests/facility/billing/paymentReconciliation.spec.ts
@@ -144,6 +144,14 @@ test.describe("Payment Reconciliation", () => {
       .getByRole("textbox", { name: "Amount Paid" })
       .fill(paymentAmount);
 
+    // For Cash, Amount Received is required and must be >= Amount Paid
+    const tenderAmount = faker.number
+      .int({ min: parseInt(paymentAmount), max: 10000 })
+      .toString();
+    await page
+      .getByRole("textbox", { name: "Amount Received" })
+      .fill(tenderAmount);
+
     await expect(submitButton).toBeEnabled();
   });
 


### PR DESCRIPTION
## Proposed Changes

<img width="1134" height="738" alt="image" src="https://github.com/user-attachments/assets/a149fb6e-64d9-46fe-b8b3-842fffe9e4cc" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment form now requires payment method, positive amount, payment date, and reconciliation type before allowing submission; location is required when site settings mandate it. Submit button also respects pending/loading states.

* **Tests**
  * Updated test to verify the Record Payment button remains disabled until all required fields are completed and becomes enabled afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->