### PR TITLE
feat: make toast notification position configurable via env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -103,6 +103,11 @@ REACT_PAYMENT_LOCATION_REQUIRED=true
 # Example: REACT_DEFAULT_PAYMENT_METHOD=cash
 REACT_DEFAULT_PAYMENT_METHOD=
 
+# Screen position for toast notifications (optional)
+# Valid values: top-left, top-center, top-right, bottom-left, bottom-center, bottom-right
+# Defaults to top-center if unset or invalid.
+REACT_TOAST_POSITION=
+
 # Relative number of days to show in the appointments page by default.0 means today, positive for future days, negative for past days.
 REACT_APPOINTMENTS_DEFAULT_DATE_FILTER=
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -168,6 +168,35 @@ const careConfig = {
     return undefined;
   })(),
 
+  /**
+   * Screen position for toast notifications (Sonner)
+   * Valid values: top-left, top-center, top-right, bottom-left, bottom-center, bottom-right
+   * Defaults to top-center if unset or invalid.
+   */
+  toastPosition: (() => {
+    const validPositions = [
+      "top-left",
+      "top-center",
+      "top-right",
+      "bottom-left",
+      "bottom-center",
+      "bottom-right",
+    ] as const;
+
+    const defaultPosition: (typeof validPositions)[number] = "top-center";
+    const position = env.REACT_TOAST_POSITION;
+    if (!position) return defaultPosition;
+
+    if (validPositions.includes(position as (typeof validPositions)[number])) {
+      return position as (typeof validPositions)[number];
+    }
+
+    console.warn(
+      `Invalid REACT_TOAST_POSITION: "${position}". Valid values are: ${validPositions.join(", ")}. Falling back to ${defaultPosition}.`,
+    );
+    return defaultPosition;
+  })(),
+
   careApps: env.REACT_ENABLED_APPS
     ? env.REACT_ENABLED_APPS.split(",").map((app) => {
         const [module, cdn] = app.split("@");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import careConfig from "@careConfig";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useLocationChange } from "raviger";
@@ -51,7 +52,7 @@ const App = () => {
                   </AuthUserProvider>
                 </OverrideProvider>
                 <Toaster
-                  position="top-center"
+                  position={careConfig.toastPosition}
                   theme="light"
                   richColors
                   expand


### PR DESCRIPTION
## Proposed Changes

The Sonner toast position was hardcoded as `top-center` in `App.tsx`. This adds a `REACT_TOAST_POSITION` env var so deployments can place toast notifications in any of the six supported positions.

- Added a validated `toastPosition` field in `care.config.ts` that accepts only the six valid Sonner positions (`top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center`, `bottom-right`). Invalid or unset values warn and fall back to `top-center`, mirroring the existing `REACT_DEFAULT_PAYMENT_METHOD` validation pattern.
- Replaced the hardcoded `position="top-center"` in `src/App.tsx` with `position={careConfig.toastPosition}`.
- Documented `REACT_TOAST_POSITION` in `.example.env`.

No changes needed in `src/components/ui/sonner.tsx` since it already spreads `{...props}`, so the position flows through from `App.tsx`.

**Reviewer notes:** With no env set, behavior is byte-for-byte identical to before (`top-center`). The change only takes effect when the variable is set at build time. Type safety is preserved — the config returns a union assignable to Sonner's `position` prop.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files. (No user-facing text added.)
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable toast notification positioning. Users can now customize where notifications appear on screen via environment settings, with options for various corner and edge positions (top/bottom and left/center/right), defaulting to top-center if not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->