### PR TITLE
[ENG-660] feat: enable questionnaire draft-saving functionality in environment configuration

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -88,6 +88,11 @@ REACT_APP_MAX_IMAGE_UPLOAD_SIZE_MB=
 # Disables public patient login in Care, (default: false)
 REACT_DISABLE_PATIENT_LOGIN=false
 
+# Enable questionnaire draft-saving. Set to "true" to allow users to save
+# questionnaire responses as drafts. When disabled, draft-saving is blocked.
+# (default: false)
+REACT_ENABLE_QUESTIONNAIRE_DRAFT=false
+
 # Default payment terms for invoices
 REACT_DEFAULT_PAYMENT_TERMS=
 

--- a/care.config.ts
+++ b/care.config.ts
@@ -327,6 +327,15 @@ const careConfig = {
   ),
 
   /**
+   * Enable questionnaire draft-saving if set to "true".
+   * When disabled, users cannot save questionnaire responses as drafts.
+   */
+  enableQuestionnaireDraft: booleanFromString(
+    env.REACT_ENABLE_QUESTIONNAIRE_DRAFT,
+    false,
+  ),
+
+  /**
    * Default state for tax inclusive pricing in inventory
    * When true, base price is calculated from MRP by removing tax
    */

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -124,6 +124,7 @@ const envSchema = z
     REACT_ENABLE_AUTO_INVOICE_AFTER_DISPENSE: booleanAsStringSchema.optional(),
     REACT_ENABLE_TOKEN_GENERATION_IN_PATIENT_HOME:
       booleanAsStringSchema.optional(),
+    REACT_ENABLE_QUESTIONNAIRE_DRAFT: booleanAsStringSchema.optional(),
     REACT_INVENTORY_DEFAULT_TAX_INCLUSIVE: booleanAsStringSchema.optional(),
     REACT_INVENTORY_EXPIRY_MONTH_OFFSET: numberAsString.optional(),
     REACT_OPEN_SCHEDULE_AFTER_PATIENT_REGISTRATION:

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -5,6 +5,8 @@ import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
+import careConfig from "@careConfig";
+
 import { cn } from "@/lib/utils";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -549,7 +551,7 @@ export function QuestionnaireForm({
 
   // Check if questionnaire is saveable as draft (no structured questions)
   const isDraftSaveable = useMemo(() => {
-    if (import.meta.env.REACT_ENABLE_QUESTIONNAIRE_DRAFT !== "true") {
+    if (!careConfig.enableQuestionnaireDraft) {
       return false;
     }
 


### PR DESCRIPTION
## Proposed Changes

Fixes ENG-660

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable saving questionnaire responses as drafts.
* **Configuration**
  * Introduced a new environment setting (`REACT_ENABLE_QUESTIONNAIRE_DRAFT`) to control draft-saving behavior, defaulting to `false`.
  * Updated environment validation to recognize the new setting.
* **Documentation**
  * Updated the environment template with the new setting and an inline description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->