### PR TITLE
Add characterization tests for monetary component math and medication active-window logic

### DIFF
--- a/src/types/base/monetaryComponent/monetaryComponent.test.ts
+++ b/src/types/base/monetaryComponent/monetaryComponent.test.ts
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+//
+// jsdom is required here (rather than the default node environment) because
+// monetaryComponent.ts imports CURRENCY_SYMBOL from a UI module that
+// transitively pulls in React component code expecting a DOM.
+import { describe, expect, it } from "vitest";
+
+import { ConditionOperation } from "@/types/base/condition/condition";
+import {
+  calculateComponentAmount,
+  calculateSubtotal,
+  calculateTotalPrice,
+  calculateTotalPriceWithQuantity,
+  getBasePrice,
+  getDiscountAmount,
+  getPriceBreakdown,
+  getSurchargeAmount,
+  getTaxAmount,
+  MonetaryComponent,
+  MonetaryComponentType,
+} from "@/types/base/monetaryComponent/monetaryComponent";
+import { decimal } from "@/Utils/decimal";
+
+describe("calculateComponentAmount", () => {
+  it("computes percentage-based amounts as baseAmount * factor / 100", () => {
+    const component: MonetaryComponent = {
+      monetary_component_type: MonetaryComponentType.surcharge,
+      factor: "10",
+    };
+    expect(calculateComponentAmount(component, decimal("100")).toString()).toBe(
+      "10",
+    );
+  });
+
+  it("computes fixed amounts as-is when factor is not set", () => {
+    const component: MonetaryComponent = {
+      monetary_component_type: MonetaryComponentType.surcharge,
+      amount: "50",
+    };
+    expect(calculateComponentAmount(component, decimal("100")).toString()).toBe(
+      "50",
+    );
+  });
+
+  it("returns 0 when neither factor nor amount is set", () => {
+    const component: MonetaryComponent = {
+      monetary_component_type: MonetaryComponentType.surcharge,
+    };
+    expect(calculateComponentAmount(component, decimal("100")).toString()).toBe(
+      "0",
+    );
+  });
+
+  it("prefers factor over amount when both are set (factor precedence)", () => {
+    const component: MonetaryComponent = {
+      monetary_component_type: MonetaryComponentType.surcharge,
+      factor: "10",
+      amount: "50",
+    };
+    expect(calculateComponentAmount(component, decimal("100")).toString()).toBe(
+      "10",
+    );
+  });
+});
+
+describe("getBasePrice", () => {
+  it("returns the amount of the first base-type component", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.informational },
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      { monetary_component_type: MonetaryComponentType.base, amount: "999" },
+    ];
+    expect(getBasePrice(components).toString()).toBe("100");
+  });
+
+  it("returns 0 when there is no base component", () => {
+    const components: MonetaryComponent[] = [
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+    ];
+    expect(getBasePrice(components).toString()).toBe("0");
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(getBasePrice([]).toString()).toBe("0");
+  });
+});
+
+describe("getSurchargeAmount", () => {
+  it("sums surcharges as percentages of the base amount", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+    ];
+    expect(getSurchargeAmount(components).toString()).toBe("10");
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(getSurchargeAmount([]).toString()).toBe("0");
+  });
+});
+
+describe("getDiscountAmount", () => {
+  it("applies discounts to the base amount, not the running subtotal", () => {
+    // base 100, surcharge 10% (=10) -> subtotal-so-far 110, but the discount
+    // percentage is still computed against the base (100), not 110.
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+      {
+        monetary_component_type: MonetaryComponentType.discount,
+        factor: "20",
+        conditions: [],
+      },
+    ];
+    expect(getDiscountAmount(components).toString()).toBe("20");
+  });
+
+  it("excludes discounts with a non-empty conditions array", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.discount,
+        factor: "20",
+        conditions: [
+          {
+            metric: "patient_gender",
+            operation: ConditionOperation.equality,
+            value: "male",
+          },
+        ],
+      },
+    ];
+    expect(getDiscountAmount(components).toString()).toBe("0");
+  });
+
+  it("excludes discounts whose conditions field is undefined (pins current behavior: conditions must be an explicit empty array to apply — flagged for maintainer review)", () => {
+    // `c.conditions?.length === 0` is false when `conditions` is undefined
+    // (`undefined?.length === 0` evaluates to `undefined === 0` -> false), so a
+    // discount with no `conditions` key at all is silently excluded, the same
+    // as one with a populated conditions array. Pinned here as current
+    // behavior, not necessarily intended behavior.
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.discount,
+        factor: "20",
+        // no `conditions` key
+      },
+    ];
+    expect(getDiscountAmount(components).toString()).toBe("0");
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(getDiscountAmount([]).toString()).toBe("0");
+  });
+});
+
+describe("calculateSubtotal", () => {
+  it("computes base + surcharges - discounts", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+      {
+        monetary_component_type: MonetaryComponentType.discount,
+        factor: "20",
+        conditions: [],
+      },
+    ];
+    // base 100 + surcharge 10 (10% of 100) - discount 20 (20% of 100) = 90
+    expect(calculateSubtotal(components).toString()).toBe("90");
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(calculateSubtotal([]).toString()).toBe("0");
+  });
+});
+
+describe("getTaxAmount", () => {
+  it("computes tax on the subtotal (base + surcharge), not the base", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+      { monetary_component_type: MonetaryComponentType.tax, factor: "5" },
+    ];
+    // subtotal = 100 + 10 = 110; tax = 5% of 110 = 5.5 (not 5% of 100 = 5)
+    expect(calculateSubtotal(components).toString()).toBe("110");
+    expect(getTaxAmount(components).toString()).toBe("5.5");
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(getTaxAmount([]).toString()).toBe("0");
+  });
+});
+
+describe("calculateTotalPrice / calculateTotalPriceWithQuantity", () => {
+  it("computes subtotal + tax", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+      {
+        monetary_component_type: MonetaryComponentType.surcharge,
+        factor: "10",
+      },
+      { monetary_component_type: MonetaryComponentType.tax, factor: "5" },
+    ];
+    expect(calculateTotalPrice(components).toString()).toBe("115.5");
+  });
+
+  it("multiplies the total price by quantity", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "100" },
+    ];
+    expect(calculateTotalPriceWithQuantity(components, 3).toString()).toBe(
+      "300",
+    );
+  });
+
+  it("returns 0 for an empty component list", () => {
+    expect(calculateTotalPrice([]).toString()).toBe("0");
+  });
+});
+
+describe("getPriceBreakdown", () => {
+  it("rounds every line item to 2 decimals and multiplies by quantity", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "33.33" },
+    ];
+    const breakdown = getPriceBreakdown(components, 3);
+    expect(breakdown).toEqual({
+      basePrice: "99.99",
+      surcharges: "0.00",
+      discounts: "0.00",
+      subtotal: "99.99",
+      tax: "0.00",
+      total: "99.99",
+    });
+  });
+
+  it("defaults quantity to 1", () => {
+    const components: MonetaryComponent[] = [
+      { monetary_component_type: MonetaryComponentType.base, amount: "50" },
+    ];
+    expect(getPriceBreakdown(components).total).toBe("50.00");
+  });
+
+  it("returns zeroed strings for an empty component list without throwing", () => {
+    expect(() => getPriceBreakdown([])).not.toThrow();
+    expect(getPriceBreakdown([])).toEqual({
+      basePrice: "0.00",
+      surcharges: "0.00",
+      discounts: "0.00",
+      subtotal: "0.00",
+      tax: "0.00",
+      total: "0.00",
+    });
+  });
+});

