### PR TITLE
Versions for Valusets

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -179,3 +179,6 @@ REACT_DECIMAL_ROUNDING_METHOD=ROUND_HALF_UP
 
 # Maximum number of forms that can be favorited in the forms dialog (default: 5)
 REACT_MAX_FORM_DIALOG_FAVORITES=5
+
+# Default tab for medication selector. Valid values: product, valueset
+REACT_MEDICATION_VALUE_SET_SELECT_DEFAULT_TAB=product

--- a/care.config.ts
+++ b/care.config.ts
@@ -208,6 +208,11 @@ const careConfig = {
     name: env.REACT_DEFAULT_COUNTRY_NAME || "India",
   },
 
+  medicationValueSetSelectDefaultTab:
+    env.REACT_MEDICATION_VALUE_SET_SELECT_DEFAULT_TAB === "valueset"
+      ? "valueset"
+      : "product",
+
   resendOtpTimeout: env.REACT_APP_RESEND_OTP_TIMEOUT
     ? parseInt(env.REACT_APP_RESEND_OTP_TIMEOUT, 10)
     : 30,

--- a/src/components/Questionnaire/MedicationValueSetSelect.tsx
+++ b/src/components/Questionnaire/MedicationValueSetSelect.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
+import careConfig from "@careConfig";
 
 import {
   Breadcrumb,
@@ -79,7 +80,9 @@ export default function MedicationValueSetSelect({
   const { t } = useTranslation();
   const { facilityId } = useCurrentFacilitySilently();
   const [open, setOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<TabType>("product");
+  const [activeTab, setActiveTab] = useState<TabType>(
+    careConfig.medicationValueSetSelectDefaultTab,
+  );
   const [search, setSearch] = useState("");
   const isMobile = useBreakpoints({ default: true, sm: false });
 

--- a/src/components/ValueSet/ValueSetEditor.tsx
+++ b/src/components/ValueSet/ValueSetEditor.tsx
@@ -22,6 +22,22 @@ interface ValueSetEditorProps {
   onSuccess?: (data: ValueSetRead) => void;
 }
 
+function normalizeValueSetPayload(data: ValueSetBase): ValueSetBase {
+  return {
+    ...data,
+    compose: {
+      include: data.compose.include.map((rule) => ({
+        ...rule,
+        version: rule.version?.trim() || null,
+      })),
+      exclude: data.compose.exclude.map((rule) => ({
+        ...rule,
+        version: rule.version?.trim() || null,
+      })),
+    },
+  };
+}
+
 export function ValueSetEditor({ slug, onSuccess }: ValueSetEditorProps) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
@@ -58,14 +74,16 @@ export function ValueSetEditor({ slug, onSuccess }: ValueSetEditorProps) {
   });
 
   const handleSubmit = (data: ValueSetBase) => {
+    const payload = normalizeValueSetPayload(data);
+
     if (slug && existingValueset) {
       const updateData: ValueSetUpdate = {
-        ...data,
+        ...payload,
         id: existingValueset.id,
       };
       updateMutation.mutate(updateData);
     } else {
-      const createData: ValueSetCreate = data;
+      const createData: ValueSetCreate = payload;
       createMutation.mutate(createData);
     }
   };

--- a/src/components/ValueSet/ValueSetForm.tsx
+++ b/src/components/ValueSet/ValueSetForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm, type UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as z from "zod";
 
@@ -30,6 +30,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   TERMINOLOGY_SYSTEMS,
   ValueSetBase,
+  ValueSetInclude,
   ValueSetRead,
   ValueSetStatus,
 } from "@/types/valueSet/valueSet";
@@ -46,6 +47,17 @@ interface ValueSetFormProps {
   isReadOnly?: boolean;
 }
 
+interface ValueSetFormInclude extends Omit<ValueSetInclude, "version"> {
+  version: string;
+}
+
+interface ValueSetFormData extends Omit<ValueSetBase, "compose"> {
+  compose: {
+    exclude: ValueSetFormInclude[];
+    include: ValueSetFormInclude[];
+  };
+}
+
 function ConceptFields({
   nestIndex,
   type,
@@ -54,7 +66,7 @@ function ConceptFields({
 }: {
   nestIndex: number;
   type: "include" | "exclude";
-  parentForm: ReturnType<typeof useForm<ValueSetBase>>;
+  parentForm: UseFormReturn<ValueSetFormData>;
   disabled?: boolean;
 }) {
   const { t } = useTranslation(); // Add translation hook
@@ -104,7 +116,7 @@ function FilterFields({
   nestIndex: number;
   type: "include" | "exclude";
   disabled?: boolean;
-  parentForm: ReturnType<typeof useForm<ValueSetBase>>;
+  parentForm: UseFormReturn<ValueSetFormData>;
 }) {
   const { t } = useTranslation();
   const { fields, append, remove } = useFieldArray({
@@ -201,7 +213,7 @@ function RuleFields({
   disabled,
 }: {
   type: "include" | "exclude";
-  form: ReturnType<typeof useForm<ValueSetBase>>;
+  form: UseFormReturn<ValueSetFormData>;
   disabled?: boolean;
 }) {
   const { t } = useTranslation();
@@ -223,6 +235,7 @@ function RuleFields({
           onClick={() =>
             append({
               system: Object.values(TERMINOLOGY_SYSTEMS)[0],
+              version: "",
               concept: [],
               filter: [],
             })
@@ -264,6 +277,23 @@ function RuleFields({
                         )}
                       </SelectContent>
                     </Select>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`compose.${type}.${index}.version`}
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel>{t("version")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={t("version")}
+                        disabled={disabled}
+                      />
+                    </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
@@ -323,6 +353,7 @@ export function ValueSetForm({
       include: z.array(
         z.object({
           system: z.string(),
+          version: z.string(),
           concept: z
             .array(
               z.object({
@@ -345,6 +376,7 @@ export function ValueSetForm({
       exclude: z.array(
         z.object({
           system: z.string(),
+          version: z.string(),
           concept: z
             .array(
               z.object({
@@ -367,7 +399,7 @@ export function ValueSetForm({
     }),
   });
 
-  const form = useForm({
+  const form = useForm<ValueSetFormData>({
     resolver: zodResolver(valuesetFormSchema),
     defaultValues: {
       name: initialData?.name || "",
@@ -376,8 +408,16 @@ export function ValueSetForm({
       status: initialData?.status || ValueSetStatus.ACTIVE,
       is_system_defined: initialData?.is_system_defined || false,
       compose: {
-        include: initialData?.compose?.include || [],
-        exclude: initialData?.compose?.exclude || [],
+        include:
+          initialData?.compose?.include.map((rule) => ({
+            ...rule,
+            version: rule.version ?? "",
+          })) || [],
+        exclude:
+          initialData?.compose?.exclude.map((rule) => ({
+            ...rule,
+            version: rule.version ?? "",
+          })) || [],
       },
     },
   });

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -39,7 +39,7 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
         compose: valueset.compose.include[0]?.system
           ? valueset.compose
           : {
-              include: [{ system: "http://snomed.info/sct", version: "" }],
+              include: [{ system: "http://snomed.info/sct", version: null }],
               exclude: [],
             },
       },

--- a/src/components/ValueSet/ValueSetPreview.tsx
+++ b/src/components/ValueSet/ValueSetPreview.tsx
@@ -39,7 +39,7 @@ export function ValueSetPreview({ valueset, trigger }: ValueSetPreviewProps) {
         compose: valueset.compose.include[0]?.system
           ? valueset.compose
           : {
-              include: [{ system: "http://snomed.info/sct" }],
+              include: [{ system: "http://snomed.info/sct", version: "" }],
               exclude: [],
             },
       },

--- a/src/types/valueSet/valueSet.ts
+++ b/src/types/valueSet/valueSet.ts
@@ -41,6 +41,7 @@ export interface ValueSetConcept {
 export interface ValueSetInclude {
   filter?: ValueSetFilter[];
   system: string;
+  version: string | null;
   concept?: ValueSetConcept[];
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -46,6 +46,7 @@ interface ImportMetaEnv {
   readonly REACT_ACCOUNTING_PRECISION?: string;
   readonly REACT_DECIMAL_ROUNDING_METHOD?: string;
   readonly REACT_MAX_FORM_DIALOG_FAVORITES?: string;
+  readonly REACT_MEDICATION_VALUE_SET_SELECT_DEFAULT_TAB?: string;
 
   // Plugins related envs...
   readonly REACT_SENTRY_DSN?: string;


### PR DESCRIPTION
## Proposed Changes

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable default tab for medication lookup (valueset or product) via environment setting.
  * Added a version field for value set composition rules with visible inputs in the rule UI.

* **Bug Fixes**
  * Trim and normalize version fields on form submit to avoid empty/whitespace issues.
  * Improved preview behavior to include explicit version information for more accurate searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->