### PR TITLE
[ENG-519] feat: enable error focus on form submission in PaymentReconciliationSheet

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -311,10 +311,12 @@ export function PaymentReconciliationSheet({
       submitPayment(submissionData);
     },
     () => {
-      const firstError = formRef.current?.querySelector(
-        "[data-slot='form-message']",
-      );
-      firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
+      requestAnimationFrame(() => {
+        const firstError = formRef.current?.querySelector(
+          "[data-slot='form-message']",
+        );
+        firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
     },
   );
 

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { t } from "i18next";
 import { useAtom } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -191,6 +191,7 @@ export function PaymentReconciliationSheet({
 }: PaymentReconciliationSheetProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const formRef = useRef<HTMLFormElement>(null);
   const [selectedLocationObject, setSelectedLocationObject] = useAtom(
     paymentReconcilationLocationAtom(facilityId),
   );
@@ -215,7 +216,6 @@ export function PaymentReconciliationSheet({
   type FormValues = z.infer<typeof formSchema>;
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    shouldFocusError: true,
   });
 
   const extensions = useEntityExtensions({
@@ -312,7 +312,9 @@ export function PaymentReconciliationSheet({
     },
     () => {
       setTimeout(() => {
-        const firstError = document.querySelector("[data-slot='form-message']");
+        const firstError = formRef.current?.querySelector(
+          "[data-slot='form-message']",
+        );
         firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
       }, 100);
     },
@@ -381,7 +383,11 @@ export function PaymentReconciliationSheet({
         </SheetHeader>
 
         <Form {...form}>
-          <form onSubmit={handleSubmit} className="space-y-6 py-4">
+          <form
+            ref={formRef}
+            onSubmit={handleSubmit}
+            className="space-y-6 py-4"
+          >
             <div className="space-y-6">
               <div className="rounded-lg bg-gray-50 border border-gray-200 p-3 space-y-3">
                 {invoice && (

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -311,12 +311,10 @@ export function PaymentReconciliationSheet({
       submitPayment(submissionData);
     },
     () => {
-      setTimeout(() => {
-        const firstError = formRef.current?.querySelector(
-          "[data-slot='form-message']",
-        );
-        firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
-      }, 100);
+      const firstError = formRef.current?.querySelector(
+        "[data-slot='form-message']",
+      );
+      firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
     },
   );
 

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -215,6 +215,7 @@ export function PaymentReconciliationSheet({
   type FormValues = z.infer<typeof formSchema>;
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
+    shouldFocusError: true,
   });
 
   const extensions = useEntityExtensions({
@@ -293,21 +294,29 @@ export function PaymentReconciliationSheet({
     },
   });
 
-  const handleSubmit = form.handleSubmit((data) => {
-    const { extensions: formExtensions, ...restData } = data;
-    const cleanedExtensions = extensions.prepareForSubmit(
-      formExtensions as NamespacedExtensionData,
-    );
+  const handleSubmit = form.handleSubmit(
+    (data) => {
+      const { extensions: formExtensions, ...restData } = data;
+      const cleanedExtensions = extensions.prepareForSubmit(
+        formExtensions as NamespacedExtensionData,
+      );
 
-    // Convert form data to PaymentReconciliationCreate type
-    const submissionData: PaymentReconciliationCreate = {
-      ...restData,
-      is_credit_note: isCreditNote,
-      location: restData.location,
-      extensions: cleanedExtensions,
-    };
-    submitPayment(submissionData);
-  });
+      // Convert form data to PaymentReconciliationCreate type
+      const submissionData: PaymentReconciliationCreate = {
+        ...restData,
+        is_credit_note: isCreditNote,
+        location: restData.location,
+        extensions: cleanedExtensions,
+      };
+      submitPayment(submissionData);
+    },
+    () => {
+      setTimeout(() => {
+        const firstError = document.querySelector("[data-slot='form-message']");
+        firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 100);
+    },
+  );
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
## Proposed Changes

This PR enable error focus via scroll.

https://github.com/user-attachments/assets/b7485165-ef4b-4f83-b29d-15c82d020e03


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission handling: when validation fails, the interface now smoothly scrolls the first validation message into view and centers it for easier correction.
  * Enhanced error visibility and usability for large or complex forms so users can find and fix issues more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->