### PR TITLE
[ENG-522]: Register InvoicePrint for plugin overrides

### DIFF
--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+import { register } from "@/lib/override/";
 import { cn } from "@/lib/utils";
 import {
   InvoiceChargeItemTitle,
@@ -49,7 +50,7 @@ type PrintInvoiceProps = {
   invoiceId: string;
 };
 
-export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
+export function PrintInvoiceBase({ facilityId, invoiceId }: PrintInvoiceProps) {
   const { t } = useTranslation();
 
   const { data: invoice, isLoading: isInvoiceLoading } = useQuery({
@@ -710,4 +711,4 @@ export function PrintInvoice({ facilityId, invoiceId }: PrintInvoiceProps) {
   );
 }
 
-export default PrintInvoice;
+export default register("PrintInvoice", PrintInvoiceBase);

--- a/src/pages/Facility/billing/invoice/components/InvoiceChargeItemTitle.tsx
+++ b/src/pages/Facility/billing/invoice/components/InvoiceChargeItemTitle.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-import { register } from "@/lib/override/register";
 import { BatchRequest } from "@/types/base/batch/batch";
 import batchApi from "@/types/base/batch/batchApi";
 import {
@@ -22,7 +21,7 @@ interface InvoiceChargeItemTitleProps {
   isLoading: boolean;
 }
 
-function InvoiceChargeItemTitleBase({
+export function InvoiceChargeItemTitle({
   item,
   dispenseMap,
   isLoading,
@@ -72,11 +71,6 @@ function InvoiceChargeItemTitleBase({
     </div>
   );
 }
-
-export const InvoiceChargeItemTitle = register(
-  "InvoiceChargeItemTitle",
-  InvoiceChargeItemTitleBase,
-);
 
 interface UseMedicationDispenseDataResult {
   dispenseMap: Record<string, MedicationDispenseRead | undefined>;

--- a/src/pages/Facility/billing/invoice/components/InvoiceChargeItemTitle.tsx
+++ b/src/pages/Facility/billing/invoice/components/InvoiceChargeItemTitle.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
+import { register } from "@/lib/override/register";
 import { BatchRequest } from "@/types/base/batch/batch";
 import batchApi from "@/types/base/batch/batchApi";
 import {
@@ -21,7 +22,7 @@ interface InvoiceChargeItemTitleProps {
   isLoading: boolean;
 }
 
-export function InvoiceChargeItemTitle({
+function InvoiceChargeItemTitleBase({
   item,
   dispenseMap,
   isLoading,
@@ -71,6 +72,11 @@ export function InvoiceChargeItemTitle({
     </div>
   );
 }
+
+export const InvoiceChargeItemTitle = register(
+  "InvoiceChargeItemTitle",
+  InvoiceChargeItemTitleBase,
+);
 
 interface UseMedicationDispenseDataResult {
   dispenseMap: Record<string, MedicationDispenseRead | undefined>;


### PR DESCRIPTION
## Proposed Changes

- ENG-522
- Allows overriding PrintInvoice for including additional information.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for the invoice printing component to support enhanced customization capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->