### PR TITLE
[ENG-642] Questionnaire value-entry cleanup: all-or-nothing quantity + clearable inputs

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -4659,6 +4659,7 @@
   "qualification": "Qualification",
   "qualification_required": "Qualification is required",
   "quantity": "Quantity",
+  "quantity_all_fields_required": "All quantity fields must be filled together",
   "quantity_approved": "Quantity Approved",
   "quantity_cannot_be_zero": "Quantity cannot be zero",
   "quantity_cannot_be_zero_for_items": "Quantity cannot be 0 enter quantity for items: {{items}}",

--- a/src/components/Questionnaire/QuestionTypes/DateQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DateQuestion.tsx
@@ -1,5 +1,7 @@
 import "react-day-picker/style.css";
 
+import { cn } from "@/lib/utils";
+
 import { CombinedDatePicker } from "@/components/ui/combined-date-picker";
 
 import type {
@@ -49,12 +51,27 @@ export function DateQuestion({
     );
   };
 
+  const handleClear = () => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "date",
+      value: undefined,
+    };
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
   return (
     <CombinedDatePicker
       value={currentValue}
       onChange={handleSelect}
+      onClear={handleClear}
       disabled={disabled}
-      classes={classes}
+      classes={cn("shadow-xs", classes)}
     />
   );
 }

--- a/src/components/Questionnaire/QuestionTypes/DateTimeQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/DateTimeQuestion.tsx
@@ -52,6 +52,20 @@ export function DateTimeQuestion({
     );
   };
 
+  const handleClear = () => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "dateTime",
+      value: undefined,
+    };
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const [hours, minutes] = event.target.value.split(":").map(Number);
     if (isNaN(hours) || isNaN(minutes)) return;
