### PR TITLE
[ENG-584] feat: keep accounts visible and show print for eligible appointments

### DIFF
--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -460,15 +460,12 @@ export default function AppointmentDetail(props: Props) {
                 </CardContent>
               </Card>
             )}
-            {/* Lets only show encounter details if the appointment is not in a final status or if there is an encounter linked to the appointment */}
             <div>
               <h3 className="text-base font-semibold mt-4">
                 {t("quick_actions")}
               </h3>
               <div className="grid gap-1 grid-cols-1 md:grid-cols-2 mt-1">
-                {![...AppointmentFinalStatuses].includes(
-                  appointment.status,
-                ) && (
+                {!AppointmentFinalStatuses.includes(appointment.status) && (
                   <>
                     {/* Start Consultation - For booked and checked in appointments */}
                     {["booked", "checked_in"].includes(currentStatus) &&
@@ -552,7 +549,7 @@ export default function AppointmentDetail(props: Props) {
                   title={t("accounts")}
                   actionId="goto-account"
                   basePath="/"
-                  href={`/facility/${facilityId}/billing/account?status=active&patient_filter=${appointment.patient.id}&patient_name=${appointment.patient.name}`}
+                  href={`/facility/${facilityId}/billing/account?status=active&patient_filter=${appointment.patient.id}&patient_name=${encodeURIComponent(appointment.patient.name || "")}`}
                 />
               </div>
             </div>

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -43,6 +43,7 @@ import {
   AppointmentRead,
   AppointmentStatus,
   AppointmentUpdateRequest,
+  CancelledAppointmentStatuses,
   SchedulableResourceType,
   formatScheduleResourceName,
 } from "@/types/scheduling/schedule";
@@ -318,7 +319,7 @@ export default function AppointmentDetail(props: Props) {
                 </div>
               </>
             ) : (
-              !["fulfilled"].includes(appointment.status) &&
+              !AppointmentFinalStatuses.includes(appointment.status) &&
               canWriteToken && (
                 <>
                   <h3 className="text-base font-semibold">{t("token")}</h3>
@@ -536,14 +537,15 @@ export default function AppointmentDetail(props: Props) {
                     )}
                   </>
                 )}
-                {/* Print Appointment */}
-                <QuickAction
-                  icon={<PrinterIcon className="size-4" />}
-                  title={t("print_appointment")}
-                  actionId="print-appointment"
-                  basePath="/"
-                  href={`/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}/print`}
-                />
+                {!CancelledAppointmentStatuses.includes(appointment.status) && (
+                  <QuickAction
+                    icon={<PrinterIcon className="size-4" />}
+                    title={t("print_appointment")}
+                    actionId="print-appointment"
+                    basePath="/"
+                    href={`/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}/print`}
+                  />
+                )}
                 <QuickAction
                   icon={<Wallet className="size-4" />}
                   title={t("accounts")}

--- a/src/pages/Appointments/AppointmentDetail.tsx
+++ b/src/pages/Appointments/AppointmentDetail.tsx
@@ -306,9 +306,9 @@ export default function AppointmentDetail(props: Props) {
             facility={facility}
           />
           <div className="mt-6 pl-0 md:pl-4 flex-1">
-            <h3 className="text-base font-semibold">{t("token")}</h3>
             {appointment.token?.number ? (
               <>
+                <h3 className="text-base font-semibold">{t("token")}</h3>
                 <div id="single-print">
                   <TokenCard
                     appointment={appointment}
@@ -320,42 +320,45 @@ export default function AppointmentDetail(props: Props) {
             ) : (
               !["fulfilled"].includes(appointment.status) &&
               canWriteToken && (
-                <div className="bg-gray-100 border border-gray-200 rounded flex flex-col items-center justify-center text-center">
-                  <ReceiptText className="size-8 text-gray-500 mt-4" />
-                  <div className="mt-2">
-                    <h6 className="text-gray-900 text-sm font-semibold">
-                      {t("token_not_generated")}
-                    </h6>
-                    <p className="text-gray-900 text-sm">
-                      {t("token_not_generated_description")}
-                    </p>
+                <>
+                  <h3 className="text-base font-semibold">{t("token")}</h3>
+                  <div className="bg-gray-100 border border-gray-200 rounded flex flex-col items-center justify-center text-center">
+                    <ReceiptText className="size-8 text-gray-500 mt-4" />
+                    <div className="mt-2">
+                      <h6 className="text-gray-900 text-sm font-semibold">
+                        {t("token_not_generated")}
+                      </h6>
+                      <p className="text-gray-900 text-sm">
+                        {t("token_not_generated_description")}
+                      </p>
+                    </div>
+                    <div className="mt-2 mb-4">
+                      <TokenGenerationSheet
+                        facilityId={facility.id}
+                        resourceType={appointment.resource_type}
+                        appointmentId={appointment.id}
+                        trigger={
+                          <Button
+                            variant="outline"
+                            className="px-6"
+                            disabled={AppointmentFinalStatuses.includes(
+                              appointment.status,
+                            )}
+                          >
+                            <PlusCircledIcon className="size-4 mr-2" />
+                            {t("generate_token")}
+                            <ShortcutBadge actionId="generate-token" />
+                          </Button>
+                        }
+                        onSuccess={() => {
+                          queryClient.invalidateQueries({
+                            queryKey: ["appointment", appointment.id],
+                          });
+                        }}
+                      />
+                    </div>
                   </div>
-                  <div className="mt-2 mb-4">
-                    <TokenGenerationSheet
-                      facilityId={facility.id}
-                      resourceType={appointment.resource_type}
-                      appointmentId={appointment.id}
-                      trigger={
-                        <Button
-                          variant="outline"
-                          className="px-6"
-                          disabled={AppointmentFinalStatuses.includes(
-                            appointment.status,
-                          )}
-                        >
-                          <PlusCircledIcon className="size-4 mr-2" />
-                          {t("generate_token")}
-                          <ShortcutBadge actionId="generate-token" />
-                        </Button>
-                      }
-                      onSuccess={() => {
-                        queryClient.invalidateQueries({
-                          queryKey: ["appointment", appointment.id],
-                        });
-                      }}
-                    />
-                  </div>
-                </div>
+                </>
               )
             )}
             {appointment.associated_encounter?.id && (
@@ -458,96 +461,101 @@ export default function AppointmentDetail(props: Props) {
               </Card>
             )}
             {/* Lets only show encounter details if the appointment is not in a final status or if there is an encounter linked to the appointment */}
-            {![...AppointmentFinalStatuses].includes(appointment.status) && (
-              <div>
-                <h3 className="text-base font-semibold mt-4">
-                  {t("quick_actions")}
-                </h3>
-                <div className="grid gap-1 grid-cols-1 md:grid-cols-2 mt-1">
-                  {/* Start Consultation - For booked and checked in appointments */}
-                  {["booked", "checked_in"].includes(currentStatus) &&
-                    canCheckIn &&
-                    (appointment.associated_encounter?.id ? (
-                      // When encounter exists: set status to in_consultation and redirect
-                      <QuickAction
-                        icon={<PlusSquare className="text-primary-500" />}
-                        title={t("start_consultation")}
-                        actionId="start-consultation"
-                        onClick={() => {
-                          updateAppointment({
-                            status: AppointmentStatus.IN_CONSULTATION,
-                            note: appointment.note,
-                          });
-                          navigate(
-                            `/facility/${facilityId}/patient/${appointment.patient.id}/encounter/${appointment.associated_encounter!.id}/updates`,
-                          );
-                        }}
-                      />
-                    ) : (
-                      // When no encounter exists: create encounter and set status to in_consultation
+            <div>
+              <h3 className="text-base font-semibold mt-4">
+                {t("quick_actions")}
+              </h3>
+              <div className="grid gap-1 grid-cols-1 md:grid-cols-2 mt-1">
+                {![...AppointmentFinalStatuses].includes(
+                  appointment.status,
+                ) && (
+                  <>
+                    {/* Start Consultation - For booked and checked in appointments */}
+                    {["booked", "checked_in"].includes(currentStatus) &&
+                      canCheckIn &&
+                      (appointment.associated_encounter?.id ? (
+                        // When encounter exists: set status to in_consultation and redirect
+                        <QuickAction
+                          icon={<PlusSquare className="text-primary-500" />}
+                          title={t("start_consultation")}
+                          actionId="start-consultation"
+                          onClick={() => {
+                            updateAppointment({
+                              status: AppointmentStatus.IN_CONSULTATION,
+                              note: appointment.note,
+                            });
+                            navigate(
+                              `/facility/${facilityId}/patient/${appointment.patient.id}/encounter/${appointment.associated_encounter!.id}/updates`,
+                            );
+                          }}
+                        />
+                      ) : (
+                        // When no encounter exists: create encounter and set status to in_consultation
+                        <CreateEncounterForm
+                          patientId={appointment.patient.id}
+                          facilityId={facilityId}
+                          patientName={appointment.patient.name}
+                          appointment={appointment.id}
+                          defaultOpen={from_queue === "true"}
+                          defaultStatus={EncounterStatus.IN_PROGRESS}
+                          trigger={
+                            <QuickAction
+                              icon={<PlusSquare className="text-primary-500" />}
+                              title={t("start_consultation")}
+                              actionId="start-consultation"
+                            />
+                          }
+                          onSuccess={() => {
+                            updateAppointment({
+                              status: AppointmentStatus.IN_CONSULTATION,
+                              note: appointment.note,
+                            });
+                          }}
+                        />
+                      ))}
+
+                    {!appointment.associated_encounter?.id && (
                       <CreateEncounterForm
                         patientId={appointment.patient.id}
                         facilityId={facilityId}
                         patientName={appointment.patient.name}
                         appointment={appointment.id}
-                        defaultOpen={from_queue === "true"}
-                        defaultStatus={EncounterStatus.IN_PROGRESS}
+                        disableRedirectOnSuccess={true}
                         trigger={
                           <QuickAction
-                            icon={<PlusSquare className="text-primary-500" />}
-                            title={t("start_consultation")}
-                            actionId="start-consultation"
+                            icon={
+                              <SquareActivity className="text-orange-500" />
+                            }
+                            title={t("create_planned_encounter")}
+                            actionId="create-encounter"
                           />
                         }
                         onSuccess={() => {
-                          updateAppointment({
-                            status: AppointmentStatus.IN_CONSULTATION,
-                            note: appointment.note,
+                          queryClient.invalidateQueries({
+                            queryKey: ["appointment", appointment.id],
                           });
                         }}
                       />
-                    ))}
-
-                  {!appointment.associated_encounter?.id && (
-                    <CreateEncounterForm
-                      patientId={appointment.patient.id}
-                      facilityId={facilityId}
-                      patientName={appointment.patient.name}
-                      appointment={appointment.id}
-                      disableRedirectOnSuccess={true}
-                      trigger={
-                        <QuickAction
-                          icon={<SquareActivity className="text-orange-500" />}
-                          title={t("create_planned_encounter")}
-                          actionId="create-encounter"
-                        />
-                      }
-                      onSuccess={() => {
-                        queryClient.invalidateQueries({
-                          queryKey: ["appointment", appointment.id],
-                        });
-                      }}
-                    />
-                  )}
-                  {/* Print Appointment */}
-                  <QuickAction
-                    icon={<PrinterIcon className="size-4" />}
-                    title={t("print_appointment")}
-                    actionId="print-appointment"
-                    basePath="/"
-                    href={`/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}/print`}
-                  />
-
-                  <QuickAction
-                    icon={<Wallet className="size-4" />}
-                    title={t("accounts")}
-                    actionId="goto-account"
-                    basePath="/"
-                    href={`/facility/${facilityId}/billing/account?status=active&patient_filter=${appointment.patient.id}&patient_name=${appointment.patient.name}`}
-                  />
-                </div>
+                    )}
+                  </>
+                )}
+                {/* Print Appointment */}
+                <QuickAction
+                  icon={<PrinterIcon className="size-4" />}
+                  title={t("print_appointment")}
+                  actionId="print-appointment"
+                  basePath="/"
+                  href={`/facility/${facilityId}/patient/${appointment.patient.id}/appointments/${appointment.id}/print`}
+                />
+                <QuickAction
+                  icon={<Wallet className="size-4" />}
+                  title={t("accounts")}
+                  actionId="goto-account"
+                  basePath="/"
+                  href={`/facility/${facilityId}/billing/account?status=active&patient_filter=${appointment.patient.id}&patient_name=${appointment.patient.name}`}
+                />
               </div>
-            )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Proposed Changes

- [ENG-584]
- Show quick actions (print appointment and accounts) all the time
- Move token heading inside so it only shows up if token is generated/able to be generated.

<img width="714" height="307" alt="image" src="https://github.com/user-attachments/assets/7abe14d9-d0e8-4577-b1cc-5430bd03a6a4" />

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-584]: https://openhealthcarenetwork.atlassian.net/browse/ENG-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved conditional rendering for token details, including when to show the token header and the “token not generated” prompt.
  * Updated the “token not generated” logic to rely on final status groups for more consistent visibility.
  * Reworked the quick actions section so start-consultation and planned-encounter actions appear only in the appropriate appointment states.
  * Adjusted visibility of print and accounts quick actions based on cancelled vs all other statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->