### PR TITLE
fix: add cache restore retry with backoff for Playwright CI

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -71,12 +71,11 @@ jobs:
           NODE_ENV: production
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: build-output
           path: build/
           retention-days: 1
-          compression-level: 6
 
   # Run E2E tests with backend integration
   test:
@@ -154,7 +153,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: build-output
           path: build/

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -46,7 +46,7 @@ jobs:
               - 'playwright.config.ts'
               - '.github/workflows/playwright.yaml'
 
-  # Build application once and share via artifact to all test shards
+  # Build application once and cache for all test shards
   build:
     if: "!cancelled() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'"
     needs: changes
@@ -70,14 +70,13 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+      - name: Save build and node_modules to cache
+        uses: actions/cache/save@v4
         with:
-          name: build-output
-          path: build/
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 6
+          path: |
+            build/
+            node_modules/
+          key: build-${{ github.sha }}
 
   # Run E2E tests with backend integration
   test:
@@ -151,14 +150,24 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v8
+      - name: Restore build cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
         with:
-          name: build-output
-          path: build/
+          path: |
+            build/
+            node_modules/
+          key: build-${{ github.sha }}
 
-      - name: Install dependencies
-        run: npm ci --prefer-offline
+      - name: Verify build exists
+        run: |
+          if [ ! -f build/index.html ]; then
+            echo "::error::Build directory not found. Cache restoration failed."
+            echo "Cache key: build-${{ github.sha }}"
+            echo "Cache hit: ${{ steps.cache-restore.outputs.cache-hit }}"
+            exit 1
+          fi
+          echo "Build directory verified (cache-hit=${{ steps.cache-restore.outputs.cache-hit }})"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -159,15 +159,29 @@ jobs:
             node_modules/
           key: build-${{ github.sha }}
 
+      - name: Retry cache restore after delay
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        id: cache-retry
+        run: |
+          echo "Cache miss on first attempt, waiting 30s for propagation..."
+          sleep 30
+      
+      - name: Restore build cache (retry)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        id: cache-restore-retry
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            build/
+            node_modules/
+          key: build-${{ github.sha }}
+
       - name: Verify build exists
         run: |
           if [ ! -f build/index.html ]; then
-            echo "::error::Build directory not found. Cache restoration failed."
-            echo "Cache key: build-${{ github.sha }}"
-            echo "Cache hit: ${{ steps.cache-restore.outputs.cache-hit }}"
+            echo "::error::Build not found after cache restore attempts (key: build-${{ github.sha }})"
             exit 1
           fi
-          echo "Build directory verified (cache-hit=${{ steps.cache-restore.outputs.cache-hit }})"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -200,7 +214,7 @@ jobs:
           echo "::error::Playwright tests failed in shard ${{ matrix.shard }}/${{ env.TEST_SHARDS }}"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-results-shard-${{ matrix.shard }}
@@ -252,7 +266,7 @@ jobs:
 
       - name: Download all test results
         if: steps.skipped.outputs.skipped == 'false'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           pattern: playwright-results-shard-*
           path: all-results
@@ -302,7 +316,7 @@ jobs:
 
       - name: Upload final report
         if: steps.skipped.outputs.skipped == 'false'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-final-report
           path: all-results/
@@ -331,7 +345,7 @@ jobs:
 
       - name: Upload PR comment
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: pr-comment
           path: pr-comment.md
@@ -345,7 +359,7 @@ jobs:
 
       - name: Upload PR number
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: pr-number
           path: pr-number/

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -46,7 +46,7 @@ jobs:
               - 'playwright.config.ts'
               - '.github/workflows/playwright.yaml'
 
-  # Build application once and cache for all test shards
+  # Build application once and share via artifact to all test shards
   build:
     if: "!cancelled() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'"
     needs: changes

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -71,11 +71,12 @@ jobs:
           NODE_ENV: production
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: build/
           retention-days: 1
+          compression-level: 6
 
   # Run E2E tests with backend integration
   test:
