### PR TITLE
[ENG-706] feat: enhance AppRouter to show loading state for resolving plugins

### DIFF
--- a/src/Routers/AppRouter.tsx
+++ b/src/Routers/AppRouter.tsx
@@ -1,4 +1,5 @@
 import careConfig from "@careConfig";
+import { useIsFetching } from "@tanstack/react-query";
 import { Redirect, usePath, useRedirect, useRoutes } from "raviger";
 
 import IconIndex from "@/CAREUI/icons/Index";
@@ -7,12 +8,17 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar, SidebarFor } from "@/components/ui/sidebar/app-sidebar";
 
 import ErrorBoundary from "@/components/Common/ErrorBoundary";
+import Loading from "@/components/Common/Loading";
 import BrowserWarning from "@/components/ErrorPages/BrowserWarning";
 import ErrorPage from "@/components/ErrorPages/DefaultErrorPage";
 import SessionExpired from "@/components/ErrorPages/SessionExpired";
 
 import useAuthUser from "@/hooks/useAuthUser";
-import { useOrganizationRoutes, usePluginRoutes } from "@/hooks/useCareApps";
+import {
+  useCareApps,
+  useOrganizationRoutes,
+  usePluginRoutes,
+} from "@/hooks/useCareApps";
 import useSidebarState from "@/hooks/useSidebarState";
 
 import { routes as publicRoutes } from "@/Routers/PublicRouter";
@@ -119,7 +125,18 @@ export default function AppRouter() {
 
   const sidebarFor = isAdminPage ? SidebarFor.ADMIN : SidebarFor.FACILITY;
 
-  const pages = appPages || adminPages || publicRedirectsPages || <ErrorPage />;
+  const careApps = useCareApps();
+  const arePluginsResolving =
+    useIsFetching({
+      queryKey: ["enabled-plugins"],
+      predicate: (query) => query.state.status === "pending",
+    }) > 0 || careApps.some((plugin) => plugin.isLoading);
+
+  const pages =
+    appPages ||
+    adminPages ||
+    publicRedirectsPages ||
+    (arePluginsResolving ? <Loading /> : <ErrorPage />);
 
   const user = useAuthUser();
 


### PR DESCRIPTION
## Proposed Changes

Fixes ENG-706

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state while plugins are being resolved, so users now see a loading screen instead of an immediate error during plugin startup.
* **Bug Fixes**
  * Improved route handling to better distinguish between “still loading” and “no matching page found,” reducing confusing error screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->