--- a/src/types/emr/medicationRequest/medicationRequest.test.ts
+++ b/src/types/emr/medicationRequest/medicationRequest.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BoundsDuration,
+  getMedicationActiveWindow,
+  getTimingBounds,
+  MedicationRequestDosageInstruction,
+  MedicationRequestRead,
+  PeriodSpec,
+  TimingRange,
+} from "@/types/emr/medicationRequest/medicationRequest";
+
+type ActiveWindowFixture = Pick<
+  MedicationRequestRead,
+  "authored_on" | "modified_date" | "status" | "dosage_instruction"
+>;
+
+function makeInstruction(bounds?: {
+  bounds_duration?: BoundsDuration;
+  bounds_range?: TimingRange;
+  bounds_period?: PeriodSpec;
+}): MedicationRequestDosageInstruction {
+  return {
+    as_needed_boolean: false,
+    timing: {
+      repeat: {
+        frequency: 1,
+        period: "1",
+        period_unit: "d",
+        ...bounds,
+      },
+    },
+  };
+}
+
+describe("getTimingBounds", () => {
+  it("prefers bounds_range over bounds_period and bounds_duration", () => {
+    const range: TimingRange = {
+      low: { value: "3", unit: "d" },
+      high: { value: "7", unit: "d" },
+    };
+    const bounds = getTimingBounds({
+      bounds_range: range,
+      bounds_period: { start: "2026-01-10T00:00:00Z" },
+      bounds_duration: { value: "5", unit: "d" },
+    });
+    expect(bounds).toEqual({ type: "range", value: range });
+  });
+
+  it("prefers bounds_period over bounds_duration when there is no bounds_range", () => {
+    const period: PeriodSpec = { start: "2026-01-10T00:00:00Z" };
+    const bounds = getTimingBounds({
+      bounds_period: period,
+      bounds_duration: { value: "5", unit: "d" },
+    });
+    expect(bounds).toEqual({ type: "period", value: period });
+  });
+
+  it("falls back to bounds_duration when it is the only bound set", () => {
+    const duration: BoundsDuration = { value: "5", unit: "d" };
+    const bounds = getTimingBounds({ bounds_duration: duration });
+    expect(bounds).toEqual({ type: "duration", value: duration });
+  });
+
+  it("treats a bounds_duration of value '0' as no bound", () => {
+    const bounds = getTimingBounds({
+      bounds_duration: { value: "0", unit: "d" },
+    });
+    expect(bounds).toBeUndefined();
+  });
+
+  it("returns undefined when no bounds are set", () => {
+    expect(getTimingBounds({})).toBeUndefined();
+    expect(getTimingBounds(undefined)).toBeUndefined();
+  });
+});
+
+describe("getMedicationActiveWindow", () => {
+  it("uses bounds_period.start/end as local midnight / local end-of-day (day-rollover regression test)", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-01T00:00:00Z",
+      modified_date: "2026-01-01T00:00:00Z",
+      status: "active",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-10T00:00:00Z",
+            end: "2026-01-25T00:00:00Z",
+          },
+        }),
+      ],
+    };
+    const { start, end } = getMedicationActiveWindow(request);
+
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(0); // January
+    expect(start.getDate()).toBe(10);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+
+    expect(end).toBeDefined();
+    expect(end!.getFullYear()).toBe(2026);
+    expect(end!.getMonth()).toBe(0); // January
+    expect(end!.getDate()).toBe(25);
+    // The regression this guards against: naively parsing the end date as UTC
+    // midnight would roll over to day 26 for UTC+ local timezones. Anchoring
+    // to LOCAL end-of-day keeps it on day 25 regardless of the runner's TZ.
+    expect(end!.getHours()).toBe(23);
+    expect(end!.getMinutes()).toBe(59);
+    expect(end!.getSeconds()).toBe(59);
+  });
+
+  it("anchors a bounds_duration window to authored_on and adds the duration in hours", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-10T08:00:00Z",
+      modified_date: "2026-01-10T08:00:00Z",
+      status: "active",
+      dosage_instruction: [
+        makeInstruction({ bounds_duration: { value: "5", unit: "d" } }),
+      ],
+    };
+    const { start, end } = getMedicationActiveWindow(request);
+
+    expect(start.getTime()).toBe(new Date("2026-01-10T08:00:00Z").getTime());
+    expect(end).toBeDefined();
+    expect(end!.getTime() - start.getTime()).toBe(120 * 3_600_000); // 5 days
+  });
+
+  it("uses the high end of a bounds_range for the window end", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-10T08:00:00Z",
+      modified_date: "2026-01-10T08:00:00Z",
+      status: "active",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_range: {
+            low: { value: "3", unit: "d" },
+            high: { value: "7", unit: "d" },
+          },
+        }),
+      ],
+    };
+    const { start, end } = getMedicationActiveWindow(request);
+
+    expect(end).toBeDefined();
+    expect(end!.getTime() - start.getTime()).toBe(7 * 24 * 3_600_000);
+  });
+
+  it("is open-ended (end undefined) when no bound is set", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-10T08:00:00Z",
+      modified_date: "2026-01-10T08:00:00Z",
+      status: "active",
+      dosage_instruction: [makeInstruction()],
+    };
+    const { end } = getMedicationActiveWindow(request);
+    expect(end).toBeUndefined();
+  });
+
+  it("is open-ended when there is no dosage_instruction at all", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-10T08:00:00Z",
+      modified_date: "2026-01-10T08:00:00Z",
+      status: "active",
+      dosage_instruction: [],
+    };
+    const { end } = getMedicationActiveWindow(request);
+    expect(end).toBeUndefined();
+  });
+
+  it("unions multiple dosage instructions to the earliest start and latest end", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-01T00:00:00Z",
+      modified_date: "2026-01-01T00:00:00Z",
+      status: "active",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-10T00:00:00Z",
+            end: "2026-01-15T00:00:00Z",
+          },
+        }),
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-12T00:00:00Z",
+            end: "2026-01-20T00:00:00Z",
+          },
+        }),
+      ],
+    };
+    const { start, end } = getMedicationActiveWindow(request);
+
+    expect(start.getDate()).toBe(10);
+    expect(end).toBeDefined();
+    expect(end!.getDate()).toBe(20);
+    expect(end!.getHours()).toBe(23);
+  });
+
+  it("is open-ended overall when any one instruction is open-ended, even if another is bounded", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-01T00:00:00Z",
+      modified_date: "2026-01-01T00:00:00Z",
+      status: "active",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-10T00:00:00Z",
+            end: "2026-01-15T00:00:00Z",
+          },
+        }),
+        makeInstruction(), // no bounds -> open-ended
+      ],
+    };
+    const { end } = getMedicationActiveWindow(request);
+    expect(end).toBeUndefined();
+  });
+
+  it("clamps the end to modified_date when an inactive request was stopped before its scheduled end", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-01T00:00:00Z",
+      modified_date: "2026-01-18T10:00:00Z",
+      status: "ended",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-01T00:00:00Z",
+            end: "2026-01-25T00:00:00Z",
+          },
+        }),
+      ],
+    };
+    const { end } = getMedicationActiveWindow(request);
+    expect(end).toBeDefined();
+    expect(end!.getTime()).toBe(new Date("2026-01-18T10:00:00Z").getTime());
+  });
+
+  it("does not extend the window when modified_date is after the scheduled end", () => {
+    const request: ActiveWindowFixture = {
+      authored_on: "2026-01-01T00:00:00Z",
+      modified_date: "2026-01-20T10:00:00Z",
+      status: "ended",
+      dosage_instruction: [
+        makeInstruction({
+          bounds_period: {
+            start: "2026-01-01T00:00:00Z",
+            end: "2026-01-15T00:00:00Z",
+          },
+        }),
+      ],
+    };
+    const { end } = getMedicationActiveWindow(request);
+    expect(end).toBeDefined();
+    // Still clamped to the scheduled end-of-day (Jan 15), not extended to the
+    // later modified_date (Jan 20) — pins current behavior: modified_date
+    // only ever shortens the window, never lengthens it.
+    expect(end!.getDate()).toBe(15);
+    expect(end!.getHours()).toBe(23);
+  });
+});


