### PR TITLE
[ENG-580] feat: allow orgs to be cleared in Role org selector

### DIFF
--- a/src/components/Common/RoleOrgSelector.tsx
+++ b/src/components/Common/RoleOrgSelector.tsx
@@ -44,7 +44,7 @@ export default function RoleOrgSelector(props: RoleOrgSelectorProps) {
 
   const [selectedOrganizations, setSelectedOrganizations] = useState<
     Organization[]
-  >([]);
+  >(currentOrganizations || []);
   const [currentSelection, setCurrentSelection] = useState<Organization | null>(
     null,
   );

--- a/src/pages/Admin/TagConfig/TagConfigForm.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigForm.tsx
@@ -74,8 +74,8 @@ export default function TagConfigForm({
     resource: z.nativeEnum(TagResource, {
       required_error: t("field_required"),
     }),
-    facility_organization: z.string().optional(),
-    organization: z.string().optional(),
+    facility_organization: z.string().nullable(),
+    organization: z.string().nullable(),
   });
 
   type TagConfigFormValues = z.infer<typeof tagConfigSchema>;
@@ -99,8 +99,8 @@ export default function TagConfigForm({
       priority: parentTag?.priority || 100,
       status: TagStatus.ACTIVE,
       resource: parentTag?.resource || TagResource.PATIENT,
-      facility_organization: undefined,
-      organization: undefined,
+      facility_organization: null,
+      organization: null,
     },
   });
 
@@ -124,8 +124,8 @@ export default function TagConfigForm({
         priority: existingConfig.priority,
         status: existingConfig.status,
         resource: existingConfig.resource,
-        facility_organization: existingConfig.facility_organization?.id,
-        organization: existingConfig.organization?.id,
+        facility_organization: existingConfig.facility_organization?.id ?? null,
+        organization: existingConfig.organization?.id ?? null,
       });
     }
   }, [existingConfig, isEditing, form]);
@@ -140,8 +140,8 @@ export default function TagConfigForm({
         priority: parentTag.priority,
         status: TagStatus.ACTIVE,
         resource: parentTag.resource,
-        facility_organization: undefined,
-        organization: undefined,
+        facility_organization: null,
+        organization: null,
       });
     }
   }, [parentTag, isCreatingChild, form]);
@@ -184,12 +184,8 @@ export default function TagConfigForm({
       resource: data.resource,
       ...(parentId && { parent: parentId }),
       ...(facilityId && { facility: facilityId }),
-      ...(data.facility_organization && {
-        facility_organization: data.facility_organization,
-      }),
-      ...(data.organization && {
-        organization: data.organization,
-      }),
+      facility_organization: data.facility_organization,
+      organization: data.organization,
     };
 
     if (isEditing) {

--- a/src/pages/Admin/TagConfig/TagConfigView.tsx
+++ b/src/pages/Admin/TagConfig/TagConfigView.tsx
@@ -81,6 +81,8 @@ export default function TagConfigView({
         priority: childData.priority,
         status: TagStatus.ARCHIVED,
         resource: childData.resource,
+        facility_organization: childData.facility_organization?.id ?? null,
+        organization: childData.organization?.id ?? null,
         parent:
           childData.parent &&
           typeof childData.parent === "object" &&

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -187,7 +187,7 @@ export default function FacilityOrganizationSelector(
 
   const handleConfirmSelection = useCallback(
     (org: FacilityOrganizationRead) => {
-      if (!selectedOrganizations.includes(org)) {
+      if (!selectedOrganizations.find((o) => o.id === org.id)) {
         const newSelection = singleSelection
           ? [org]
           : [...selectedOrganizations, org];
@@ -302,7 +302,7 @@ export default function FacilityOrganizationSelector(
       // Reset the auto-select flag when value is cleared (e.g., form reset)
       // setHasAutoSelectedPreferred(false);
     }
-  }, [value, currentOrganizations, showAllOrgs]);
+  }, [value, currentOrganizations]);
 
   // Auto-select preferred departments
   useEffect(() => {

--- a/src/types/emr/tagConfig/tagConfig.ts
+++ b/src/types/emr/tagConfig/tagConfig.ts
@@ -75,9 +75,9 @@ export interface TagConfigRequest {
   status: TagStatus;
   parent?: string | null;
   resource: TagResource;
-  organization?: string;
+  organization: string | null;
   facility?: string;
-  facility_organization?: string;
+  facility_organization: string | null;
 }
 
 export function getTagHierarchyDisplay(


### PR DESCRIPTION
## Proposed Changes

- [ENG-580]
- Required [BE](https://github.com/ohcnetwork/care/pull/3690)
- Allow clearing orgs in role org selector for tag management

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-580]: https://openhealthcarenetwork.atlassian.net/browse/ENG-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state initialization in role/organization selection to use proper defaults
  * Corrected duplicate detection logic to prevent selecting the same organization multiple times
  * Fixed organization field handling in tag configuration to ensure proper null defaults and data consistency
  * Improved performance by reducing unnecessary UI updates when toggling organization visibility options
  * Updated archive functionality to preserve organization relationship data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->