### PR TITLE
Fix relative date to be in the future instead of the past

### DIFF
--- a/src/components/ui/relative-date-picker.tsx
+++ b/src/components/ui/relative-date-picker.tsx
@@ -1,15 +1,15 @@
 import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
   differenceInDays,
   differenceInMonths,
   differenceInWeeks,
   differenceInYears,
   format,
-  subDays,
-  subMonths,
-  subWeeks,
-  subYears,
 } from "date-fns";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -35,50 +35,71 @@ interface RelativeDatePickerProps {
   disabled?: (date: Date) => boolean;
 }
 
-const computeDate = (unit: TimeUnit, value: number) => {
-  const now = new Date();
+const getMaxValue = (unit: TimeUnit) => {
   switch (unit) {
     case "days":
-      return subDays(now, value);
+      return 31;
     case "weeks":
-      return subWeeks(now, value);
+      return 12;
     case "months":
-      return subMonths(now, value);
+      return 36;
     case "years":
-      return subYears(now, value);
+      return 60;
+  }
+};
+
+const computeDate = (unit: TimeUnit, value: number) => {
+  const now = new Date();
+
+  switch (unit) {
+    case "days":
+      return addDays(now, value);
+    case "weeks":
+      return addWeeks(now, value);
+    case "months":
+      return addMonths(now, value);
+    case "years":
+      return addYears(now, value);
   }
 };
 
 const computeTimeUnits = (date?: Date): TimeUnitState => {
   const now = new Date();
+
   if (!date) {
     return { unit: "days", value: 1 };
   }
-  const daysDiff = differenceInDays(now, date);
-  const weeksDiff = differenceInWeeks(now, date);
-  const monthsDiff = differenceInMonths(now, date);
-  const yearsDiff = differenceInYears(now, date);
+
+  const yearsDiff = differenceInYears(date, now);
+  const monthsDiff = differenceInMonths(date, now);
+  const weeksDiff = differenceInWeeks(date, now);
+  const daysDiff = differenceInDays(date, now);
+
   if (yearsDiff > 0) {
     return {
       unit: "years",
       value: yearsDiff,
     };
-  } else if (monthsDiff > 0) {
+  }
+
+  if (monthsDiff > 0) {
     return {
       unit: "months",
       value: monthsDiff,
     };
-  } else if (weeksDiff > 0) {
+  }
+
+  if (weeksDiff > 0) {
     return {
       unit: "weeks",
       value: weeksDiff,
     };
-  } else {
-    return {
-      unit: "days",
-      value: daysDiff,
-    };
   }
+
+  return {
+    unit: "days",
+    value: Math.max(daysDiff, 1),
+  };
 };
 
 export function RelativeDatePicker({
@@ -87,25 +108,16 @@ export function RelativeDatePicker({
   disabled,
 }: RelativeDatePickerProps) {
   const { t } = useTranslation();
+
   const [selected, setSelected] = useState(() => computeTimeUnits(value));
-  const [resultDate, setResultDate] = useState<Date>(value || new Date());
+
+  const [resultDate, setResultDate] = useState<Date>(
+    value || computeDate("days", 1),
+  );
 
   const timeUnits: TimeUnit[] = ["days", "weeks", "months", "years"];
 
-  const maxValue = useMemo(() => {
-    switch (selected.unit) {
-      case "days":
-        return 31;
-      case "weeks":
-        return 12;
-      case "months":
-        return 36;
-      case "years":
-        return 60;
-      default:
-        return 31;
-    }
-  }, [selected.unit]);
+  const maxValue = getMaxValue(selected.unit);
 
   const validateDate = (unit: TimeUnit, value: number) => {
     const selectedDate = computeDate(unit, value);
@@ -113,17 +125,29 @@ export function RelativeDatePicker({
     return !isDisabled;
   };
 
-  // Update result date
   useEffect(() => {
-    setResultDate(computeDate(selected.unit, selected.value));
-    onDateChange(computeDate(selected.unit, selected.value));
+    const newDate = computeDate(selected.unit, selected.value);
+
+    setResultDate(newDate);
+    onDateChange(newDate);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
 
   const handleUnitChange = (newUnit: TimeUnit) => {
-    if (validateDate(newUnit, 1)) {
-      setSelected((prev) => ({ ...prev, unit: newUnit, value: 1 }));
-    } else toast.error(t("select_valid_date"));
+    setSelected((prev) => {
+      const newValue = Math.min(prev.value, getMaxValue(newUnit));
+
+      if (!validateDate(newUnit, newValue)) {
+        toast.error(t("select_valid_date"));
+        return prev;
+      }
+
+      return {
+        unit: newUnit,
+        value: newValue,
+      };
+    });
   };
 
   return (
@@ -133,7 +157,8 @@ export function RelativeDatePicker({
           <Select
             value={selected.value.toString()}
             onValueChange={(value) => {
-              const numValue = Number.parseInt(value) || 0;
+              const numValue = Number.parseInt(value, 10) || 1;
+
               if (validateDate(selected.unit, numValue)) {
                 setSelected((prev) => ({
                   ...prev,
@@ -146,10 +171,12 @@ export function RelativeDatePicker({
             <SelectTrigger className="col-span-2">
               <SelectValue placeholder={t("select_a_number")} />
             </SelectTrigger>
+
             <SelectContent>
               {Array.from({ length: maxValue }, (_, i) => i + 1).map((num) => {
                 const isDisabled =
                   disabled?.(computeDate(selected.unit, num)) ?? false;
+
                 return (
                   <SelectItem
                     key={num}
@@ -163,6 +190,7 @@ export function RelativeDatePicker({
               })}
             </SelectContent>
           </Select>
+
           {timeUnits.map((unit) => (
             <Button
               key={unit}
@@ -181,6 +209,7 @@ export function RelativeDatePicker({
         <div className="text-xl font-bold mb-1 truncate">
           {format(resultDate, "MMM d, yyyy")}
         </div>
+
         <div className="text-sm truncate">{format(resultDate, "EEEE")}</div>
       </div>
     </div>


### PR DESCRIPTION
## Proposed Changes

The relative date picker was returning dates in the past instead of the future.


BEFORE : 
<img width="314" height="318" alt="Screenshot 2026-06-06 at 2 25 50 PM" src="https://github.com/user-attachments/assets/56034aa9-58a0-4317-96fd-cec7e6215a22" />

AFTER : 
<img width="314" height="318" alt="Screenshot 2026-06-06 at 2 26 46 PM" src="https://github.com/user-attachments/assets/784495cd-1f11-4289-b41b-59d16238e3bc" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed date calculation logic in the relative date picker for accurate forward offset handling
  * Improved validation and constraint handling for date value and unit selections
  * Enhanced default value parsing to ensure consistent minimum threshold behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->