### PR TITLE
Add Plugin Extension Support for External Delivery Integrations

### DIFF
--- a/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderList.tsx
+++ b/src/pages/Facility/services/inventory/externalSupply/deliveryOrder/DeliveryOrderList.tsx
@@ -3,6 +3,7 @@ import { navigate, useQueryParams } from "raviger";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
+import { PLUGIN_Component } from "@/PluginEngine";
 
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -82,6 +83,7 @@ export function DeliveryOrderList({
   const { data: response, isLoading } = useQuery({
     queryKey: [
       "deliveryOrders",
+      facilityId,
       locationId,
       internal,
       isRequester,
@@ -134,6 +136,13 @@ export function DeliveryOrderList({
           </div>
           {(!isRequester || !internal) && (
             <div className="flex items-center gap-2">
+              {!internal && (
+                <PLUGIN_Component
+                  __name="DeliveryOrderActions"
+                  facilityId={facilityId}
+                  locationId={locationId}
+                />
+              )}
               <Button
                 variant="primary"
                 onClick={() =>

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -115,6 +115,12 @@ export type DiagnosticReportOverrideComponentType = React.FC<{
   disabled?: boolean;
 }>;
 
+// To Support additional options to create delivery orders
+export type DeliveryOrderActionsComponentType = React.FC<{
+  facilityId: string;
+  locationId: string;
+}>;
+
 // Define supported plugin components
 export type SupportedPluginComponents = {
   DoctorConnectButtons: DoctorConnectButtonComponentType;
@@ -133,6 +139,7 @@ export type SupportedPluginComponents = {
   EncounterOverviewTop: EncounterOverviewTopComponentType;
   DiagnosticReportOverride: DiagnosticReportOverrideComponentType;
   PatientHomeQuickActions: PatientHomeActionsComponentType;
+  DeliveryOrderActions: DeliveryOrderActionsComponentType;
 };
 
 // Create a type for lazy-loaded components


### PR DESCRIPTION
## Proposed Changes
Introduced a new DeliveryOrderActions plugin extension point in the Delivery Order list screen, enabling external integrations to add custom action buttons for importing inward stock and delivery details from third-party systems. 

### Change details
<img width="1503" height="540" alt="Screenshot 2026-06-06 at 2 38 13 PM" src="https://github.com/user-attachments/assets/e07828ea-adb1-4040-bddd-1fb70e414478" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