### PR DESCRIPTION
Closes #16512

Stacked on #16514 (needs the Vitest harness). GitHub will retarget this to `develop` when that merges. **Test-only PR — zero runtime code changes** (531 insertions, both files are new tests).

## What

Characterization suites for the two highest-consequence pure-logic modules, both previously untested:

- **`monetaryComponent.test.ts` (23 tests)** — pins the invoice arithmetic: percentage vs fixed components, factor precedence over amount, surcharges/discounts computed on base, **tax computed on subtotal** (base + surcharge − discount, e.g. 5% of 110 = 5.5, not 5), quantity scaling, 2-decimal breakdown rounding, empty-input behavior.
- **`medicationRequest.test.ts` (14 tests)** — pins `getTimingBounds` precedence (`range > period > duration`, `"0"` duration ignored) and `getMedicationActiveWindow`: period bounds landing on **local** calendar days (start at 00:00, end at 23:59:59 local — the day-rollover regression case), duration anchored to `authored_on`, range using `high`, multi-instruction window unions, open-ended handling, and the stopped-early clamp via `modified_date` (including that a later `modified_date` does not extend the window). Assertions use local date components so they pass in any timezone.

## One behavior flagged for maintainer review

`getDiscountAmount` counts a discount only when `conditions` is an **explicit empty array** — a component with `conditions: undefined` is silently excluded (`c.conditions?.length === 0`). The test pins this as-is with a `pins current behavior` comment rather than judging it. If that's unintended, fix code + test together.

## Verification

`npm run test:unit` → 42/42 (37 new + seed suite) · `npm run typecheck` → exit 0 · commit touches only the two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