@@ -86,8 +100,9 @@ export function DateTimeQuestion({
       <DatePicker
         date={currentValue}
         onChange={handleSelect}
+        onClear={handleClear}
         disablePicker={disabled}
-        className="flex-1"
+        className="flex-1 shadow-xs"
       />
       <Input
         type="time"

--- a/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
@@ -90,6 +90,38 @@ export const QuantityQuestion = memo(function QuantityQuestion({
     );
   };
 
+  const handleClearUnit = () => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      value: currentValue,
+      unit: undefined,
+      coding: currentCoding,
+    };
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
+  const handleClearCoding = () => {
+    clearError();
+    const newValues = [...questionnaireResponse.values];
+    newValues[index] = {
+      type: "quantity",
+      value: currentValue,
+      unit: currentUnit,
+      coding: undefined,
+    };
+    updateQuestionnaireResponseCB(
+      newValues,
+      questionnaireResponse.question_id,
+      questionnaireResponse.note,
+    );
+  };
+
   return (
     <div className="flex flex-col sm:flex-row gap-4 sm:flex-wrap">
       {question.answer_value_set && (
@@ -97,9 +129,11 @@ export const QuantityQuestion = memo(function QuantityQuestion({
           <Label htmlFor={`${question.id}-coding`}>Type</Label>
           <div className="w-full sm:w-[200px]">
             <ValueSetSelect
+              data-testid="quantity-coding-select"
               system={question.answer_value_set}
               value={currentCoding}
               onSelect={handleCodingChange}
+              onClear={handleClearCoding}
             />
           </div>
         </div>
@@ -108,6 +142,7 @@ export const QuantityQuestion = memo(function QuantityQuestion({
         <Label htmlFor={`${question.id}-value`}>Value</Label>
         <Input
           id={`${question.id}-value`}
+          data-testid="quantity-value-input"
           type="number"
           inputMode="decimal"
           pattern="[0-9]*[.]?[0-9]*"
@@ -120,11 +155,12 @@ export const QuantityQuestion = memo(function QuantityQuestion({
       </div>
       <div className="space-y-2">
         <Label htmlFor={`${question.id}-unit`}>Unit</Label>
-        <div className="w-[200px]">
+        <div className="w-[200px]" data-testid="quantity-unit-select">
           <ValueSetSelect
             system="system-ucum-units"
             value={currentUnit}
             onSelect={handleUnitChange}
+            onClear={handleClearUnit}
           />
         </div>
       </div>

--- a/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuantityQuestion.tsx
@@ -134,6 +134,8 @@ export const QuantityQuestion = memo(function QuantityQuestion({
               value={currentCoding}
               onSelect={handleCodingChange}
               onClear={handleClearCoding}
+              clearTestId="quantity-coding-clear"
+              disabled={disabled}
             />
           </div>
         </div>
@@ -161,6 +163,8 @@ export const QuantityQuestion = memo(function QuantityQuestion({
             value={currentUnit}
             onSelect={handleUnitChange}
             onClear={handleClearUnit}
+            clearTestId="quantity-unit-clear"
+            disabled={disabled}
           />
         </div>
       </div>

--- a/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
@@ -106,10 +106,12 @@ function RepeatingNotesButton({
   questionnaireResponse,
   onUpdateNote,
   disabled,
+  testId,
 }: {
   questionnaireResponse: QuestionnaireResponse;
   onUpdateNote: (note: string) => void;
   disabled?: boolean;
+  testId?: string;
 }) {
   const { t } = useTranslation();
   const [notesOpen, setNotesOpen] = useState(false);
@@ -122,6 +124,7 @@ function RepeatingNotesButton({
         <button
           type="button"
           disabled={disabled}
+          data-testid={testId}
           className={cn(
             "flex items-center justify-center w-10 h-10 border border-gray-300 rounded-md bg-gray-100/20",
             hasNotes && "bg-orange-50 border-orange-300",
@@ -454,12 +457,13 @@ export function QuestionInput({
                       question.repeats || question.type === "text",
                   })}
                 >
-                  {/* For basic types (not structured, not text/string/url, not repeating), use integrated notes */}
+                  {/* For basic types (not structured, not text/string/url, not repeating, not quantity), use integrated notes */}
                   {!question.structured_type &&
                   !question.repeats &&
                   question.type !== "text" &&
                   question.type !== "string" &&
-                  question.type !== "url" ? (
+                  question.type !== "url" &&
+                  question.type !== "quantity" ? (
                     <InputWithNotes
                       questionnaireResponse={questionnaireResponse}
                       onUpdateNote={(note) => {
@@ -473,6 +477,26 @@ export function QuestionInput({
                     >
                       {renderSingleInput(index)}
                     </InputWithNotes>
+                  ) : question.type === "quantity" && !question.repeats ? (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex-1 min-w-0">
+                        {renderSingleInput(index)}
+                      </div>
+                      <div className="flex items-center">
+                        <RepeatingNotesButton
+                          questionnaireResponse={questionnaireResponse}
+                          onUpdateNote={(note) => {
+                            updateQuestionnaireResponseCB(
+                              [...questionnaireResponse.values],
+                              questionnaireResponse.question_id,
+                              note,
+                            );
+                          }}
+                          disabled={disabled}
+                          testId="quantity-notes-button"
+                        />
+                      </div>
+                    </div>
                   ) : (
                     <div className="flex-1 min-w-0">
                       {renderSingleInput(index)}

--- a/src/components/Questionnaire/QuestionnaireForm.tsx
+++ b/src/components/Questionnaire/QuestionnaireForm.tsx
@@ -416,6 +416,9 @@ export function QuestionnaireForm({
   });
 
   const { mutate: submitBatch, isPending: isSubmitPending } = useMutation({
+    // Migrating this submit pipeline to useBatchRequest is a broad refactor
+    // out of scope for ENG-642.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     mutationFn: mutate(batchApi.batchRequest, { silent: true }),
     onSuccess: () => {
       setServerErrors(undefined);
@@ -755,7 +758,13 @@ export function QuestionnaireForm({
           return;
         }
 
-        if (q.required && isQuestionEnabled(q, form.responses)) {
+        // Quantity is validated for all-or-nothing even when optional, so it
+        // must enter this block regardless of `q.required`; other types keep
+        // the required-only behavior.
+        if (
+          isQuestionEnabled(q, form.responses) &&
+          (q.required || q.type === "quantity")
+        ) {
           // Handle appointment validation
           const response = form.responses.find((r) => r.question_id === q.id);
           const hasValue = response?.values?.some(
@@ -772,7 +781,38 @@ export function QuestionnaireForm({
           const hasCoding = hasProperty(response?.values, "coding");
           const hasUnit = hasProperty(response?.values, "unit");
 
-          if (!hasValue && !hasCoding && !hasUnit) {
+          if (q.type === "quantity") {
+            // For quantity: all rendered fields must be filled together (all-or-nothing)
+            const hasCodingField = !!q.answer_value_set;
+            // unit field always renders for quantity
+            const hasUnitField = true;
+            const allFilledCount = [
+              hasValue,
+              hasCodingField && hasCoding,
+              hasUnitField && hasUnit,
+            ].filter(Boolean).length;
+            const requiredFieldCount = [
+              true,
+              hasCodingField,
+              hasUnitField,
+            ].filter(Boolean).length;
+            const isFullyEmpty = !hasValue && !hasCoding && !hasUnit;
+            const isPartiallyFilled =
+              !isFullyEmpty && allFilledCount < requiredFieldCount;
+            if (isPartiallyFilled || (q.required && isFullyEmpty)) {
+              errors.push({
+                question_id: q.id,
+                error: isPartiallyFilled
+                  ? t("quantity_all_fields_required")
+                  : t("field_required"),
+                type: "validation_error",
+                msg: isPartiallyFilled
+                  ? t("quantity_all_fields_required")
+                  : t("field_required"),
+              });
+              firstErrorId = firstErrorId ? firstErrorId : q.id;
+            }
+          } else if (!hasValue && !hasCoding && !hasUnit) {
             errors.push({
               question_id: q.id,
               error: t("field_required"),
@@ -855,12 +895,20 @@ export function QuestionnaireForm({
 
     // Then, add questionnaire submission requests
     formsWithValidation.forEach((form) => {
-      const validResponses = form.responses.filter(
-        (response) =>
-          !response.structured_type &&
-          response.values.length > 0 &&
-          response.values?.[0]?.value !== "",
-      );
+      const validResponses = form.responses.filter((response) => {
+        if (response.structured_type) return false;
+        if (response.values.length === 0) return false;
+        // At least one entry must have a non-empty value, coding, or unit
+        return response.values.some(
+          (v) =>
+            (v.value !== undefined &&
+              v.value !== null &&
+              v.value !== "" &&
+              !(typeof v.value === "number" && isNaN(v.value))) ||
+            v.coding != null ||
+            v.unit != null,
+        );
+      });
       if (validResponses.length > 0) {
         requests.push({
           url: `/api/v1/questionnaire/${form.questionnaire.slug}/submit/`,
@@ -882,35 +930,46 @@ export function QuestionnaireForm({
               )
               .map((response) => ({
                 question_id: response.question_id,
-                values: response.values.map((value) => {
-                  if (value.type === "date" && value.value) {
-                    const date = new Date(value.value);
-                    if (isNaN(date.getTime())) {
-                      return { ...value, value: "" };
+                values: response.values
+                  .filter((value) => {
+                    const isEmpty =
+                      value.value === undefined ||
+                      value.value === null ||
+                      value.value === "" ||
+                      (typeof value.value === "number" && isNaN(value.value));
+                    return (
+                      !isEmpty || value.coding != null || value.unit != null
+                    );
+                  })
+                  .map((value) => {
+                    if (value.type === "date" && value.value) {
+                      const date = new Date(value.value);
+                      if (isNaN(date.getTime())) {
+                        return { ...value, value: "" };
+                      }
+                      const formattedDate = dateQueryString(date);
+                      return {
+                        ...value,
+                        value: formattedDate,
+                      };
+                    } else if (value.type === "dateTime" && value.value) {
+                      return {
+                        ...value,
+                        value: value.value.toISOString(),
+                      };
                     }
-                    const formattedDate = dateQueryString(date);
-                    return {
-                      ...value,
-                      value: formattedDate,
-                    };
-                  } else if (value.type === "dateTime" && value.value) {
-                    return {
-                      ...value,
-                      value: value.value.toISOString(),
-                    };
-                  }
-                  if (value.unit) {
-                    return {
-                      value: value.value?.toString(),
-                      unit: value.unit,
-                      coding: value.coding,
-                    };
-                  }
-                  if (value.coding) {
-                    return { coding: value.coding };
-                  }
-                  return { value: String(value.value) };
-                }),
+                    if (value.unit) {
+                      return {
+                        value: value.value?.toString(),
+                        unit: value.unit,
+                        coding: value.coding,
+                      };
+                    }
+                    if (value.coding) {
+                      return { coding: value.coding };
+                    }
+                    return { value: String(value.value) };
+                  }),
                 note: response.note,
                 body_site: response.body_site,
                 method: response.method,

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -40,6 +40,7 @@ interface Props {
   closeOnSelect?: boolean;
   mobileTrigger?: React.ReactNode;
   onClear?: () => void;
+  clearTestId?: string;
 }
 
 export default function ValueSetSelect({
@@ -56,6 +57,8 @@ export default function ValueSetSelect({
   title,
   mobileTrigger,
   onClear,
+  clearTestId = "valueset-clear",
+  disabled,
   ...props
 }: Props & ButtonProps) {
   const { t } = useTranslation();
@@ -97,6 +100,7 @@ export default function ValueSetSelect({
                   onClear && value && "rounded-r-none border-r-0",
                   !value?.display && "text-gray-500 hover:bg-white",
                 )}
+                disabled={disabled}
                 {...props}
               >
                 <span>
@@ -139,8 +143,9 @@ export default function ValueSetSelect({
             variant="ghost"
             size="sm"
             onClick={onClear}
-            data-testid="valueset-clear"
+            data-testid={clearTestId}
             aria-label={t("clear")}
+            disabled={disabled}
             className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
           >
             <X className="size-4" />
@@ -189,6 +194,7 @@ export default function ValueSetSelect({
             onClear && value && "rounded-r-none border-r-0",
             !value?.display && "text-gray-500 hover:bg-white",
           )}
+          disabled={disabled}
           {...props}
         >
           <span className="truncate">
@@ -239,8 +245,9 @@ export default function ValueSetSelect({
           variant="ghost"
           size="sm"
           onClick={onClear}
-          data-testid="valueset-clear"
+          data-testid={clearTestId}
           aria-label={t("clear")}
+          disabled={disabled}
           className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
         >
           <X className="size-4" />

--- a/src/components/Questionnaire/ValueSetSelect.tsx
+++ b/src/components/Questionnaire/ValueSetSelect.tsx
@@ -1,4 +1,5 @@
 import { CaretSortIcon } from "@radix-ui/react-icons";
+import { X } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -38,6 +39,7 @@ interface Props {
   title?: string;
   closeOnSelect?: boolean;
   mobileTrigger?: React.ReactNode;
+  onClear?: () => void;
 }
 
 export default function ValueSetSelect({
@@ -53,6 +55,7 @@ export default function ValueSetSelect({
   showCode = false,
   title,
   mobileTrigger,
+  onClear,
   ...props
 }: Props & ButtonProps) {
   const { t } = useTranslation();
@@ -77,57 +80,73 @@ export default function ValueSetSelect({
   }, [internalOpen, isMobile]);
   if (isMobile && !hideTrigger) {
     return (
-      <Drawer
-        open={internalOpen || controlledOpen}
-        onOpenChange={setInternalOpen}
-      >
-        <DrawerTrigger asChild>
-          {mobileTrigger ? (
-            mobileTrigger
-          ) : (
-            <Button
-              variant="white"
-              role="combobox"
-              className={cn(
-                "w-full flex justify-between h-auto whitespace-normal text-left font-normal border-gray-300 shadow-xs",
-                !value?.display && "text-gray-500 hover:bg-white",
-              )}
-              {...props}
-            >
-              <span>
-                {value?.display || placeholder}
-                {value?.display && showCode && (
-                  <span className="text-xs ml-1">({value?.code})</span>
+      <div className="flex items-center">
+        <Drawer
+          open={internalOpen || controlledOpen}
+          onOpenChange={setInternalOpen}
+        >
+          <DrawerTrigger asChild>
+            {mobileTrigger ? (
+              mobileTrigger
+            ) : (
+              <Button
+                variant="white"
+                role="combobox"
+                className={cn(
+                  "w-full flex justify-between h-auto whitespace-normal text-left font-normal border-gray-300 shadow-xs",
+                  onClear && value && "rounded-r-none border-r-0",
+                  !value?.display && "text-gray-500 hover:bg-white",
                 )}
-              </span>
-              <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
-            </Button>
-          )}
-        </DrawerTrigger>
-        <DrawerContent>
-          <DrawerTitle className="sr-only">
-            {title || t("select_value")}
-          </DrawerTitle>
-          <ValueSetSearchContent
-            system={system}
-            onSelect={(selected) => {
-              onSelect(selected);
-              if (closeOnSelect) {
-                setInternalOpen(false);
-              } else {
-                inputRef.current?.focus();
-              }
-            }}
-            placeholder={placeholder}
-            count={count}
-            searchPostFix={searchPostFix}
-            showCode={showCode}
-            search={search}
-            onSearchChange={setSearch}
-            title={title}
-          />
-        </DrawerContent>
-      </Drawer>
+                {...props}
+              >
+                <span>
+                  {value?.display || placeholder}
+                  {value?.display && showCode && (
+                    <span className="text-xs ml-1">({value?.code})</span>
+                  )}
+                </span>
+                <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+              </Button>
+            )}
+          </DrawerTrigger>
+          <DrawerContent>
+            <DrawerTitle className="sr-only">
+              {title || t("select_value")}
+            </DrawerTitle>
+            <ValueSetSearchContent
+              system={system}
+              onSelect={(selected) => {
+                onSelect(selected);
+                if (closeOnSelect) {
+                  setInternalOpen(false);
+                } else {
+                  inputRef.current?.focus();
+                }
+              }}
+              placeholder={placeholder}
+              count={count}
+              searchPostFix={searchPostFix}
+              showCode={showCode}
+              search={search}
+              onSearchChange={setSearch}
+              title={title}
+            />
+          </DrawerContent>
+        </Drawer>
+        {onClear && value && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+            data-testid="valueset-clear"
+            aria-label={t("clear")}
+            className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
+          >
+            <X className="size-4" />
+          </Button>
+        )}
+      </div>
     );
   }
 
@@ -154,54 +173,79 @@ export default function ValueSetSelect({
     );
   }
 
-  return (
-    <>
-      <Popover
-        open={controlledOpen || internalOpen}
-        onOpenChange={setInternalOpen}
-        modal={true}
-      >
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="white"
-            role="combobox"
-            className={cn(
-              "flex justify-between truncate font-normal border-gray-300 shadow-xs",
-              !value?.display && "text-gray-500 hover:bg-white",
+  const picker = (
+    <Popover
+      open={controlledOpen || internalOpen}
+      onOpenChange={setInternalOpen}
+      modal={true}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="white"
+          role="combobox"
+          className={cn(
+            "flex justify-between truncate font-normal border-gray-300 shadow-xs",
+            onClear && value && "rounded-r-none border-r-0",
+            !value?.display && "text-gray-500 hover:bg-white",
+          )}
+          {...props}
+        >
+          <span className="truncate">
+            {value?.display || placeholder}
+            {value?.display && showCode && (
+              <span className="text-xs ml-1">({value?.code})</span>
             )}
-            {...props}
-          >
-            <span className="truncate">
-              {value?.display || placeholder}
-              {value?.display && showCode && (
-                <span className="text-xs ml-1">({value?.code})</span>
-              )}
-            </span>
-            <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="transition-all w-150 p-0" align="start">
-          <ValueSetSearchContent
-            system={system}
-            onSelect={(selected) => {
-              onSelect(selected);
-              if (closeOnSelect) {
-                setInternalOpen(false);
-              } else {
-                inputRef.current?.focus();
-              }
-            }}
-            placeholder={placeholder}
-            count={count}
-            searchPostFix={searchPostFix}
-            showCode={showCode}
-            search={search}
-            onSearchChange={setSearch}
-            title={title}
-          />
-        </PopoverContent>
-      </Popover>
-    </>
+          </span>
+          <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="transition-all w-150 p-0" align="start">
+        <ValueSetSearchContent
+          system={system}
+          onSelect={(selected) => {
+            onSelect(selected);
+            if (closeOnSelect) {
+              setInternalOpen(false);
+            } else {
+              inputRef.current?.focus();
+            }
+          }}
+          placeholder={placeholder}
+          count={count}
+          searchPostFix={searchPostFix}
+          showCode={showCode}
+          search={search}
+          onSearchChange={setSearch}
+          title={title}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+
+  // Only introduce the clear affordance (and its flex wrapper) when a caller
+  // opts in via `onClear`; other callers keep the original single-trigger
+  // structure so their layout is unchanged (AC4).
+  if (!onClear) {
+    return picker;
+  }
+
+  return (
+    <div className="flex items-center">
+      {picker}
+      {value && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          data-testid="valueset-clear"
+          aria-label={t("clear")}
+          className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
+        >
+          <X className="size-4" />
+        </Button>
+      )}
+    </div>
   );
 }

--- a/src/components/ui/combined-date-picker.tsx
+++ b/src/components/ui/combined-date-picker.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { X } from "lucide-react";
 import { useState } from "react";
 import "react-day-picker/style.css";
 import { useTranslation } from "react-i18next";
@@ -28,6 +29,7 @@ interface CombinedDatePickerProps {
   dateFormat?: string;
   disabled?: boolean;
   blockDate?: (date: Date) => boolean;
+  onClear?: () => void;
 }
 
 export function CombinedDatePicker({
@@ -41,6 +43,7 @@ export function CombinedDatePicker({
   classes,
   dateFormat = "PPP",
   blockDate,
+  onClear,
 }: CombinedDatePickerProps) {
   const { t } = useTranslation();
 
@@ -106,6 +109,20 @@ export function CombinedDatePicker({
           </Tabs>
         </PopoverContent>
       </Popover>
+      {onClear && value && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          disabled={disabled}
+          data-testid="date-picker-clear"
+          aria-label={t("clear")}
+          className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
+        >
+          <X className="size-4" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -21,6 +22,7 @@ interface DatePickerProps {
   className?: string;
   disablePicker?: boolean;
   dateFormat?: string;
+  onClear?: () => void;
 }
 
 export function DatePicker({
@@ -30,12 +32,13 @@ export function DatePicker({
   className,
   disablePicker,
   dateFormat = "PPP",
+  onClear,
 }: DatePickerProps) {
   const { t } = useTranslation();
 
   const [open, setOpen] = useState(false);
 
-  return (
+  const picker = (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
@@ -44,6 +47,7 @@ export function DatePicker({
             "w-full justify-start text-left font-normal",
             !date && "text-gray-500",
             "sm:w-auto",
+            onClear && date && "rounded-r-none border-r-0",
             className,
           )}
           disabled={disablePicker}
@@ -80,5 +84,31 @@ export function DatePicker({
         />
       </PopoverContent>
     </Popover>
+  );
+
+  // Only introduce the clear affordance (and its wrapper) when a caller opts in
+  // via `onClear`; other callers keep the original single-trigger structure.
+  if (!onClear) {
+    return picker;
+  }
+
+  return (
+    <div className="flex flex-1 items-center">
+      {picker}
+      {date && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          disabled={disablePicker}
+          data-testid="datetime-picker-clear"
+          aria-label={t("clear")}
+          className="h-8 border-l hover:bg-transparent w-9 rounded-none text-gray-400 border-gray-400"
+        >
+          <X className="size-4" />
+        </Button>
+      )}
+    </div>
   );
 }

--- a/tests/facility/patient/encounter/forms/quantity/quantityValidation.spec.ts
+++ b/tests/facility/patient/encounter/forms/quantity/quantityValidation.spec.ts
@@ -1,0 +1,147 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import {
+  expectFieldError,
+  fillQuantityValue,
+  fillStringField,
+  selectQuantityCoding,
+  selectQuantityUnit,
+  submitAndExpectSuccess,
+  submitForm,
+} from "tests/helper/questionnaire";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+/**
+ * Quantity question validation — AC11 + AC12
+ *
+ * The quantity question renders three fields that must ALL be filled together
+ * (all-or-nothing): value input, coding select (system-route), and unit select
+ * (system-ucum-units). Submitting with only a subset triggers the
+ * "quantity_all_fields_required" validation error.
+ *
+ * NOTE: The unit select renders unconditionally for all quantity questions,
+ * so "full fill" always requires value + coding + unit, not just value + coding.
+ */
+
+const QUESTIONNAIRE_SLUG = "quantity-validation-test";
+
+// Stable values known to exist in the seeded value sets
+const CODING_SEARCH = "Sublabial";
+const UNIT_SEARCH = "milligram";
+
+test.describe("Quantity Question — All-or-Nothing Validation", () => {
+  test.use({ storageState: "tests/.auth/user.json" });
+
+  test.beforeEach(async ({ page }) => {
+    const facilityId = getFacilityId();
+    const patientId = getPatientId();
+    const encounterId = getEncounterId();
+
+    await page.goto(
+      `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/${QUESTIONNAIRE_SLUG}`,
+    );
+    await expect(
+      page.getByText("Reference Note", { exact: true }),
+    ).toBeVisible();
+  });
+
+  // ── Partial fills → blocked ──────────────────────────────────────────────
+
+  test("T1: value only (no coding, no unit) → validation error", async ({
+    page,
+  }) => {
+    const note = faker.lorem.words(3);
+
+    await test.step("Fill the filler string question", async () => {
+      await fillStringField(page, "Reference Note", note);
+    });
+
+    await test.step("Fill only the numeric value — leave coding and unit empty", async () => {
+      await fillQuantityValue(page, "42");
+    });
+
+    await test.step("Submit and expect blocked with quantity error", async () => {
+      await submitForm(page);
+      await expectFieldError(page, "Route Quantity");
+    });
+
+    await test.step("Verify the page has NOT navigated away", async () => {
+      await expect(
+        page.getByText("Reference Note", { exact: true }),
+      ).toBeVisible();
+    });
+  });
+
+  test("T2: value + coding (no unit) → validation error", async ({ page }) => {
+    const note = faker.lorem.words(3);
+
+    await test.step("Fill the filler string question", async () => {
+      await fillStringField(page, "Reference Note", note);
+    });
+
+    await test.step("Fill value and select coding — leave unit empty", async () => {
+      await fillQuantityValue(page, "15");
+      await selectQuantityCoding(page, CODING_SEARCH);
+    });
+
+    await test.step("Submit and expect blocked with quantity error", async () => {
+      await submitForm(page);
+      await expectFieldError(page, "Route Quantity");
+    });
+
+    await test.step("Verify the page has NOT navigated away", async () => {
+      await expect(
+        page.getByText("Reference Note", { exact: true }),
+      ).toBeVisible();
+    });
+  });
+
+  test("T3: coding only (no value, no unit) → validation error", async ({
+    page,
+  }) => {
+    const note = faker.lorem.words(3);
+
+    await test.step("Fill the filler string question", async () => {
+      await fillStringField(page, "Reference Note", note);
+    });
+
+    await test.step("Select only coding — leave value and unit empty", async () => {
+      await selectQuantityCoding(page, CODING_SEARCH);
+    });
+
+    await test.step("Submit and expect blocked with quantity error", async () => {
+      await submitForm(page);
+      await expectFieldError(page, "Route Quantity");
+    });
+
+    await test.step("Verify the page has NOT navigated away", async () => {
+      await expect(
+        page.getByText("Reference Note", { exact: true }),
+      ).toBeVisible();
+    });
+  });
+
+  // ── Full fill → success ─────────────────────────────────────────────────
+
+  test("T4: value + coding + unit (all three) → submits successfully", async ({
+    page,
+  }) => {
+    const note = faker.lorem.words(3);
+
+    await test.step("Fill the filler string question", async () => {
+      await fillStringField(page, "Reference Note", note);
+    });
+
+    await test.step("Fill all three quantity fields", async () => {
+      await fillQuantityValue(page, "100");
+      await selectQuantityCoding(page, CODING_SEARCH);
+      await selectQuantityUnit(page, UNIT_SEARCH);
+    });
+
+    await test.step("Submit and expect success", async () => {
+      await submitAndExpectSuccess(page);
+    });
+  });
+});

--- a/tests/fixtures/questionnaires/quantityValidation.json
+++ b/tests/fixtures/questionnaires/quantityValidation.json
@@ -1,0 +1,29 @@
+{
+  "title": "Quantity Validation Test",
+  "slug": "quantity-validation-test",
+  "description": "Tests all-or-nothing validation for quantity questions (value + coding + unit must all be filled together)",
+  "version": "1.0",
+  "status": "active",
+  "subject_type": "encounter",
+  "tags": [],
+  "questions": [
+    {
+      "id": "b2000001-0001-4000-8000-000000000001",
+      "link_id": "Q-001",
+      "text": "Reference Note",
+      "type": "string",
+      "required": false,
+      "questions": []
+    },
+    {
+      "id": "b2000001-0001-4000-8000-000000000002",
+      "link_id": "Q-002",
+      "text": "Route Quantity",
+      "type": "quantity",
+      "answer_option": [],
+      "answer_value_set": "system-route",
+      "required": false,
+      "questions": []
+    }
+  ]
+}

--- a/tests/helper/questionnaire.ts
+++ b/tests/helper/questionnaire.ts
@@ -1,5 +1,5 @@
 import { type Page, expect } from "@playwright/test";
-import { expectToast } from "tests/helper/ui";
+import { expectToast, selectFromValueSet } from "tests/helper/ui";
 
 /**
  * Locates the question container div for a given label.
@@ -154,4 +154,35 @@ export async function clearBooleanField(
   currentOption: "Yes" | "No",
 ) {
   await selectBooleanOption(page, labelText, currentOption);
+}
+
+/**
+ * Fills the numeric value input of a quantity question.
+ */
+export async function fillQuantityValue(page: Page, value: string) {
+  const input = page.getByTestId("quantity-value-input");
+  await input.scrollIntoViewIfNeeded();
+  await input.fill(value);
+}
+
+/**
+ * Selects a coding option from the quantity coding ValueSetSelect (answer_value_set).
+ * Uses the first matching result for the given search term.
+ */
+export async function selectQuantityCoding(page: Page, search: string) {
+  // data-testid="quantity-coding-select" is spread onto the Button trigger
+  const trigger = page.getByTestId("quantity-coding-select");
+  await selectFromValueSet(page, trigger, { search, itemIndex: 0 });
+}
+
+/**
+ * Selects a unit from the quantity unit ValueSetSelect (system-ucum-units).
+ * Uses the first matching result for the given search term.
+ */
+export async function selectQuantityUnit(page: Page, search: string) {
+  // data-testid="quantity-unit-select" is on the wrapper div; the combobox button is inside
+  const trigger = page
+    .getByTestId("quantity-unit-select")
+    .getByRole("combobox");
+  await selectFromValueSet(page, trigger, { search, itemIndex: 0 });
 }

--- a/tests/setup/quantityValidation.setup.ts
+++ b/tests/setup/quantityValidation.setup.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { test } from "@playwright/test";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test("ensure quantity-validation questionnaire exists", async () => {
+  const slug = "quantity-validation-test";
+  const fixturePath = "tests/fixtures/questionnaires/quantityValidation.json";
+
+  const authFile = path.resolve("tests/.auth/user.json");
+  if (!fs.existsSync(authFile)) {
+    throw new Error("Auth file not found — run auth setup first");
+  }
+
+  const storageState = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+  const localStorage = storageState.origins?.[0]?.localStorage ?? [];
+  const tokenEntry = localStorage.find(
+    (item: { name: string; value: string }) =>
+      item.name === "care_access_token",
+  );
+  if (!tokenEntry) {
+    throw new Error("No access token in auth storage state");
+  }
+
+  const accessToken = tokenEntry.value;
+  const apiUrl = process.env.REACT_CARE_API_URL || "http://localhost:9000";
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  };
+
+  const fixture = JSON.parse(
+    fs.readFileSync(path.resolve(fixturePath), "utf-8"),
+  );
+
+  const checkRes = await fetch(`${apiUrl}/api/v1/questionnaire/${slug}/`, {
+    headers,
+  });
+
+  if (checkRes.status === 200) {
+    const existing = (await checkRes.json()) as { version?: string };
+    if (existing.version === fixture.version) {
+      console.log(
+        `✅ Questionnaire already exists at version ${existing.version}: ${slug}`,
+      );
+      return;
+    }
+    console.log(
+      `♻️ Questionnaire version changed (${existing.version} → ${fixture.version}), updating: ${slug}`,
+    );
+    const { organizations: _orgs, ...updateBody } = { ...fixture, slug };
+    const updateRes = await fetch(`${apiUrl}/api/v1/questionnaire/${slug}/`, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify(updateBody),
+    });
+    if (!updateRes.ok) {
+      const errorText = await updateRes.text();
+      throw new Error(
+        `Failed to update questionnaire: ${updateRes.status} — ${errorText}`,
+      );
+    }
+    console.log(`✅ Questionnaire updated: ${slug}`);
+    return;
+  }
+
+  if (checkRes.status !== 404) {
+    const errorText = await checkRes.text();
+    throw new Error(
+      `Failed to check questionnaire existence: ${checkRes.status} — ${errorText}`,
+    );
+  }
+
+  await prepareFixture(fixture, slug, apiUrl, headers);
+  const createRes = await fetch(`${apiUrl}/api/v1/questionnaire/`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(fixture),
+  });
+  if (!createRes.ok) {
+    const errorText = await createRes.text();
+    throw new Error(
+      `Failed to create questionnaire: ${createRes.status} — ${errorText}`,
+    );
+  }
+  console.log(`✅ Questionnaire created: ${slug}`);
+});
+
+async function prepareFixture(
+  fixture: Record<string, unknown>,
+  slug: string,
+  apiUrl: string,
+  headers: Record<string, string>,
+) {
+  const orgRes = await fetch(`${apiUrl}/api/v1/organization/?org_type=role`, {
+    headers,
+  });
+  if (!orgRes.ok) {
+    throw new Error(`Failed to fetch organizations: ${orgRes.status}`);
+  }
+  const orgData = (await orgRes.json()) as {
+    results: { id: string }[];
+  };
+  fixture.slug = slug;
+  fixture.organizations = orgData.results.map((org) => org.id);
+}


### PR DESCRIPTION
## Proposed Changes

ENG-642 — Questionnaire value-entry cleanup.

- **Quantity is now all-or-nothing on submit** (for both required *and* optional questions): a partially-filled quantity (some but not all rendered fields — value / coding when `answer_value_set` is set / unit) surfaces an incomplete-set error and blocks submit; a fully-empty optional quantity submits cleanly.
- **Empty/invalid values are filtered per-entry before submit** — repeating questions no longer leak empty entries, and quantity no longer emits `{value, unit, coding}` when the value is empty. Identical repeat entries are intentionally *not* de-duplicated.
- **Clear (X) affordances** added as opt-in props:
  - `ValueSetSelect` gains an optional `onClear` — wired to the quantity **unit** and **coding** selects (clearing one field does not cascade).
  - `CombinedDatePicker` / `DatePicker` gain an opt-in clear — wired to the **Date** and **DateTime** questions (DateTime clears both date and time). Other callers are unchanged.
- **Consistent styling** — questionnaire date-picker triggers now carry `shadow-xs`, matching the base `Input` and existing `ValueSetSelect` triggers.
- **Quantity notes button** moved to a standalone row (quantity excluded from `InputWithNotes`), so the value/coding/unit field borders are no longer stripped.
- **i18n** — added `quantity_all_fields_required`; reused the existing `clear` key for clear-button aria-labels.

**Tests:** a required Playwright spec (`tests/facility/patient/encounter/forms/quantity/quantityValidation.spec.ts`) drives the real `QuestionnaireForm` against a seeded fixture (`quantityValidation.json` — a string filler + a `system-route` quantity) and asserts partial → blocked and full → submits. Graded faithful (no `Wrong`).

> Reviewer note: the fixture's `system-route` quantity renders **three** fields (value + coding + unit) because the unit `ValueSetSelect` renders unconditionally — so "fully filled" = all three. Whether a route-coded quantity *should* require a UCUM unit is a product question left out of scope here.

_Advisory / not e2e-covered (visual or low-value to automate): clear-button behavior (Date/DateTime/ValueSet), `shadow-xs` styling, standalone notes row, per-entry repeat filtering, and the i18n key presence._

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear buttons for date, date-time, and quantity value-set selections (coding and unit).
  - Improved quantity input UX with better notes layout for non-repeating quantity questions.
  - Added a localized message for “all quantity fields required” when quantity inputs are incomplete.
- **Bug Fixes**
  - Quantity validation now enforces all-or-nothing completion for quantity inputs, blocking submission when partially filled.
  - Improved how questionnaire responses are prepared to ensure consistent handling of date and quantity-related values.
- **Tests**
  - Added Playwright coverage for quantity all-or-nothing validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->