### PR TITLE
🧩 Add GenericAutocomplete with radio mode + refactor HealthcareServiceSelector

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -1,3 +1,10 @@
+/**
+ * @deprecated Use `GenericAutocomplete` from `@/components/ui/generic-autocomplete` instead.
+ * Migration is a drop-in rename for `string`-valued usages:
+ *   `import Autocomplete from "@/components/ui/autocomplete"`
+ *   → `import GenericAutocomplete from "@/components/ui/generic-autocomplete"`
+ * The props contract is identical for `T = string`.
+ */
 import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -59,7 +59,7 @@ interface GenericAutocompleteProps<T> {
   popoverContentClassName?: string;
   closeOnSelect?: boolean;
   showClearButton?: boolean;
-  /** When true and options.length <= RADIO_THRESHOLD, renders as RadioGroup */
+  /** When true and options.length <= RADIO_TRIGGER_MAX_OPTIONS (and not loading), renders as RadioGroup */
   enableRadio?: boolean;
   radioClassName?: string;
   /**
@@ -84,33 +84,30 @@ interface GenericAutocompleteProps<T> {
   shortcutId?: string;
 }
 
-function GenericAutocompleteInner<T>(
-  {
-    options,
-    isLoading = false,
-    value,
-    onChange,
-    onSearch,
-    placeholder = "Select...",
-    inputPlaceholder = "Search option...",
-    noOptionsMessage = "No options found",
-    disabled,
-    align = "center",
-    className,
-    popoverClassName,
-    popoverContentClassName,
-    closeOnSelect = true,
-    showClearButton = true,
-    enableRadio = false,
-    radioClassName,
-    renderOption,
-    renderTrigger,
-    ref,
-    shortcutId,
-    ...props
-  }: GenericAutocompleteProps<T>,
-  _ref: React.Ref<HTMLButtonElement | null>,
-) {
+function GenericAutocomplete<T>({
+  options,
+  isLoading = false,
+  value,
+  onChange,
+  onSearch,
+  placeholder = "Select...",
+  inputPlaceholder = "Search option...",
+  noOptionsMessage = "No options found",
+  disabled,
+  align = "center",
+  className,
+  popoverClassName,
+  popoverContentClassName,
+  closeOnSelect = true,
+  showClearButton = true,
+  enableRadio = false,
+  radioClassName,
+  renderOption,
+  renderTrigger,
+  ref,
+  shortcutId,
+  ...props
+}: GenericAutocompleteProps<T>) {
   const [open, setOpen] = React.useState(false);
   const [searchTerm, setSearchTerm] = React.useState("");
   const isMobile = useBreakpoints({ default: true, sm: false });
@@ -121,11 +118,16 @@ function GenericAutocompleteInner<T>(
       ? (options.find((o) => o.value === value) ?? null)
       : null;
 
-  // Decide radio vs dropdown against the eager-fetched (unfiltered) option
-  // count. While a search term is active the list is server-filtered, so a
-  // narrowed result must not collapse an open dropdown into radios.
+  // Show radio buttons only when: radio is enabled, the component isn't loading
+  // (would render a blank group), there are actual options to display, and no
+  // active search term (which would narrow the server-filtered count below the
+  // threshold without reflecting the true total).
   const showRadio =
-    enableRadio && !searchTerm && options.length <= RADIO_TRIGGER_MAX_OPTIONS;
+    enableRadio &&
+    !isLoading &&
+    options.length > 0 &&
+    !searchTerm &&
+    options.length <= RADIO_TRIGGER_MAX_OPTIONS;
 
   const handleClear = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -155,9 +157,9 @@ function GenericAutocompleteInner<T>(
           }}
           disabled={disabled}
         >
-          {options.map((option, i) => {
+          {options.map((option) => {
             const isSelected = selectedOption?.value === option.value;
-            const id = `radio-option-${i}`;
+            const id = `radio-option-${String(option.value)}`;
             return (
               <div
                 key={id}
@@ -248,15 +250,19 @@ function GenericAutocompleteInner<T>(
           <CommandEmpty>{noOptionsMessage}</CommandEmpty>
         )}
         <CommandGroup>
-          {options.map((option, i) => {
+          {options.map((option) => {
             const isSelected = selectedOption?.value === option.value;
             return (
               <CommandItem
-                key={i}
+                key={String(option.value)}
                 value={`${option.label} - ${String(option.value)}`}
                 onSelect={() => {
                   onChange(option.value);
-                  if (closeOnSelect) setOpen(false);
+                  if (closeOnSelect) {
+                    setOpen(false);
+                    setSearchTerm("");
+                    onSearch?.("");
+                  }
                 }}
               >
                 {renderOption ? (
@@ -316,6 +322,7 @@ function GenericAutocompleteInner<T>(
         </Drawer>
         {selectedOption && showClearButton ? (
           <Button
+            type="button"
             variant="outline"
             size="icon"
             className="rounded-l-none border-l-0 text-gray-400 h-auto"
@@ -368,6 +375,7 @@ function GenericAutocompleteInner<T>(
       </Popover>
       {selectedOption && showClearButton ? (
         <Button
+          type="button"
           variant="outline"
           size="icon"
           className="rounded-l-none border-l-0 text-gray-400 h-auto"
@@ -395,11 +403,5 @@ function GenericAutocompleteInner<T>(
     </div>
   );
 }
-
-const GenericAutocomplete = React.forwardRef(GenericAutocompleteInner) as <T>(
-  props: GenericAutocompleteProps<T> & {
-    ref?: React.Ref<HTMLButtonElement | null>;
-  },
-) => React.ReactElement;
 
 export default GenericAutocomplete;

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -1,0 +1,396 @@
+import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
+
+import useBreakpoints from "@/hooks/useBreakpoints";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+
+/**
+ * When `enableRadio` is true, radio buttons render only if the option count is
+ * at or below this threshold; otherwise the component falls back to the
+ * searchable dropdown.
+ */
+export const RADIO_TRIGGER_MAX_OPTIONS = 5;
+
+export interface GenericAutocompleteOption<T> {
+  label: string;
+  value: T;
+}
+
+interface GenericAutocompleteProps<T> {
+  options: GenericAutocompleteOption<T>[];
+  isLoading?: boolean;
+  value: T | null;
+  onChange: (value: T | null) => void;
+  onSearch?: (value: string) => void;
+  placeholder?: string;
+  inputPlaceholder?: string;
+  noOptionsMessage?: string;
+  disabled?: boolean;
+  align?: "start" | "center" | "end";
+  className?: string;
+  popoverClassName?: string;
+  popoverContentClassName?: string;
+  closeOnSelect?: boolean;
+  showClearButton?: boolean;
+  /** When true and options.length <= RADIO_THRESHOLD, renders as RadioGroup */
+  enableRadio?: boolean;
+  radioClassName?: string;
+  /**
+   * Custom content rendered inside each option row (dropdown CommandItem and
+   * radio label). Receives the option and whether it is currently selected.
+   * Falls back to `option.label` when omitted.
+   */
+  renderOption?: (
+    option: GenericAutocompleteOption<T>,
+    isSelected: boolean,
+  ) => React.ReactNode;
+  /**
+   * Custom content for the trigger button (dropdown mode only).
+   * Receives the currently selected option, or null when nothing is selected.
+   * Falls back to `selected.label` / `placeholder` when omitted.
+   */
+  renderTrigger?: (
+    selected: GenericAutocompleteOption<T> | null,
+  ) => React.ReactNode;
+  ref?: React.RefCallback<HTMLButtonElement | null>;
+  "aria-invalid"?: boolean;
+  shortcutId?: string;
+}
+
+function GenericAutocompleteInner<T>(
+  {
+    options,
+    isLoading = false,
+    value,
+    onChange,
+    onSearch,
+    placeholder = "Select...",
+    inputPlaceholder = "Search option...",
+    noOptionsMessage = "No options found",
+    disabled,
+    align = "center",
+    className,
+    popoverClassName,
+    popoverContentClassName,
+    closeOnSelect = true,
+    showClearButton = true,
+    enableRadio = false,
+    radioClassName,
+    renderOption,
+    renderTrigger,
+    ref,
+    shortcutId,
+    ...props
+  }: GenericAutocompleteProps<T>,
+  _ref: React.Ref<HTMLButtonElement | null>,
+) {
+  const [open, setOpen] = React.useState(false);
+  const isMobile = useBreakpoints({ default: true, sm: false });
+  const { t } = useTranslation();
+
+  const selectedOption =
+    value !== null && value !== undefined
+      ? (options.find((o) => o.value === value) ?? null)
+      : null;
+
+  const showRadio = enableRadio && options.length <= RADIO_TRIGGER_MAX_OPTIONS;
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onChange(null);
+    onSearch?.("");
+    setOpen(false);
+  };
+
+  // ── Radio mode ────────────────────────────────────────────────────────────
+  if (showRadio) {
+    return (
+      <div
+        className={cn("flex flex-col gap-2", radioClassName)}
+        data-testid="autocomplete-radio-group"
+      >
+        <RadioGroup
+          value={
+            value !== null && value !== undefined ? String(value) : undefined
+          }
+          // RadioGroup itself does not fire for the already-selected value;
+          // toggle-to-deselect is handled by the wrapper click below.
+          onValueChange={(v) => {
+            const match = options.find((o) => String(o.value) === v);
+            if (match) onChange(match.value);
+          }}
+          disabled={disabled}
+        >
+          {options.map((option, i) => {
+            const isSelected = selectedOption?.value === option.value;
+            const id = `radio-option-${i}`;
+            return (
+              <div
+                key={id}
+                data-testid="autocomplete-radio-option"
+                className={cn(
+                  "flex items-center gap-3 rounded-lg border p-3 cursor-pointer transition-colors",
+                  isSelected
+                    ? "border-primary bg-primary/5"
+                    : "border-gray-200 hover:bg-gray-50",
+                  disabled && "cursor-not-allowed opacity-50",
+                )}
+                onClick={
+                  // Toggle-to-deselect: clicking the selected option clears it.
+                  isSelected && !disabled
+                    ? (e) => {
+                        e.preventDefault();
+                        onChange(null);
+                      }
+                    : undefined
+                }
+              >
+                <RadioGroupItem
+                  value={String(option.value)}
+                  id={id}
+                  aria-label={option.label}
+                />
+                <label
+                  htmlFor={id}
+                  className={cn(
+                    "flex-1 min-w-0 cursor-pointer",
+                    disabled && "cursor-not-allowed",
+                  )}
+                >
+                  {renderOption ? (
+                    renderOption(option, isSelected)
+                  ) : (
+                    <span className="text-sm font-medium">{option.label}</span>
+                  )}
+                </label>
+              </div>
+            );
+          })}
+        </RadioGroup>
+        {selectedOption && showClearButton && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-fit text-gray-400 px-0 h-auto"
+            onClick={handleClear}
+            disabled={disabled}
+            type="button"
+          >
+            <Cross2Icon className="mr-1 size-3" />
+            {t("clear")}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  // ── Combobox mode ─────────────────────────────────────────────────────────
+  const defaultTriggerContent = selectedOption ? (
+    <span className="truncate">{selectedOption.label}</span>
+  ) : (
+    <span className="text-gray-500">{placeholder}</span>
+  );
+
+  const triggerContent = renderTrigger
+    ? renderTrigger(selectedOption)
+    : defaultTriggerContent;
+
+  const commandContent = (
+    <>
+      <CommandInput
+        placeholder={inputPlaceholder}
+        disabled={disabled}
+        onValueChange={(v) => onSearch?.(v)}
+        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
+        autoFocus
+      />
+      <CommandList className="overflow-y-auto">
+        {isLoading ? (
+          <CardListSkeleton count={3} />
+        ) : (
+          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+        )}
+        <CommandGroup>
+          {options.map((option, i) => {
+            const isSelected = selectedOption?.value === option.value;
+            return (
+              <CommandItem
+                key={i}
+                value={`${option.label} - ${String(option.value)}`}
+                onSelect={() => {
+                  onChange(option.value);
+                  if (closeOnSelect) setOpen(false);
+                }}
+              >
+                {renderOption ? (
+                  renderOption(option, isSelected)
+                ) : (
+                  <>
+                    <CheckIcon
+                      className={cn(
+                        "mr-2 size-4",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option.label}
+                  </>
+                )}
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="flex relative w-full">
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerTrigger asChild>
+            <Button
+              aria-invalid={props["aria-invalid"]}
+              variant="outline"
+              ref={ref}
+              role="combobox"
+              aria-expanded={open}
+              className={cn(
+                "w-full justify-between",
+                className,
+                selectedOption && showClearButton && "rounded-r-none",
+              )}
+              disabled={disabled}
+              type="button"
+            >
+              {triggerContent}
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent
+            aria-describedby={undefined}
+            className="min-h-[50vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
+          >
+            <DrawerTitle className="sr-only">
+              {t("autocomplete_options")}
+            </DrawerTitle>
+            <div className="mt-6 pb-[env(safe-area-inset-bottom)] flex-1 overflow-y-auto">
+              <Command>{commandContent}</Command>
+            </div>
+          </DrawerContent>
+        </Drawer>
+        {selectedOption && showClearButton ? (
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-l-none border-l-0 text-gray-400 h-auto"
+            onClick={handleClear}
+            title={t("clear")}
+            hidden={disabled}
+          >
+            <Cross2Icon />
+            <span className="sr-only">{t("clear")}</span>
+          </Button>
+        ) : (
+          <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex relative w-full">
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
+        <PopoverTrigger asChild className={popoverClassName}>
+          <Button
+            title={selectedOption ? selectedOption.label : undefined}
+            variant="outline"
+            role="combobox"
+            aria-invalid={props["aria-invalid"]}
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-between",
+              className,
+              selectedOption && showClearButton && "rounded-r-none",
+            )}
+            disabled={disabled}
+            onClick={() => setOpen(!open)}
+            ref={ref}
+            data-shortcut-id={shortcutId}
+          >
+            {triggerContent}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]",
+            popoverContentClassName,
+          )}
+          align={align}
+        >
+          <Command>{commandContent}</Command>
+        </PopoverContent>
+      </Popover>
+      {selectedOption && showClearButton ? (
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-l-none border-l-0 text-gray-400 h-auto"
+          onClick={handleClear}
+          title={t("clear")}
+          hidden={disabled}
+        >
+          <Cross2Icon />
+          <span className="sr-only">{t("clear")}</span>
+        </Button>
+      ) : (
+        <>
+          {shortcutId ? (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <div className="flex items-center justify-center gap-1">
+                <ShortcutBadge actionId={shortcutId} />
+                <CaretSortIcon className="size-3 shrink-0 opacity-50" />
+              </div>
+            </div>
+          ) : (
+            <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+const GenericAutocomplete = React.forwardRef(GenericAutocompleteInner) as <T>(
+  props: GenericAutocompleteProps<T> & {
+    ref?: React.Ref<HTMLButtonElement | null>;
+  },
+) => React.ReactElement;
+
+export default GenericAutocomplete;

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -112,6 +112,7 @@ function GenericAutocompleteInner<T>(
   _ref: React.Ref<HTMLButtonElement | null>,
 ) {
   const [open, setOpen] = React.useState(false);
+  const [searchTerm, setSearchTerm] = React.useState("");
   const isMobile = useBreakpoints({ default: true, sm: false });
   const { t } = useTranslation();
 
@@ -120,13 +121,18 @@ function GenericAutocompleteInner<T>(
       ? (options.find((o) => o.value === value) ?? null)
       : null;
 
-  const showRadio = enableRadio && options.length <= RADIO_TRIGGER_MAX_OPTIONS;
+  // Decide radio vs dropdown against the eager-fetched (unfiltered) option
+  // count. While a search term is active the list is server-filtered, so a
+  // narrowed result must not collapse an open dropdown into radios.
+  const showRadio =
+    enableRadio && !searchTerm && options.length <= RADIO_TRIGGER_MAX_OPTIONS;
 
   const handleClear = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     onChange(null);
     onSearch?.("");
+    setSearchTerm("");
     setOpen(false);
   };
 
@@ -228,7 +234,10 @@ function GenericAutocompleteInner<T>(
       <CommandInput
         placeholder={inputPlaceholder}
         disabled={disabled}
-        onValueChange={(v) => onSearch?.(v)}
+        onValueChange={(v) => {
+          setSearchTerm(v);
+          onSearch?.(v);
+        }}
         className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
         autoFocus
       />

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -1,6 +1,4 @@
-import { CaretDownIcon, CheckIcon } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
-import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,29 +6,11 @@ import ColoredIndicator from "@/CAREUI/display/ColoredIndicator";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 import duoToneIcons from "@/CAREUI/icons/DuoTonePaths.json";
 
-import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import GenericAutocomplete, {
+  GenericAutocompleteOption,
+} from "@/components/ui/generic-autocomplete";
 
 import query from "@/Utils/request/query";
-import useBreakpoints from "@/hooks/useBreakpoints";
 import {
   HealthcareServiceReadSpec,
   InternalType,
@@ -55,15 +35,9 @@ export const HealthcareServiceSelector = ({
   internalType,
 }: HealthcareServiceSelectorProps) => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
-  const isMobile = useBreakpoints({ default: true, sm: false });
 
-  const {
-    data: services,
-    isLoading,
-    isFetching,
-  } = useQuery({
+  const { data: services, isLoading } = useQuery({
     queryKey: ["healthcareServices", facilityId, searchValue, internalType],
     queryFn: query.debounced(healthcareServiceApi.listHealthcareService, {
       pathParams: { facilityId },
@@ -73,149 +47,78 @@ export const HealthcareServiceSelector = ({
         ...(searchValue && { name: searchValue }),
       },
     }),
-    enabled: open,
   });
 
   const getIconName = (name: string): DuoToneIconName =>
     `d-${name}` as DuoToneIconName;
 
-  const triggerButton = (
-    <Button
-      variant="outline"
-      role="combobox"
-      className="min-w-60 w-full justify-start"
-      disabled={isLoading}
-    >
-      {selected ? (
-        <div className="flex items-center gap-2">
-          <div className="relative size-6 rounded-sm flex items-center justify-center">
-            <ColoredIndicator
-              id={selected.id}
-              className="absolute inset-0 rounded-sm opacity-20"
-            />
-            <CareIcon
-              icon={
-                selected.styling_metadata?.careIcon
-                  ? getIconName(selected.styling_metadata.careIcon)
-                  : "d-health-worker"
-              }
-              className="size-4 relative z-1"
-            />
-          </div>
-          <span className="truncate">{selected.name}</span>
-        </div>
-      ) : (
-        <span className="text-gray-400">{t("select_healthcare_service")}</span>
-      )}
-      <CaretDownIcon className="ml-auto" />
-    </Button>
-  );
+  const serviceMap = new Map((services?.results ?? []).map((s) => [s.id, s]));
 
-  const commandContent = (
-    <Command shouldFilter={false}>
-      <CommandInput
-        placeholder={t("search")}
-        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm"
-        value={searchValue}
-        onValueChange={setSearchValue}
-        autoFocus
-      />
-      <CommandList>
-        <CommandEmpty>
-          {isFetching ? t("searching") : t("no_services_found")}
-        </CommandEmpty>
-        <CommandGroup>
-          {selected && clearSelection && (
-            <CommandItem
-              onSelect={() => {
-                onSelect(null);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full h-9"
-            >
-              <>
-                <XIcon />
-                <span> {t("clear_selection")}</span>
-              </>
-            </CommandItem>
-          )}
-          {services?.results.map((service) => (
-            <CommandItem
-              key={service.id}
-              value={service.name}
-              onSelect={() => {
-                onSelect(service);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full"
-            >
-              <div className="flex items-center gap-2 w-full">
-                <div className="relative size-6 rounded-sm flex items-center justify-center">
-                  <ColoredIndicator
-                    id={service.id}
-                    className="absolute inset-0 rounded-sm opacity-20"
-                  />
-                  <CareIcon
-                    icon={
-                      service.styling_metadata?.careIcon
-                        ? getIconName(service.styling_metadata.careIcon)
-                        : "d-health-worker"
-                    }
-                    className="size-4 relative z-1"
-                  />
-                </div>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span
-                    className="truncate text-sm font-medium"
-                    title={service.name}
-                  >
-                    {service.name}
-                  </span>
-                  {service.extra_details && (
-                    <span className="text-xs text-gray-500 truncate">
-                      {service.extra_details}
-                    </span>
-                  )}
-                </div>
-                {selected?.id === service.id && (
-                  <CheckIcon className="ml-auto" />
-                )}
-              </div>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  );
+  const options: GenericAutocompleteOption<string>[] = (
+    services?.results ?? []
+  ).map((service) => ({
+    label: service.name,
+    value: service.id,
+  }));
 
-  if (isMobile) {
+  const renderServiceRow = (id: string) => {
+    const service = serviceMap.get(id);
+    if (!service) return null;
     return (
-      <Drawer open={open} onOpenChange={setOpen} direction="bottom">
-        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-        <DrawerContent
-          aria-describedby={undefined}
-          className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
-        >
-          <DrawerTitle className="sr-only">
-            {t("select_healthcare_service")}
-          </DrawerTitle>
-          <div className="mt-6 h-full">{commandContent}</div>
-        </DrawerContent>
-      </Drawer>
+      <div className="flex items-center gap-2 w-full min-w-0">
+        <div className="relative size-6 shrink-0 rounded-sm flex items-center justify-center">
+          <ColoredIndicator
+            id={service.id}
+            className="absolute inset-0 rounded-sm opacity-20"
+          />
+          <CareIcon
+            icon={
+              service.styling_metadata?.careIcon
+                ? getIconName(service.styling_metadata.careIcon)
+                : "d-health-worker"
+            }
+            className="size-4 relative z-1"
+          />
+        </div>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span className="truncate text-sm font-medium" title={service.name}>
+            {service.name}
+          </span>
+          {service.extra_details && (
+            <span className="text-xs text-gray-500 truncate">
+              {service.extra_details}
+            </span>
+          )}
+        </div>
+      </div>
     );
-  }
+  };
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild disabled={isLoading}>
-        {triggerButton}
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 w-(--radix-popover-trigger-width)"
-        align="start"
-      >
-        {commandContent}
-      </PopoverContent>
-    </Popover>
+    <GenericAutocomplete<string>
+      options={options}
+      isLoading={isLoading}
+      value={selected?.id ?? null}
+      onChange={(id) => {
+        onSelect(id ? (serviceMap.get(id) ?? null) : null);
+      }}
+      onSearch={setSearchValue}
+      placeholder={t("select_healthcare_service")}
+      inputPlaceholder={t("search")}
+      noOptionsMessage={t("no_services_found")}
+      enableRadio={true}
+      showClearButton={clearSelection}
+      renderOption={(option) => renderServiceRow(option.value)}
+      renderTrigger={(opt) =>
+        opt ? (
+          renderServiceRow(opt.value)
+        ) : (
+          <span className="text-gray-400">
+            {t("select_healthcare_service")}
+          </span>
+        )
+      }
+      className="min-w-60"
+    />
   );
 };

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -52,14 +52,15 @@ export const HealthcareServiceSelector = ({
   const getIconName = (name: string): DuoToneIconName =>
     `d-${name}` as DuoToneIconName;
 
-  const serviceMap = new Map((services?.results ?? []).map((s) => [s.id, s]));
+  const results = services?.results ?? [];
+  const serviceMap = new Map(results.map((s) => [s.id, s]));
 
-  const options: GenericAutocompleteOption<string>[] = (
-    services?.results ?? []
-  ).map((service) => ({
-    label: service.name,
-    value: service.id,
-  }));
+  const options: GenericAutocompleteOption<string>[] = results.map(
+    (service) => ({
+      label: service.name,
+      value: service.id,
+    }),
+  );
 
   const renderServiceRow = (id: string) => {
     const service = serviceMap.get(id);

--- a/tests/facility/settings/activityDefinition/activityDefinition.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinition.ts
@@ -6,8 +6,8 @@ import {
   closeAnyOpenPopovers,
   expectToast,
   selectFromCategoryPicker,
-  selectFromCommand,
   selectFromLocationMultiSelect,
+  selectFromRadio,
   selectFromRequirements,
   selectFromValueSet,
 } from "tests/helper/ui";
@@ -220,13 +220,7 @@ export async function createActivityDefinition(
       closeAfterSelect: true,
     });
 
-    const healthcareServiceTrigger = page
-      .getByRole("combobox")
-      .filter({ hasText: /select.*healthcare service/i });
-    await selectFromCommand(page, healthcareServiceTrigger, {
-      search: data.healthcareService!,
-      itemIndex: 0,
-    });
+    await selectFromRadio(page, { name: data.healthcareService! });
 
     const locationsTrigger = page
       .getByRole("combobox")

--- a/tests/facility/settings/activityDefinition/activityDefinition.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinition.ts
@@ -6,8 +6,8 @@ import {
   closeAnyOpenPopovers,
   expectToast,
   selectFromCategoryPicker,
+  selectFromGenericAutocomplete,
   selectFromLocationMultiSelect,
-  selectFromRadio,
   selectFromRequirements,
   selectFromValueSet,
 } from "tests/helper/ui";
@@ -220,7 +220,13 @@ export async function createActivityDefinition(
       closeAfterSelect: true,
     });
 
-    await selectFromRadio(page, { name: data.healthcareService! });
+    await selectFromGenericAutocomplete(
+      page,
+      page
+        .getByRole("combobox")
+        .filter({ hasText: /select.*healthcare service/i }),
+      { name: data.healthcareService! },
+    );
 
     const locationsTrigger = page
       .getByRole("combobox")

--- a/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
@@ -9,8 +9,8 @@ import {
   expectToast,
   getCardByTitle,
   selectFromCategoryPicker,
+  selectFromGenericAutocomplete,
   selectFromLocationMultiSelect,
-  selectFromRadio,
   selectFromRequirements,
   selectFromValueSet,
 } from "tests/helper/ui";
@@ -95,11 +95,22 @@ test.describe("activity definition edit", () => {
         .first(),
     ).toBeVisible();
 
-    await expect(
-      page
-        .locator('[data-testid="autocomplete-radio-group"]')
-        .getByRole("radio", { name: createdAD.healthcareService! }),
-    ).toBeChecked();
+    // Pre-fill check: works in both radio mode (≤5 services) and dropdown mode (>5)
+    const radioGroup = page.locator('[data-testid="autocomplete-radio-group"]');
+    const isRadioMode = await radioGroup
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+    if (isRadioMode) {
+      await expect(
+        radioGroup.getByRole("radio", { name: createdAD.healthcareService! }),
+      ).toBeChecked();
+    } else {
+      await expect(
+        page.getByRole("combobox").filter({
+          hasText: createdAD.healthcareService!,
+        }),
+      ).toBeVisible();
+    }
 
     await expect(
       page
@@ -184,7 +195,13 @@ test.describe("activity definition edit", () => {
       closeAfterSelect: true,
     });
 
-    await selectFromRadio(page, { name: "main pharmacy" });
+    await selectFromGenericAutocomplete(
+      page,
+      page
+        .getByRole("combobox")
+        .filter({ hasText: /select.*healthcare service/i }),
+      { name: "main pharmacy" },
+    );
 
     const locationsTrigger = page
       .getByRole("combobox")

--- a/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
@@ -9,8 +9,8 @@ import {
   expectToast,
   getCardByTitle,
   selectFromCategoryPicker,
-  selectFromCommand,
   selectFromLocationMultiSelect,
+  selectFromRadio,
   selectFromRequirements,
   selectFromValueSet,
 } from "tests/helper/ui";
@@ -96,10 +96,10 @@ test.describe("activity definition edit", () => {
     ).toBeVisible();
 
     await expect(
-      page.getByRole("combobox").filter({
-        hasText: createdAD.healthcareService!,
-      }),
-    ).toBeVisible();
+      page
+        .locator('[data-testid="autocomplete-radio-group"]')
+        .getByRole("radio", { name: createdAD.healthcareService! }),
+    ).toBeChecked();
 
     await expect(
       page
@@ -184,13 +184,7 @@ test.describe("activity definition edit", () => {
       closeAfterSelect: true,
     });
 
-    const healthcareServiceTrigger = page
-      .getByRole("combobox")
-      .filter({ hasText: /select.*healthcare service/i });
-    await selectFromCommand(page, healthcareServiceTrigger, {
-      search: "main pharmacy",
-      itemIndex: 0,
-    });
+    await selectFromRadio(page, { name: "main pharmacy" });
 
     const locationsTrigger = page
       .getByRole("combobox")

--- a/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts
@@ -98,7 +98,8 @@ test.describe("activity definition edit", () => {
     // Pre-fill check: works in both radio mode (≤5 services) and dropdown mode (>5)
     const radioGroup = page.locator('[data-testid="autocomplete-radio-group"]');
     const isRadioMode = await radioGroup
-      .isVisible({ timeout: 2000 })
+      .waitFor({ state: "visible", timeout: 2000 })
+      .then(() => true)
       .catch(() => false);
     if (isRadioMode) {
       await expect(

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -735,3 +735,58 @@ export async function selectFromRadio(
   await radioOption.scrollIntoViewIfNeeded();
   await radioOption.click();
 }
+
+interface SelectFromGenericAutocompleteOptions {
+  /**
+   * Accessible name of the option to select (used in radio mode and as the
+   * default search term in dropdown mode).
+   */
+  name: string;
+  /** Override the search term used in dropdown/command mode. */
+  search?: string;
+}
+
+/**
+ * Mode-agnostic helper for `GenericAutocomplete` fields.
+ *
+ * `GenericAutocomplete` renders inline radio buttons when `enableRadio=true`
+ * and the loaded option count is ≤ `RADIO_TRIGGER_MAX_OPTIONS`; otherwise it
+ * renders a searchable dropdown/popover. The exact mode depends on how many
+ * options exist in the backend, which can vary across environments.
+ *
+ * This helper probes for the radio group first (short 2 s window), then falls
+ * back to `selectFromCommand` so tests pass regardless of the active mode.
+ *
+ * @param trigger – Locator for the combobox trigger button used in dropdown
+ *   mode (ignored when radio mode is active).
+ *
+ * @example
+ * const trigger = page.getByRole("combobox").filter({ hasText: /select.*healthcare service/i });
+ * await selectFromGenericAutocomplete(page, trigger, { name: "Main Pharmacy" });
+ */
+export async function selectFromGenericAutocomplete(
+  page: Page,
+  trigger: Locator,
+  { name, search }: SelectFromGenericAutocompleteOptions,
+) {
+  const radioGroup = page
+    .locator('[data-testid="autocomplete-radio-group"]')
+    .first();
+  const isRadioMode = await radioGroup
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+
+  if (isRadioMode) {
+    const radioOption = radioGroup.getByRole("radio", { name });
+    await radioOption.waitFor({ state: "visible" });
+    await radioOption.scrollIntoViewIfNeeded();
+    await radioOption.click();
+    return;
+  }
+
+  // Dropdown mode
+  await selectFromCommand(page, trigger, {
+    search: search ?? name,
+    itemIndex: 0,
+  });
+}

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -693,3 +693,45 @@ export async function clickTabOrMenuItem(
     `Tab "${tabName}" not found as visible tab or in dropdown menu`,
   );
 }
+
+interface SelectFromRadioOptions {
+  /** Accessible name (aria-label) of the radio option to select. */
+  name: string;
+  /**
+   * Locator scoping the search to a specific container.
+   * Defaults to the whole page when omitted.
+   */
+  scope?: Locator;
+}
+
+/**
+ * Helper for GenericAutocomplete in radio mode.
+ *
+ * Finds the radio group by `data-testid="autocomplete-radio-group"` (or within a
+ * provided scope), then clicks the radio option whose accessible name matches
+ * `name`.  Works for both initial selection and re-selection.
+ *
+ * Key behaviour:
+ * - Radio options carry `role="radio"` and `aria-label=<service name>`
+ * - The radio row also carries `data-testid="autocomplete-radio-option"`
+ * - Clicking the currently-selected option deselects it (toggle behaviour)
+ *
+ * @example
+ * await selectFromRadio(page, { name: "Main Pharmacy" });
+ * await selectFromRadio(page, { name: "Lab Services", scope: page.locator("#form-section") });
+ */
+export async function selectFromRadio(
+  page: Page,
+  { name, scope }: SelectFromRadioOptions,
+) {
+  const root = scope ?? page;
+  const radioGroup = root
+    .locator('[data-testid="autocomplete-radio-group"]')
+    .first();
+  await radioGroup.waitFor({ state: "visible" });
+
+  const radioOption = radioGroup.getByRole("radio", { name });
+  await radioOption.waitFor({ state: "visible" });
+  await radioOption.scrollIntoViewIfNeeded();
+  await radioOption.click();
+}

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -731,7 +731,8 @@ export async function selectFromGenericAutocomplete(
     .locator('[data-testid="autocomplete-radio-group"]')
     .first();
   const isRadioMode = await radioGroup
-    .isVisible({ timeout: 2000 })
+    .waitFor({ state: "visible", timeout: 2000 })
+    .then(() => true)
     .catch(() => false);
 
   if (isRadioMode) {

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -694,48 +694,6 @@ export async function clickTabOrMenuItem(
   );
 }
 
-interface SelectFromRadioOptions {
-  /** Accessible name (aria-label) of the radio option to select. */
-  name: string;
-  /**
-   * Locator scoping the search to a specific container.
-   * Defaults to the whole page when omitted.
-   */
-  scope?: Locator;
-}
-
-/**
- * Helper for GenericAutocomplete in radio mode.
- *
- * Finds the radio group by `data-testid="autocomplete-radio-group"` (or within a
- * provided scope), then clicks the radio option whose accessible name matches
- * `name`.  Works for both initial selection and re-selection.
- *
- * Key behaviour:
- * - Radio options carry `role="radio"` and `aria-label=<service name>`
- * - The radio row also carries `data-testid="autocomplete-radio-option"`
- * - Clicking the currently-selected option deselects it (toggle behaviour)
- *
- * @example
- * await selectFromRadio(page, { name: "Main Pharmacy" });
- * await selectFromRadio(page, { name: "Lab Services", scope: page.locator("#form-section") });
- */
-export async function selectFromRadio(
-  page: Page,
-  { name, scope }: SelectFromRadioOptions,
-) {
-  const root = scope ?? page;
-  const radioGroup = root
-    .locator('[data-testid="autocomplete-radio-group"]')
-    .first();
-  await radioGroup.waitFor({ state: "visible" });
-
-  const radioOption = radioGroup.getByRole("radio", { name });
-  await radioOption.waitFor({ state: "visible" });
-  await radioOption.scrollIntoViewIfNeeded();
-  await radioOption.click();
-}
-
 interface SelectFromGenericAutocompleteOptions {
   /**
    * Accessible name of the option to select (used in radio mode and as the


### PR DESCRIPTION
## Summary

Introduces `GenericAutocomplete<T>`, a typed replacement for `Autocomplete` that adds radio-button rendering when options fit on-screen.

### Changes

**New component: `src/components/ui/generic-autocomplete.tsx`**
- `GenericAutocomplete<T>` — generic over the option value type (`T = string` by default for drop-in compatibility)
- `RADIO_TRIGGER_MAX_OPTIONS = 5` exported constant — radio buttons render when `enableRadio=true` and loaded option count ≤ 5
- Auto-fallback to searchable dropdown/drawer when count > 5 (threshold is checked against the *unfiltered* eager-fetch, not mid-search results)
- Toggle-to-deselect in radio mode (when `clearSelection=true`, re-clicking the selected radio clears it)
- Radio mode is inline on all breakpoints (no bottom drawer)
- `renderOption` / `renderTrigger` render props for rich option rows (used by `HealthcareServiceSelector`)
- `data-testid="autocomplete-radio-group"` + `data-testid="autocomplete-radio-option"` on radio elements; `role="radio"` + `aria-label` for accessible names

**Deprecated: `src/components/ui/autocomplete.tsx`**
- `@deprecated` JSDoc added — no behaviour change, all ~20 existing consumers untouched
- Migration is a drop-in rename for `string`-valued usages

**Refactored: `src/pages/Facility/services/HealthcareServiceSelector.tsx`**
- Now uses `GenericAutocomplete` with `enableRadio={true}` — shows radio buttons when ≤ 5 services, searchable dropdown otherwise
- Eager-fetches (removed `enabled: open`) so the loaded count is available before any dropdown opens
- `renderOption` / `renderTrigger` preserve the existing `ColoredIndicator` + DuoTone `CareIcon` + name + `extra_details` visuals in both radio and dropdown modes

**Tests**
- `tests/helper/ui.ts` — added `selectFromGenericAutocomplete` helper (mode-agnostic: radio when ≤5 options, dropdown otherwise)
- `tests/facility/settings/activityDefinition/activityDefinition.ts` — `createActivityDefinition` updated for new service selector
- `tests/facility/settings/activityDefinition/activityDefinitionEdit.spec.ts` — edit spec updated; pre-fill assertion works in both modes

### Migration guide

For simple string-valued dropdowns, just rename the import:

```diff
- import Autocomplete from "@/components/ui/autocomplete";
+ import GenericAutocomplete from "@/components/ui/generic-autocomplete";

- <Autocomplete options={opts} value={v} onChange={onChange} />
+ <GenericAutocomplete options={opts} value={v} onChange={onChange} />
```

For rich option rendering, supply `renderOption` and/or `renderTrigger`.

Tagging: @ohcnetwork/care-fe-code-reviewers

Closes #ENG-648

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable autocomplete control with searchable dropdowns, radio-style selections, loading states, customizable options, clear actions, and responsive mobile/desktop layouts.
  - Healthcare service selection now uses the new autocomplete experience, with improved service icons, details, and selection handling.

- **Documentation**
  - Marked the previous autocomplete component as deprecated and identified the new component as its replacement for string-based selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->