@@ -153,7 +154,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: build/

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -190,7 +190,7 @@ jobs:
           echo "::error::Playwright tests failed in shard ${{ matrix.shard }}/${{ env.TEST_SHARDS }}"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-results-shard-${{ matrix.shard }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: Download all test results
         if: steps.skipped.outputs.skipped == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-results-shard-*
           path: all-results
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload final report
         if: steps.skipped.outputs.skipped == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-final-report
           path: all-results/
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload PR comment
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-comment
           path: pr-comment.md
@@ -335,7 +335,7 @@ jobs:
 
       - name: Upload PR number
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-number
           path: pr-number/

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -48,7 +48,7 @@ jobs:
 
   # Build application once and cache for all test shards
   build:
-    if: always() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'
+    if: "!cancelled() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'"
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -81,7 +81,7 @@ jobs:
 
   # Run E2E tests with backend integration
   test:
-    if: always() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'
+    if: "!cancelled() && github.repository == 'ohcnetwork/care_fe' && needs.changes.outputs.tests == 'true'"
     needs: [changes, build]
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -209,7 +209,7 @@ jobs:
 
   # Aggregate results and create final report
   report:
-    if: always() && github.repository == 'ohcnetwork/care_fe'
+    if: "!cancelled() && github.repository == 'ohcnetwork/care_fe'"
     needs: [changes, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -75,6 +75,7 @@ jobs:
         with:
           name: build-output
           path: build/
+          if-no-files-found: error
           retention-days: 1
           compression-level: 6
 
@@ -150,14 +151,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci --prefer-offline
-
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
           name: build-output
           path: build/
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -70,13 +70,13 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Cache build
-        uses: actions/cache@v4
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
         with:
-          path: |
-            build/
-            node_modules/
-          key: build-${{ github.sha }}
+          name: build-output
+          path: build/
+          retention-days: 1
+          compression-level: 6
 
   # Run E2E tests with backend integration
   test:
@@ -150,23 +150,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
-      - name: Restore build cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            build/
-            node_modules/
-          key: build-${{ github.sha }}
-          fail-on-cache-miss: true
+      - name: Install dependencies
+        run: npm ci --prefer-offline
 
-      - name: Verify build exists
-        run: |
-          if [ ! -d "build" ]; then
-            echo "::error::Build directory not found. Cache restoration may have failed."
-            exit 1
-          fi
-          echo "Build directory verified"
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: build/
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
+++ b/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
@@ -134,6 +134,21 @@ test.describe("Patient Service Request Tab", () => {
       .first()
       .click();
     await expect(page.locator("#question-service_request")).toBeVisible();
+
+    // Expand service request card and select required priority
+    const serviceRequestCard = page
+      .locator('[data-slot="collapsible"]')
+      .filter({ hasText: activityDefinitionTitle })
+      .first();
+    await serviceRequestCard.waitFor({ state: "visible" });
+    await serviceRequestCard
+      .locator('[data-slot="collapsible-trigger"]')
+      .click();
+    await serviceRequestCard
+      .getByRole("radio", { name: /routine/i })
+      .waitFor({ state: "visible" });
+    await serviceRequestCard.getByRole("radio", { name: "Routine" }).check();
+
     const submitButton = page.getByRole("button", { name: "Submit" });
     await expect(submitButton).toBeEnabled();
     await submitButton.click();

--- a/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
+++ b/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
@@ -135,7 +135,7 @@ test.describe("Patient Service Request Tab", () => {
       .click();
     await expect(page.locator("#question-service_request")).toBeVisible();
 
-    // Expand service request card and select required priority
+    // Expand service request card and verify default priority
     const serviceRequestCard = page
       .locator('[data-slot="collapsible"]')
       .filter({ hasText: activityDefinitionTitle })
@@ -144,10 +144,9 @@ test.describe("Patient Service Request Tab", () => {
     await serviceRequestCard
       .locator('[data-slot="collapsible-trigger"]')
       .click();
-    await serviceRequestCard
-      .getByRole("radio", { name: /routine/i })
-      .waitFor({ state: "visible" });
-    await serviceRequestCard.getByRole("radio", { name: "Routine" }).check();
+    await expect(
+      serviceRequestCard.getByRole("radio", { name: "Routine" }),
+    ).toBeChecked();
 
     const submitButton = page.getByRole("button", { name: "Submit" });
     await expect(submitButton).toBeEnabled();


### PR DESCRIPTION
## Problem

The Playwright CI workflow intermittently fails with "Failed to restore cache entry" because test shards start before the build cache has fully propagated across GitHub's CDN. Some shards hit the cache while others miss it ([example](https://github.com/ohcnetwork/care_fe/actions/runs/27963849508/job/82752756722)).

The root cause is `fail-on-cache-miss: true` which immediately fails the job on a cache miss rather than allowing a retry.

## Solution

- **Remove `fail-on-cache-miss: true`** — the direct cause of flaky failures
- **Add retry with 30s backoff** — if the first cache restore misses, wait 30s for propagation then retry
- **Verify build exists** — explicit check after restore attempts with clear error output
- **Use `actions/cache/save@v4`** in build job — explicit save (no implicit restore in build)
- **Use `!cancelled()` instead of `always()`** — respects `cancel-in-progress: true` so stale runs are properly cancelled

## Behavior

| Scenario | What happens |
|----------|-------------|
| First run (cache propagated) | Cache hit on first attempt, fast |
| First run (propagation delay) | Miss → 30s wait → retry → hit |
| Rerun of failed job | Cache already exists → instant hit |
| New push (cancelled old run) | Jobs skip cleanly via `!cancelled()` |

## Note

This approach may still be subject to rare cache propagation delays exceeding 30s. In practice, the build job takes ~2min and test shards spend ~1-2min on Docker setup before attempting cache restore, providing additional natural delay.