### PR TITLE
Revert "ci(playwright): test SNOWSTORM_DEPLOYMENT_URL with NRCES terminology server"

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -127,7 +127,6 @@ jobs:
           echo DISABLE_RATELIMIT=True >> docker/.local.env
           echo JWKS_BASE64=\"$(cat ../.github/runner-files/jwks.b64.txt)\" >> docker/.local.env
           echo MAX_QUESTIONNAIRE_TEXT_RESPONSE_SIZE=500 >> docker/.local.env
-          echo SNOWSTORM_DEPLOYMENT_URL=https://terminology.10bedicu.org/fhir >> docker/.local.env
           make docker_config_file=docker-compose.local.yaml up load-fixtures
           cd ..
         env:


### PR DESCRIPTION
Reverts ohcnetwork/care_fe#16482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Playwright workflow startup settings to use revised backend environment values for test runs.
  * Added configuration for rate limiting, authentication key loading, and questionnaire response limits.
  * Removed an old service URL setting from the workflow setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->