### PR TITLE
fix brief page not found while accessing plug page

### DIFF
--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,8 +1,4 @@
-import {
-  CareAppsContext,
-  CareAppsLoadingContext,
-  useCareApps,
-} from "@/hooks/useCareApps";
+import { CareAppsContext, useCareApps } from "@/hooks/useCareApps";
 import {
   PluginManifest,
   PluginManifestWithMeta,
@@ -170,10 +166,10 @@ export default function PluginEngine({
           </div>
         }
       >
-        <CareAppsContext.Provider value={pluginsQuery}>
-          <CareAppsLoadingContext.Provider value={arePluginsLoading}>
-            <Suspense fallback={<Loading />}>{children}</Suspense>
-          </CareAppsLoadingContext.Provider>
+        <CareAppsContext.Provider
+          value={{ apps: pluginsQuery, isLoading: arePluginsLoading }}
+        >
+          <Suspense fallback={<Loading />}>{children}</Suspense>
         </CareAppsContext.Provider>
       </ErrorBoundary>
     </Suspense>

--- a/src/PluginEngine.tsx
+++ b/src/PluginEngine.tsx
@@ -1,4 +1,8 @@
-import { CareAppsContext, useCareApps } from "@/hooks/useCareApps";
+import {
+  CareAppsContext,
+  CareAppsLoadingContext,
+  useCareApps,
+} from "@/hooks/useCareApps";
 import {
   PluginManifest,
   PluginManifestWithMeta,
@@ -73,13 +77,16 @@ export default function PluginEngine({
   children: React.ReactNode;
 }) {
   // Fetch enabled plugins from the backend API
-  const { data: enabledPlugins } = useQuery({
-    queryKey: ["enabled-plugins"],
-    queryFn: query(plugConfigApi.list, {
-      silent: (response) => response.status === 401 || response.status === 403,
-    }),
-    retry: false,
-  });
+  const { data: enabledPlugins, isLoading: isEnabledPluginsLoading } = useQuery(
+    {
+      queryKey: ["enabled-plugins"],
+      queryFn: query(plugConfigApi.list, {
+        silent: (response) =>
+          response.status === 401 || response.status === 403,
+      }),
+      retry: false,
+    },
+  );
 
   const resolvedPlugins = useMemo(
     () => mergePlugConfigs(enabledPlugins?.configs ?? []),
@@ -118,6 +125,10 @@ export default function PluginEngine({
   useEffect(() => {
     window.__CARE_PLUGIN_RUNTIME__ = deepFreeze({ meta: pluginMeta });
   }, [pluginMeta]);
+
+  // Expose plugin loading state to show loaders while a plugin page is being accessed
+  const arePluginsLoading =
+    isEnabledPluginsLoading || pluginsQuery.some((plugin) => plugin.isLoading);
 
   // Register plugin overrides
   const overrideCleanupRef = useRef<(() => void)[]>([]);
@@ -160,7 +171,9 @@ export default function PluginEngine({
         }
       >
         <CareAppsContext.Provider value={pluginsQuery}>
-          <Suspense fallback={<Loading />}>{children}</Suspense>
+          <CareAppsLoadingContext.Provider value={arePluginsLoading}>
+            <Suspense fallback={<Loading />}>{children}</Suspense>
+          </CareAppsLoadingContext.Provider>
         </CareAppsContext.Provider>
       </ErrorBoundary>
     </Suspense>

--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -7,12 +7,17 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar, SidebarFor } from "@/components/ui/sidebar/app-sidebar";
 
 import ErrorBoundary from "@/components/Common/ErrorBoundary";
+import Loading from "@/components/Common/Loading";
 import BrowserWarning from "@/components/ErrorPages/BrowserWarning";
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import SessionExpired from "@/components/ErrorPages/SessionExpired";
 
 import useAuthUser from "@/hooks/useAuthUser";
-import { useOrganizationRoutes, usePluginRoutes } from "@/hooks/useCareApps";
+import {
+  useCareAppsLoading,
+  useOrganizationRoutes,
+  usePluginRoutes,
+} from "@/hooks/useCareApps";
 import useSidebarState from "@/hooks/useSidebarState";
 
 import { routes as publicRoutes } from "@/Routers/PublicRouter";
@@ -99,6 +104,7 @@ const publicRedirects = Object.fromEntries(
 export default function AppRouter() {
   const pluginRoutes = usePluginRoutes();
   const organizationRoutes = useOrganizationRoutes();
+  const arePluginsLoading = useCareAppsLoading();
   let routes = Routes;
 
   useRedirect("/user", "/users");
@@ -119,7 +125,11 @@ export default function AppRouter() {
 
   const sidebarFor = isAdminPage ? SidebarFor.ADMIN : SidebarFor.FACILITY;
 
-  const pages = appPages || adminPages || publicRedirectsPages || <ErrorPage />;
+  const pages =
+    appPages ||
+    adminPages ||
+    publicRedirectsPages ||
+    (arePluginsLoading ? <Loading /> : <ErrorPage />);
 
   const user = useAuthUser();
 

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -13,9 +13,12 @@ export type CareAppsContextType = Array<
     (({ isLoading: false } & PluginManifestWithMeta) | { isLoading: true })
 >;
 
-export const CareAppsContext = createContext<CareAppsContextType | null>(null);
+export type CareAppsContextValue = {
+  apps: CareAppsContextType;
+  isLoading: boolean;
+};
 
-export const CareAppsLoadingContext = createContext<boolean>(false);
+export const CareAppsContext = createContext<CareAppsContextValue | null>(null);
 
 export const useCareApps = () => {
   const ctx = useContext(CareAppsContext);
@@ -24,10 +27,11 @@ export const useCareApps = () => {
       "'useCareApps' must be used within 'CareAppsProvider' only",
     );
   }
-  return ctx;
+  return ctx.apps;
 };
 
-export const useCareAppsLoading = () => useContext(CareAppsLoadingContext);
+export const useCareAppsLoading = () =>
+  useContext(CareAppsContext)?.isLoading ?? false;
 
 // export const useCareAppNavItems = () => {
 //   const careApps = useCareApps();

--- a/src/hooks/useCareApps.tsx
+++ b/src/hooks/useCareApps.tsx
@@ -15,6 +15,8 @@ export type CareAppsContextType = Array<
 
 export const CareAppsContext = createContext<CareAppsContextType | null>(null);
 
+export const CareAppsLoadingContext = createContext<boolean>(false);
+
 export const useCareApps = () => {
   const ctx = useContext(CareAppsContext);
   if (!ctx) {
@@ -24,6 +26,8 @@ export const useCareApps = () => {
   }
   return ctx;
 };
+
+export const useCareAppsLoading = () => useContext(CareAppsLoadingContext);
 
 // export const useCareAppNavItems = () => {
 //   const careApps = useCareApps();


### PR DESCRIPTION
## Proposed Changes

Currently when accessing plugin page, there is a brief page not found before the plugin page loads completely. Go to a plugin tab in encounter, do a hard refresh, the error can be noticed.

Fixes #issue_number
- Added plugin loading context which would expose plugin loading state, which can be used by app router to show loading logo when accessing plugin pages instead of page not found

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved application startup experience with proper loading state management
  * Loading screen now displays while plugins are being initialized instead of showing error states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->