### PR TITLE
Clear persisted query cache on logout

### DIFF
--- a/src/Providers/AuthUserProvider.tsx
+++ b/src/Providers/AuthUserProvider.tsx
@@ -12,6 +12,7 @@ import { LocalStorageKeys } from "@/common/constants";
 
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { clearQueryPersistenceCache } from "@/Utils/request/queryClient";
 import { userAtom } from "@/atoms/user-atom";
 import {
   JwtTokenObtainPair,
@@ -163,6 +164,7 @@ export default function AuthUserProvider({
     localStorage.removeItem(LocalStorageKeys.accessToken);
     localStorage.removeItem(LocalStorageKeys.refreshToken);
     localStorage.removeItem(LocalStorageKeys.patientTokenKey);
+    await clearQueryPersistenceCache();
     setAccessToken(null);
     setPatientToken(null);
 

--- a/src/Utils/request/queryClient.test.ts
+++ b/src/Utils/request/queryClient.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { clearQueryPersistenceCache } from "@/Utils/request/queryClient";
+
+describe("clearQueryPersistenceCache", () => {
+  beforeEach(() => {
+    localStorage.setItem(
+      "REACT_QUERY_OFFLINE_CACHE",
+      JSON.stringify({ clientState: {}, timestamp: 0 }),
+    );
+  });
+
+  it("removes the persisted cache blob from localStorage", async () => {
+    expect(localStorage.getItem("REACT_QUERY_OFFLINE_CACHE")).not.toBeNull();
+    await clearQueryPersistenceCache();
+    expect(localStorage.getItem("REACT_QUERY_OFFLINE_CACHE")).toBeNull();
+  });
+});

--- a/src/Utils/request/queryClient.ts
+++ b/src/Utils/request/queryClient.ts
@@ -33,6 +33,7 @@ const queryClient = new QueryClient({
 
 const localStoragePersister = createAsyncStoragePersister({
   storage: window.localStorage,
+  key: "REACT_QUERY_OFFLINE_CACHE",
 });
 
 persistQueryClient({
@@ -44,12 +45,11 @@ persistQueryClient({
   buster: localStorage.getItem("app-version") ?? "0.0.0",
 });
 
-export function clearQueryPersistenceCache() {
-  queryClient.invalidateQueries({
-    predicate: (query) => {
-      return query.meta?.persist === true;
-    },
+export function clearQueryPersistenceCache(): Promise<void> {
+  queryClient.removeQueries({
+    predicate: (query) => query.meta?.persist === true,
   });
+  return Promise.resolve(localStoragePersister.removeClient());
 }
 
 export default queryClient;


### PR DESCRIPTION
Closes #16509

Stacked on #16514 (uses the Vitest harness for the new test). GitHub will retarget this to `develop` when that merges.

## What

Cached application state must not survive sign-out on shared devices — but the persisted TanStack Query blob (`REACT_QUERY_OFFLINE_CACHE` in localStorage) previously outlived logout:

- `clearQueryPersistenceCache()` only called `invalidateQueries` (marks stale; removes nothing) and had zero callers.
- `signOut` removed the auth-token keys but never touched the persisted cache.

Changes:

- `src/Utils/request/queryClient.ts`: persister key is now explicit; `clearQueryPersistenceCache()` does `removeQueries` on `meta.persist === true` entries **and** `persister.removeClient()` (actually deletes the localStorage entry), returning the promise so callers can await.
- `src/Providers/AuthUserProvider.tsx`: `signOut` awaits the purge right after the token removals. The cross-tab storage listener funnels through the same `signOut`, so other tabs are covered.

## Verification

- `npm run typecheck` → exit 0
- `npm run test:unit` → 6/6, including a new jsdom test proving the localStorage entry is gone after the purge
- `grep invalidateQueries src/Utils/request/queryClient.ts` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
