### PR TITLE
Request layer: bound the paginated fetch loop and fix double body consumption

### DIFF
--- a/src/Utils/request/query.test.ts
+++ b/src/Utils/request/query.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import query from "@/Utils/request/query";
+import { PaginatedResponse } from "@/Utils/request/types";
+import { API } from "@/Utils/request/utils";
+
+const testRoute = API<PaginatedResponse<number>>("GET /api/test/");
+
+const page = (count: number, results: number[]) =>
+  new Response(JSON.stringify({ count, results }), {
+    headers: { "content-type": "application/json" },
+  });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("query.paginated", () => {
+  it("stops when the server returns an empty page despite a larger count", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(page(5, [1, 2]))
+      .mockResolvedValueOnce(page(5, []));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await query.paginated(testRoute, { pageSize: 2 })({
+      signal: new AbortController().signal,
+    });
+
+    expect(result.results).toEqual([1, 2]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  }, 2000);
+
+  it("accumulates pages until count is reached", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(page(4, [1, 2]))
+      .mockResolvedValueOnce(page(4, [3, 4]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await query.paginated(testRoute, { pageSize: 2 })({
+      signal: new AbortController().signal,
+    });
+
+    expect(result.results).toEqual([1, 2, 3, 4]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  }, 2000);
+});

--- a/src/Utils/request/query.ts
+++ b/src/Utils/request/query.ts
@@ -180,6 +180,12 @@ const paginatedQuery = <
       count = res.count;
       items.push(...res.results);
 
+      // Defensive: if the server reports more rows (count > items.length) but
+      // returns an empty page, stop instead of refetching forever.
+      if (res.results.length === 0) {
+        hasNextPage = false;
+      }
+
       if (options?.maxPages && page >= options.maxPages - 1) {
         hasNextPage = false;
       }

--- a/src/Utils/request/utils.test.ts
+++ b/src/Utils/request/utils.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import { getResponseBody } from "@/Utils/request/utils";
+
+const jsonResponse = (body: string) =>
+  new Response(body, { headers: { "content-type": "application/json" } });
+
+describe("getResponseBody", () => {
+  it("parses valid JSON", async () => {
+    await expect(getResponseBody(jsonResponse('{"a":1}'))).resolves.toEqual({
+      a: 1,
+    });
+  });
+
+  it("falls back to raw text for malformed JSON instead of throwing", async () => {
+    await expect(
+      getResponseBody(jsonResponse("<html>bad gateway</html>")),
+    ).resolves.toBe("<html>bad gateway</html>");
+  });
+
+  it("returns null for an explicitly empty body", async () => {
+    const res = new Response(null, {
+      headers: { "content-length": "0", "content-type": "application/json" },
+    });
+    await expect(getResponseBody(res)).resolves.toBeNull();
+  });
+
+  it("returns text for non-JSON content types", async () => {
+    const res = new Response("plain", {
+      headers: { "content-type": "text/plain" },
+    });
+    await expect(getResponseBody(res)).resolves.toBe("plain");
+  });
+});

--- a/src/Utils/request/utils.ts
+++ b/src/Utils/request/utils.ts
@@ -102,10 +102,11 @@ export async function getResponseBody<TData>(res: Response): Promise<TData> {
     return (await res.text()) as TData;
   }
 
+  const text = await res.text();
   try {
-    return await res.json();
+    return JSON.parse(text) as TData;
   } catch {
-    return (await res.text()) as TData;
+    return text as TData;
   }
 }
 


### PR DESCRIPTION
Closes #16511

Stacked on #16514 (uses the Vitest harness for the new tests). GitHub will retarget this to `develop` when that merges.

## What

Two defects in the shared request layer:

1. **`query.paginated()` could loop forever** (`src/Utils/request/query.ts`): the loop only stopped when accumulated `items.length >= res.count`. If the backend ever reports a `count` larger than the rows it returns (row-level filtering not reflected in the count, count/offset skew), a page comes back empty while `count` says there's more — infinite refetch. Fixed with an empty-page guard; the existing stop conditions are untouched, so behavior for well-formed responses is unchanged.

2. **`getResponseBody` consumed the body twice** (`src/Utils/request/utils.ts`): `res.json()` consumes the stream even when parsing fails, so the intended `res.text()` fallback threw `TypeError: body stream already read`, masking the real error for any JSON-labelled response with an invalid body (truncated payload, proxy error page). Now reads the body once as text and `JSON.parse`s it.

## Tests

6 new unit tests:

- `utils.test.ts`: valid JSON, malformed-JSON → raw-text fallback (fails with `Body is unusable` if the fix is reverted — verified), explicit empty body → null, non-JSON content type → text.
- `query.test.ts`: empty-page termination despite larger count (2s timeout converts a regression into a fast failure instead of a hang), and normal multi-page accumulation.

`npm run typecheck` → exit 0; `npm run test:unit` → 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
