### PR TITLE
✨ Add generic type-safe autocomplete with radio variant (ENG-648)

### DIFF
--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -24,23 +24,47 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import RadioInput from "@/components/ui/RadioInput";
 
 import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
 
 import useBreakpoints from "@/hooks/useBreakpoints";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 
-interface AutoCompleteOption {
+/**
+ * Minimum option count above which the radio variant falls back to the
+ * combobox. Radio buttons are only rendered when `enableRadio` is set AND the
+ * number of options is within this threshold.
+ */
+export const RADIO_MAX_OPTIONS = 5;
+
+/**
+ * Default option shape. Consumers that keep this shape only need to swap the
+ * component name when migrating from `Autocomplete`.
+ */
+export interface GenericAutocompleteOption {
   label: string;
   value: string;
 }
 
-interface AutocompleteProps {
-  options: AutoCompleteOption[];
+interface GenericAutocompleteProps<T = GenericAutocompleteOption> {
+  options: T[];
   isLoading?: boolean;
+  /** Currently selected value key (matches `getOptionValue`). */
   value: string;
   onChange: (value: string) => void;
   onSearch?: (value: string) => void;
+  onOpenChange?: (open: boolean) => void;
+
+  /** Extract the value key from an option. Defaults to `option.value`. */
+  getOptionValue?: (option: T) => string;
+  /** Extract the display label from an option. Defaults to `option.label`. */
+  getOptionLabel?: (option: T) => string;
+  /** Custom render for a list item. Defaults to a check icon + label. */
+  renderOption?: (option: T, isSelected: boolean) => React.ReactNode;
+  /** Custom render for the selected option inside the trigger. */
+  renderSelected?: (option: T) => React.ReactNode;
+
   placeholder?: string;
   inputPlaceholder?: string;
   noOptionsMessage?: string;
@@ -52,6 +76,12 @@ interface AutocompleteProps {
   freeInput?: boolean;
   closeOnSelect?: boolean;
   showClearButton?: boolean;
+  /** Set to `false` for server-side search to disable cmdk's internal filter. */
+  filter?: boolean;
+
+  /** Render options as a radio group instead of a combobox. */
+  enableRadio?: boolean;
+  radioClassName?: string;
 
   ref?: React.RefCallback<HTMLButtonElement | null>;
 
@@ -60,77 +90,114 @@ interface AutocompleteProps {
 }
 
 /**
- * @deprecated Use the generic, type-safe `GenericAutocomplete` from
- * `@/components/ui/generic-autocomplete` instead. For string-based options the
- * migration is a rename; it also supports custom option types and a radio
- * variant. This component is kept for existing usages and will be removed once
- * they are migrated.
+ * Generic, type-safe replacement for `Autocomplete`.
+ *
+ * With the default generic (`T = GenericAutocompleteOption`) the prop contract
+ * matches `Autocomplete` exactly, so existing usages migrate by renaming the
+ * component. For richer option types, provide `getOptionValue` /
+ * `getOptionLabel` and (optionally) `renderOption` / `renderSelected`.
  */
-export default function Autocomplete({
-  options,
-  isLoading = false,
-  value,
-  onChange,
-  onSearch,
-  placeholder = "Select...",
-  inputPlaceholder = "Search option...",
-  noOptionsMessage = "No options found",
-  disabled,
-  align = "center",
-  className,
-  popoverClassName,
-  popoverContentClassName,
-  freeInput = false,
-  closeOnSelect = true,
-  showClearButton = true,
-  ref,
-  shortcutId,
-  ...props
-}: AutocompleteProps) {
+export default function GenericAutocomplete<T = GenericAutocompleteOption>(
+  props: GenericAutocompleteProps<T>,
+) {
+  const {
+    options,
+    isLoading = false,
+    value,
+    onChange,
+    onSearch,
+    onOpenChange,
+    getOptionValue = (option: T) =>
+      (option as unknown as GenericAutocompleteOption).value,
+    getOptionLabel = (option: T) =>
+      (option as unknown as GenericAutocompleteOption).label,
+    renderOption,
+    renderSelected,
+    placeholder = "Select...",
+    inputPlaceholder = "Search option...",
+    noOptionsMessage = "No options found",
+    disabled,
+    align = "center",
+    className,
+    popoverClassName,
+    popoverContentClassName,
+    freeInput = false,
+    closeOnSelect = true,
+    showClearButton = true,
+    filter = true,
+    enableRadio = false,
+    radioClassName,
+    ref,
+    shortcutId,
+  } = props;
+
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
   // Maintain an internal state for the input text when freeInput is enabled.
-  // TODO : Find a better way to handle this, maybe as a seperate component
   const [inputValue, setInputValue] = React.useState(value);
 
-  // Find a matching option from the options list (for non freeInput or when value matches an option)
-  const selectedOption = options.find((option) => option.value === value);
+  // Find a matching option from the options list.
+  const selectedOption = options.find(
+    (option) => getOptionValue(option) === value,
+  );
 
   // Sync the inputValue with value prop changes.
   React.useEffect(() => {
-    const selected = options.find((option) => option.value === value);
+    const selected = options.find((option) => getOptionValue(option) === value);
     if (value) {
-      setInputValue(selected ? selected.label : value);
+      setInputValue(selected ? getOptionLabel(selected) : value);
     } else {
       setInputValue("");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, options]);
+
+  const renderTriggerContent = (fallback: string) => {
+    if (selectedOption && renderSelected) {
+      return renderSelected(selectedOption);
+    }
+    return (
+      <span
+        className={cn(
+          inputValue && "truncate",
+          !selectedOption && "text-gray-500",
+        )}
+      >
+        {fallback}
+      </span>
+    );
+  };
 
   // Determine what text to display on the button.
   const displayText = freeInput
     ? inputValue || placeholder
     : selectedOption
-      ? selectedOption.label
+      ? getOptionLabel(selectedOption)
       : placeholder;
 
   // Handle changes in the CommandInput.
   const handleInputChange = (newValue: string) => {
     if (freeInput) {
       setInputValue(newValue);
-      // If the new text exactly matches an option (case-insensitive), select that option.
+      // If the new text exactly matches an option (case-insensitive), select it.
       const matchingOption = options.find(
-        (option) => option.label.toLowerCase() === newValue.toLowerCase(),
+        (option) =>
+          getOptionLabel(option).toLowerCase() === newValue.toLowerCase(),
       );
       if (matchingOption) {
-        onChange(matchingOption.value);
+        onChange(getOptionValue(matchingOption));
       } else {
         onChange(newValue);
       }
     } else {
-      if (onSearch) {
-        onSearch(newValue);
-      }
+      onSearch?.(newValue);
     }
   };
 
@@ -146,9 +213,26 @@ export default function Autocomplete({
 
     onSearch?.("");
 
-    setOpen(false);
+    handleOpenChange(false);
   };
-  const { t } = useTranslation();
+
+  // Radio variant — only when enabled and within the option threshold.
+  if (enableRadio && options.length <= RADIO_MAX_OPTIONS) {
+    return (
+      <RadioInput
+        options={options.map((option) => ({
+          label: getOptionLabel(option),
+          value: getOptionValue(option),
+        }))}
+        value={value}
+        onValueChange={onChange}
+        disabled={disabled}
+        aria-invalid={props["aria-invalid"]}
+        className={radioClassName}
+      />
+    );
+  }
+
   const commandContent = (
     <>
       <CommandInput
@@ -165,36 +249,47 @@ export default function Autocomplete({
           <CommandEmpty>{noOptionsMessage}</CommandEmpty>
         )}
         <CommandGroup>
-          {options.map((option) => (
-            <CommandItem
-              key={option.value}
-              value={`${option.label} - ${option.value}`}
-              onSelect={(v) => {
-                const currentValue =
-                  options.find((o) => `${o.label} - ${o.value}` === v)?.value ||
-                  "";
-                onChange(currentValue);
-                // If freeInput is enabled, update the input text with the selected option's label.
-                if (freeInput) {
-                  const selected = options.find(
-                    (o) => o.value === currentValue,
-                  );
-                  setInputValue(selected ? selected.label : currentValue);
-                }
-                if (closeOnSelect) {
-                  setOpen(false);
-                }
-              }}
-            >
-              <CheckIcon
-                className={cn(
-                  "mr-2 size-4",
-                  value === option.value ? "opacity-100" : "opacity-0",
+          {options.map((option) => {
+            const optionValue = getOptionValue(option);
+            const optionLabel = getOptionLabel(option);
+            const isSelected = value === optionValue;
+            return (
+              <CommandItem
+                key={optionValue}
+                value={`${optionLabel} - ${optionValue}`}
+                onSelect={(v) => {
+                  const currentValue =
+                    options.find(
+                      (o) =>
+                        `${getOptionLabel(o)} - ${getOptionValue(o)}` === v,
+                    ) ?? option;
+                  const currentOptionValue = getOptionValue(currentValue);
+                  onChange(currentOptionValue);
+                  // For freeInput, reflect the selected label in the input.
+                  if (freeInput) {
+                    setInputValue(getOptionLabel(currentValue));
+                  }
+                  if (closeOnSelect) {
+                    handleOpenChange(false);
+                  }
+                }}
+              >
+                {renderOption ? (
+                  renderOption(option, isSelected)
+                ) : (
+                  <>
+                    <CheckIcon
+                      className={cn(
+                        "mr-2 size-4",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {optionLabel}
+                  </>
                 )}
-              />
-              {option.label}
-            </CommandItem>
-          ))}
+              </CommandItem>
+            );
+          })}
         </CommandGroup>
       </CommandList>
     </>
@@ -203,15 +298,15 @@ export default function Autocomplete({
   if (isMobile) {
     return (
       <div className="flex relative w-full">
-        <Drawer open={open} onOpenChange={setOpen}>
+        <Drawer open={open} onOpenChange={handleOpenChange}>
           <DrawerTrigger asChild>
             <Button
               aria-invalid={props["aria-invalid"]}
               title={
-                value
+                selectedOption
                   ? freeInput
                     ? inputValue || value
-                    : selectedOption?.label
+                    : getOptionLabel(selectedOption)
                   : undefined
               }
               variant="outline"
@@ -226,13 +321,15 @@ export default function Autocomplete({
               disabled={disabled}
               type="button"
             >
-              <span className="overflow-hidden">
-                {value
+              {renderTriggerContent(
+                value
                   ? freeInput
                     ? inputValue || value
-                    : selectedOption?.label
-                  : placeholder}
-              </span>
+                    : selectedOption
+                      ? getOptionLabel(selectedOption)
+                      : placeholder
+                  : placeholder,
+              )}
             </Button>
           </DrawerTrigger>
           <DrawerContent
@@ -244,7 +341,7 @@ export default function Autocomplete({
             </DrawerTitle>
 
             <div className="mt-6 pb-[env(safe-area-inset-bottom)] flex-1 overflow-y-auto">
-              <Command>{commandContent}</Command>
+              <Command shouldFilter={filter}>{commandContent}</Command>
             </div>
           </DrawerContent>
         </Drawer>
@@ -269,10 +366,10 @@ export default function Autocomplete({
 
   return (
     <div className="flex relative w-full">
-      <Popover open={open} onOpenChange={setOpen} modal={true}>
+      <Popover open={open} onOpenChange={handleOpenChange} modal={true}>
         <PopoverTrigger asChild className={popoverClassName}>
           <Button
-            title={selectedOption ? selectedOption.label : undefined}
+            title={selectedOption ? getOptionLabel(selectedOption) : undefined}
             variant="outline"
             role="combobox"
             aria-invalid={props["aria-invalid"]}
@@ -283,18 +380,11 @@ export default function Autocomplete({
               selectedOption && "rounded-r-none",
             )}
             disabled={disabled}
-            onClick={() => setOpen(!open)}
+            onClick={() => handleOpenChange(!open)}
             ref={ref}
             data-shortcut-id={shortcutId}
           >
-            <span
-              className={cn(
-                inputValue && "truncate",
-                !selectedOption && "text-gray-500",
-              )}
-            >
-              {displayText}
-            </span>
+            {renderTriggerContent(displayText)}
           </Button>
         </PopoverTrigger>
         <PopoverContent
@@ -304,7 +394,7 @@ export default function Autocomplete({
           )}
           align={align}
         >
-          <Command>{commandContent}</Command>
+          <Command shouldFilter={filter}>{commandContent}</Command>
         </PopoverContent>
       </Popover>
       {selectedOption && showClearButton ? (

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -1,6 +1,4 @@
-import { CaretDownIcon, CheckIcon } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
-import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,29 +6,9 @@ import ColoredIndicator from "@/CAREUI/display/ColoredIndicator";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 import duoToneIcons from "@/CAREUI/icons/DuoTonePaths.json";
 
-import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import GenericAutocomplete from "@/components/ui/generic-autocomplete";
 
 import query from "@/Utils/request/query";
-import useBreakpoints from "@/hooks/useBreakpoints";
 import {
   HealthcareServiceReadSpec,
   InternalType,
@@ -47,6 +25,26 @@ interface HealthcareServiceSelectorProps {
   internalType?: InternalType;
 }
 
+const getIconName = (name: string): DuoToneIconName =>
+  `d-${name}` as DuoToneIconName;
+
+const ServiceIcon = ({ service }: { service: HealthcareServiceReadSpec }) => (
+  <div className="relative size-6 rounded-sm flex items-center justify-center">
+    <ColoredIndicator
+      id={service.id}
+      className="absolute inset-0 rounded-sm opacity-20"
+    />
+    <CareIcon
+      icon={
+        service.styling_metadata?.careIcon
+          ? getIconName(service.styling_metadata.careIcon)
+          : "d-health-worker"
+      }
+      className="size-4 relative z-1"
+    />
+  </div>
+);
+
 export const HealthcareServiceSelector = ({
   facilityId,
   selected,
@@ -57,13 +55,8 @@ export const HealthcareServiceSelector = ({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
-  const isMobile = useBreakpoints({ default: true, sm: false });
 
-  const {
-    data: services,
-    isLoading,
-    isFetching,
-  } = useQuery({
+  const { data: services, isFetching } = useQuery({
     queryKey: ["healthcareServices", facilityId, searchValue, internalType],
     queryFn: query.debounced(healthcareServiceApi.listHealthcareService, {
       pathParams: { facilityId },
@@ -76,146 +69,45 @@ export const HealthcareServiceSelector = ({
     enabled: open,
   });
 
-  const getIconName = (name: string): DuoToneIconName =>
-    `d-${name}` as DuoToneIconName;
-
-  const triggerButton = (
-    <Button
-      variant="outline"
-      role="combobox"
-      className="min-w-60 w-full justify-start"
-      disabled={isLoading}
-    >
-      {selected ? (
-        <div className="flex items-center gap-2">
-          <div className="relative size-6 rounded-sm flex items-center justify-center">
-            <ColoredIndicator
-              id={selected.id}
-              className="absolute inset-0 rounded-sm opacity-20"
-            />
-            <CareIcon
-              icon={
-                selected.styling_metadata?.careIcon
-                  ? getIconName(selected.styling_metadata.careIcon)
-                  : "d-health-worker"
-              }
-              className="size-4 relative z-1"
-            />
-          </div>
-          <span className="truncate">{selected.name}</span>
-        </div>
-      ) : (
-        <span className="text-gray-400">{t("select_healthcare_service")}</span>
-      )}
-      <CaretDownIcon className="ml-auto" />
-    </Button>
-  );
-
-  const commandContent = (
-    <Command shouldFilter={false}>
-      <CommandInput
-        placeholder={t("search")}
-        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm"
-        value={searchValue}
-        onValueChange={setSearchValue}
-        autoFocus
-      />
-      <CommandList>
-        <CommandEmpty>
-          {isFetching ? t("searching") : t("no_services_found")}
-        </CommandEmpty>
-        <CommandGroup>
-          {selected && clearSelection && (
-            <CommandItem
-              onSelect={() => {
-                onSelect(null);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full h-9"
-            >
-              <>
-                <XIcon />
-                <span> {t("clear_selection")}</span>
-              </>
-            </CommandItem>
-          )}
-          {services?.results.map((service) => (
-            <CommandItem
-              key={service.id}
-              value={service.name}
-              onSelect={() => {
-                onSelect(service);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full"
-            >
-              <div className="flex items-center gap-2 w-full">
-                <div className="relative size-6 rounded-sm flex items-center justify-center">
-                  <ColoredIndicator
-                    id={service.id}
-                    className="absolute inset-0 rounded-sm opacity-20"
-                  />
-                  <CareIcon
-                    icon={
-                      service.styling_metadata?.careIcon
-                        ? getIconName(service.styling_metadata.careIcon)
-                        : "d-health-worker"
-                    }
-                    className="size-4 relative z-1"
-                  />
-                </div>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span
-                    className="truncate text-sm font-medium"
-                    title={service.name}
-                  >
-                    {service.name}
-                  </span>
-                  {service.extra_details && (
-                    <span className="text-xs text-gray-500 truncate">
-                      {service.extra_details}
-                    </span>
-                  )}
-                </div>
-                {selected?.id === service.id && (
-                  <CheckIcon className="ml-auto" />
-                )}
-              </div>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  );
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={setOpen} direction="bottom">
-        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-        <DrawerContent
-          aria-describedby={undefined}
-          className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
-        >
-          <DrawerTitle className="sr-only">
-            {t("select_healthcare_service")}
-          </DrawerTitle>
-          <div className="mt-6 h-full">{commandContent}</div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
-
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild disabled={isLoading}>
-        {triggerButton}
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 w-(--radix-popover-trigger-width)"
-        align="start"
-      >
-        {commandContent}
-      </PopoverContent>
-    </Popover>
+    <GenericAutocomplete<HealthcareServiceReadSpec>
+      options={services?.results ?? []}
+      value={selected?.id ?? ""}
+      onChange={(id) =>
+        onSelect(services?.results.find((s) => s.id === id) ?? null)
+      }
+      onOpenChange={setOpen}
+      onSearch={setSearchValue}
+      isLoading={isFetching}
+      filter={false}
+      className="min-w-60 justify-start"
+      showClearButton={clearSelection}
+      placeholder={t("select_healthcare_service")}
+      inputPlaceholder={t("search")}
+      noOptionsMessage={t("no_services_found")}
+      getOptionValue={(service) => service.id}
+      getOptionLabel={(service) => service.name}
+      renderSelected={(service) => (
+        <div className="flex items-center gap-2 min-w-0">
+          <ServiceIcon service={service} />
+          <span className="truncate">{service.name}</span>
+        </div>
+      )}
+      renderOption={(service) => (
+        <div className="flex items-center gap-2 w-full">
+          <ServiceIcon service={service} />
+          <div className="flex flex-col min-w-0 flex-1">
+            <span className="truncate text-sm font-medium" title={service.name}>
+              {service.name}
+            </span>
+            {service.extra_details && (
+              <span className="text-xs text-gray-500 truncate">
+                {service.extra_details}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    />
   );
 };


### PR DESCRIPTION
### 🥅 What are the changes?

Introduces a generic, type-safe replacement for the string-only `Autocomplete`.

- **New `GenericAutocomplete<T>`** (`src/components/ui/generic-autocomplete.tsx`)
  - Default generic (`T = { label; value }`) reproduces the existing `Autocomplete` prop contract exactly, so existing usages migrate by **renaming the component only**.
  - Custom option types via `getOptionValue` / `getOptionLabel`, with optional `renderOption` (list item) and `renderSelected` (trigger) for rich content.
  - New `enableRadio` variant rendering a radio group (reuses `RadioInput`), gated by a module const `RADIO_MAX_OPTIONS = 5` — radio renders only when enabled **and** `options.length <= 5`, otherwise it falls back to the combobox.
  - Preserves desktop popover + mobile drawer, server-side search (`filter={false}`), `freeInput`, clear button, `shortcutId`, `onOpenChange`.
- **Deprecates** `Autocomplete` via a `@deprecated` JSDoc pointing at the new component. The other ~20 usages migrate over time — untouched here.
- **Refactors** `HealthcareServiceSelector` to use `GenericAutocomplete` (custom `HealthcareServiceReadSpec`), dropping its hand-rolled `Command`/`Popover`/`Drawer` (~167 fewer lines) while keeping the icon + colored indicator, `extra_details` subtitle, server search, clear, and mobile drawer.

### 🧪 Testing

- `tsc --noEmit`, ESLint (changed files), and `npm run build` all pass.
- Migration path: swap `import Autocomplete` → `import GenericAutocomplete` and the JSX tag name; no prop changes for default string usage.

### Non-goals

- Not migrating the remaining `Autocomplete` usages (done incrementally).
- No multi-select changes (separate `multi-select.tsx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flexible, type-safe autocomplete component with customizable labels, rendering, search, clearing, loading states, and empty-state messaging.
  * Added optional free-text input and radio-style selection for smaller option lists.
  * Improved responsive behavior with tailored mobile and desktop selection interfaces.
  * Updated healthcare service selection with consistent service icons and integrated loading and search feedback.

* **Documentation**
  * Marked the existing autocomplete component as deprecated in favor of the new replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->