### PR TITLE
feat(ENG-648): add GenericAutocomplete<T> with radio mode

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -59,6 +59,18 @@ interface AutocompleteProps {
   shortcutId?: string;
 }
 
+/**
+ * @deprecated Use `GenericAutocomplete` from `@/components/ui/generic-autocomplete`
+ * instead. `GenericAutocomplete` supports TypeScript generics, radio mode, and a
+ * richer render-prop API.
+ *
+ * **Migration guide:**
+ * - Rename `Autocomplete` → `GenericAutocomplete`.
+ * - Add `emptyValue=""` if your state is typed as `string` (keeps the rename
+ *   zero-diff; remove it when you migrate the state type to `string | null`).
+ * - `freeInput` is not yet supported in `GenericAutocomplete`; leave those sites
+ *   on this component until a follow-up lands.
+ */
 export default function Autocomplete({
   options,
   isLoading = false,

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -1,0 +1,398 @@
+import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
+
+import useBreakpoints from "@/hooks/useBreakpoints";
+import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+
+/**
+ * Radio mode activates when `enableRadio` is true AND the option count is
+ * within this threshold. Exported so consumers can size their queries.
+ */
+export const RADIO_OPTIONS_THRESHOLD = 5;
+
+export interface GenericAutocompleteOption<T> {
+  label: string;
+  value: T;
+}
+
+export interface GenericAutocompleteProps<T> {
+  options: GenericAutocompleteOption<T>[];
+  /**
+   * The currently selected value, or `null` for no selection.
+   *
+   * **Migration note (from `Autocomplete`):** `Autocomplete` used `""` as the
+   * empty sentinel; `GenericAutocomplete` uses `null`. For a near-zero-diff
+   * rename, pass `emptyValue=""` and keep your state as `string`.
+   * Remove `emptyValue` once you migrate the state to `null`.
+   */
+  value: T | null;
+  onChange: (value: T | null) => void;
+  /**
+   * Derives a stable string key from a value for equality comparisons and
+   * React keys. Defaults to `String(value)`.
+   */
+  getOptionKey?: (value: T) => string;
+  /**
+   * Renders each option row — used in **both** dropdown and radio mode, so
+   * rich items (icon + label + subtitle) look identical in both presentations.
+   * Receives `isSelected` for optional highlight styling; the selection
+   * indicator (checkmark / radio button) is rendered by the component.
+   *
+   * When omitted, falls back to the plain `option.label` string.
+   */
+  renderOption?: (
+    option: GenericAutocompleteOption<T>,
+    isSelected: boolean,
+  ) => React.ReactNode;
+  /**
+   * Renders the selected value inside the trigger button (dropdown mode only).
+   * When omitted, falls back to the matched option's label.
+   */
+  renderValue?: (value: T) => React.ReactNode;
+  /**
+   * Renders an inline `RadioGroup` instead of the searchable dropdown when
+   * `options.length <= RADIO_OPTIONS_THRESHOLD`. Ignored when the list is
+   * larger than the threshold.
+   */
+  enableRadio?: boolean;
+  /**
+   * Show a "None" row (radio mode) or a clear button (dropdown mode) that
+   * resets the selection to `null` / `emptyValue`.
+   */
+  clearSelection?: boolean;
+  /**
+   * **Migration compat:** When set, `onChange` emits this value instead of
+   * `null` when clearing. Use `emptyValue=""` to keep string-typed state
+   * working without changes while migrating from `Autocomplete`.
+   */
+  emptyValue?: T;
+  isLoading?: boolean;
+  onSearch?: (value: string) => void;
+  placeholder?: string;
+  inputPlaceholder?: string;
+  noOptionsMessage?: string;
+  disabled?: boolean;
+  align?: "start" | "center" | "end";
+  className?: string;
+  popoverClassName?: string;
+  popoverContentClassName?: string;
+  closeOnSelect?: boolean;
+  showClearButton?: boolean;
+  ref?: React.RefCallback<HTMLButtonElement | null>;
+  "aria-invalid"?: boolean;
+  shortcutId?: string;
+}
+
+export default function GenericAutocomplete<T>({
+  options,
+  value,
+  onChange,
+  getOptionKey = (v) => String(v),
+  renderOption,
+  renderValue,
+  enableRadio = false,
+  clearSelection = false,
+  emptyValue,
+  isLoading = false,
+  onSearch,
+  placeholder = "Select...",
+  inputPlaceholder = "Search option...",
+  noOptionsMessage = "No options found",
+  disabled,
+  align = "center",
+  className,
+  popoverClassName,
+  popoverContentClassName,
+  closeOnSelect = true,
+  showClearButton = true,
+  ref,
+  shortcutId,
+  ...props
+}: GenericAutocompleteProps<T>) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const isMobile = useBreakpoints({ default: true, sm: false });
+
+  const showRadio =
+    enableRadio && options.length > 0 && options.length <= RADIO_OPTIONS_THRESHOLD;
+
+  const selectedOption = React.useMemo(
+    () =>
+      value !== null
+        ? options.find((o) => getOptionKey(o.value) === getOptionKey(value))
+        : undefined,
+    [options, value, getOptionKey],
+  );
+
+  const emitEmpty = () =>
+    onChange(emptyValue !== undefined ? emptyValue : null);
+
+  const handleSelect = (option: GenericAutocompleteOption<T>) => {
+    onChange(option.value);
+    if (closeOnSelect) setOpen(false);
+  };
+
+  // ── Radio mode ─────────────────────────────────────────────────────────────
+  if (showRadio) {
+    const radioKey = value !== null ? getOptionKey(value) : "__none__";
+
+    return (
+      <RadioGroup
+        value={radioKey}
+        onValueChange={(key) => {
+          if (key === "__none__") {
+            emitEmpty();
+            return;
+          }
+          const opt = options.find((o) => getOptionKey(o.value) === key);
+          if (opt) onChange(opt.value);
+        }}
+        disabled={disabled}
+        className="gap-2"
+      >
+        {clearSelection && (
+          <label
+            htmlFor="radio-option-none"
+            className="flex items-center gap-3 cursor-pointer rounded-md border border-gray-200 px-3 py-2 transition-colors hover:bg-gray-50 has-[[data-state=checked]]:border-primary-200 has-[[data-state=checked]]:bg-primary-50"
+          >
+            <RadioGroupItem value="__none__" id="radio-option-none" />
+            <span className="text-sm text-gray-500">{t("none")}</span>
+          </label>
+        )}
+        {options.map((option) => {
+          const key = getOptionKey(option.value);
+          const isSelected = value !== null && getOptionKey(value) === key;
+          return (
+            <label
+              key={key}
+              htmlFor={`radio-option-${key}`}
+              className="flex items-center gap-3 cursor-pointer rounded-md border border-gray-200 px-3 py-2 transition-colors hover:bg-gray-50 has-[[data-state=checked]]:border-primary-200 has-[[data-state=checked]]:bg-primary-50"
+            >
+              <RadioGroupItem value={key} id={`radio-option-${key}`} />
+              <div className="flex-1 min-w-0">
+                {renderOption
+                  ? renderOption(option, isSelected)
+                  : option.label}
+              </div>
+            </label>
+          );
+        })}
+      </RadioGroup>
+    );
+  }
+
+  // ── Dropdown mode ───────────────────────────────────────────────────────────
+  const triggerContent =
+    value !== null
+      ? renderValue
+        ? renderValue(value)
+        : selectedOption?.label ?? placeholder
+      : undefined;
+
+  const commandContent = (
+    <>
+      <CommandInput
+        placeholder={inputPlaceholder}
+        disabled={disabled}
+        onValueChange={(v) => onSearch?.(v)}
+        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
+        autoFocus
+      />
+      <CommandList className="overflow-y-auto">
+        {isLoading ? (
+          <CardListSkeleton count={3} />
+        ) : (
+          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+        )}
+        <CommandGroup>
+          {options.map((option) => {
+            const key = getOptionKey(option.value);
+            const isSelected =
+              value !== null && getOptionKey(value) === key;
+            return (
+              <CommandItem
+                key={key}
+                value={`${option.label} - ${key}`}
+                onSelect={() => handleSelect(option)}
+                className="cursor-pointer"
+              >
+                {renderOption ? (
+                  <div className="flex items-center w-full">
+                    <div className="flex-1 min-w-0">
+                      {renderOption(option, isSelected)}
+                    </div>
+                    {isSelected && (
+                      <CheckIcon className="ml-auto shrink-0 size-4" />
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <CheckIcon
+                      className={cn(
+                        "mr-2 size-4",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option.label}
+                  </>
+                )}
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </>
+  );
+
+  const hasSelection = selectedOption !== undefined;
+
+  if (isMobile) {
+    return (
+      <div className="flex relative w-full">
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerTrigger asChild>
+            <Button
+              aria-invalid={props["aria-invalid"]}
+              variant="outline"
+              ref={ref}
+              role="combobox"
+              aria-expanded={open}
+              className={cn(
+                "w-full justify-between",
+                className,
+                hasSelection && showClearButton && "rounded-r-none",
+              )}
+              disabled={disabled}
+              type="button"
+            >
+              <span className="overflow-hidden">
+                {triggerContent ?? (
+                  <span className="text-gray-500">{placeholder}</span>
+                )}
+              </span>
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent
+            aria-describedby={undefined}
+            className="min-h-[50vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
+          >
+            <DrawerTitle className="sr-only">{placeholder}</DrawerTitle>
+            <div className="mt-6 pb-[env(safe-area-inset-bottom)] flex-1 overflow-y-auto">
+              <Command shouldFilter={false}>{commandContent}</Command>
+            </div>
+          </DrawerContent>
+        </Drawer>
+        {hasSelection && showClearButton ? (
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-l-none border-l-0 text-gray-400 h-auto"
+            onClick={emitEmpty}
+            title={t("clear")}
+            hidden={disabled}
+          >
+            <Cross2Icon />
+            <span className="sr-only">{t("clear")}</span>
+          </Button>
+        ) : (
+          <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex relative w-full">
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
+        <PopoverTrigger asChild className={popoverClassName}>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-invalid={props["aria-invalid"]}
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-between",
+              className,
+              hasSelection && showClearButton && "rounded-r-none",
+            )}
+            disabled={disabled}
+            onClick={() => setOpen(!open)}
+            ref={ref}
+            data-shortcut-id={shortcutId}
+          >
+            <span
+              className={cn(
+                "overflow-hidden flex-1 text-left",
+                !triggerContent && "text-gray-500",
+              )}
+            >
+              {triggerContent ?? placeholder}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]",
+            popoverContentClassName,
+          )}
+          align={align}
+        >
+          <Command shouldFilter={false}>{commandContent}</Command>
+        </PopoverContent>
+      </Popover>
+      {hasSelection && showClearButton ? (
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-l-none border-l-0 text-gray-400 h-auto"
+          onClick={emitEmpty}
+          title={t("clear")}
+          hidden={disabled}
+        >
+          <Cross2Icon />
+          <span className="sr-only">{t("clear")}</span>
+        </Button>
+      ) : (
+        <>
+          {shortcutId ? (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <div className="flex items-center justify-center gap-1">
+                <ShortcutBadge actionId={shortcutId} />
+                <CaretSortIcon className="size-3 shrink-0 opacity-50" />
+              </div>
+            </div>
+          ) : (
+            <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -151,6 +151,15 @@ export default function GenericAutocomplete<T>({
     [options, value, getOptionKey],
   );
 
+  // When clearSelection is explicitly set, it gates clearing in all modes.
+  // When not set, showClearButton controls the dropdown clear button (Autocomplete compat).
+  const canClear =
+    clearSelection !== undefined && clearSelection !== false
+      ? true
+      : clearSelection === false
+        ? false
+        : showClearButton;
+
   const emitEmpty = () =>
     onChange(emptyValue !== undefined ? emptyValue : null);
 
@@ -271,7 +280,8 @@ export default function GenericAutocomplete<T>({
     </>
   );
 
-  const hasSelection = selectedOption !== undefined;
+  // W3: base on value, not options — value stays known even when filtered options don't include it.
+  const hasSelection = value !== null;
 
   if (isMobile) {
     return (
@@ -287,7 +297,7 @@ export default function GenericAutocomplete<T>({
               className={cn(
                 "w-full justify-between",
                 className,
-                hasSelection && showClearButton && "rounded-r-none",
+                hasSelection && canClear && "rounded-r-none",
               )}
               disabled={disabled}
               type="button"
@@ -309,8 +319,9 @@ export default function GenericAutocomplete<T>({
             </div>
           </DrawerContent>
         </Drawer>
-        {hasSelection && showClearButton ? (
+        {hasSelection && canClear ? (
           <Button
+            type="button"
             variant="outline"
             size="icon"
             className="rounded-l-none border-l-0 text-gray-400 h-auto"
@@ -340,7 +351,7 @@ export default function GenericAutocomplete<T>({
             className={cn(
               "w-full justify-between",
               className,
-              hasSelection && showClearButton && "rounded-r-none",
+              hasSelection && canClear && "rounded-r-none",
             )}
             disabled={disabled}
             onClick={() => setOpen(!open)}
@@ -367,8 +378,9 @@ export default function GenericAutocomplete<T>({
           <Command shouldFilter={false}>{commandContent}</Command>
         </PopoverContent>
       </Popover>
-      {hasSelection && showClearButton ? (
+      {hasSelection && canClear ? (
         <Button
+          type="button"
           variant="outline"
           size="icon"
           className="rounded-l-none border-l-0 text-gray-400 h-auto"

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -1,6 +1,4 @@
-import { CaretDownIcon, CheckIcon } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
-import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,29 +6,11 @@ import ColoredIndicator from "@/CAREUI/display/ColoredIndicator";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 import duoToneIcons from "@/CAREUI/icons/DuoTonePaths.json";
 
-import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import GenericAutocomplete, {
+  GenericAutocompleteOption,
+} from "@/components/ui/generic-autocomplete";
 
 import query from "@/Utils/request/query";
-import useBreakpoints from "@/hooks/useBreakpoints";
 import {
   HealthcareServiceReadSpec,
   InternalType,
@@ -47,6 +27,44 @@ interface HealthcareServiceSelectorProps {
   internalType?: InternalType;
 }
 
+const getServiceIconName = (name: string): DuoToneIconName =>
+  `d-${name}` as DuoToneIconName;
+
+function ServiceItemContent({
+  service,
+}: {
+  service: HealthcareServiceReadSpec;
+}) {
+  return (
+    <div className="flex items-center gap-2 w-full min-w-0">
+      <div className="relative size-6 rounded-sm shrink-0 flex items-center justify-center">
+        <ColoredIndicator
+          id={service.id}
+          className="absolute inset-0 rounded-sm opacity-20"
+        />
+        <CareIcon
+          icon={
+            service.styling_metadata?.careIcon
+              ? getServiceIconName(service.styling_metadata.careIcon)
+              : "d-health-worker"
+          }
+          className="size-4 relative z-1"
+        />
+      </div>
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="truncate text-sm font-medium" title={service.name}>
+          {service.name}
+        </span>
+        {service.extra_details && (
+          <span className="text-xs text-gray-500 truncate">
+            {service.extra_details}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export const HealthcareServiceSelector = ({
   facilityId,
   selected,
@@ -55,15 +73,9 @@ export const HealthcareServiceSelector = ({
   internalType,
 }: HealthcareServiceSelectorProps) => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
-  const isMobile = useBreakpoints({ default: true, sm: false });
 
-  const {
-    data: services,
-    isLoading,
-    isFetching,
-  } = useQuery({
+  const { data: services, isLoading } = useQuery({
     queryKey: ["healthcareServices", facilityId, searchValue, internalType],
     queryFn: query.debounced(healthcareServiceApi.listHealthcareService, {
       pathParams: { facilityId },
@@ -73,149 +85,27 @@ export const HealthcareServiceSelector = ({
         ...(searchValue && { name: searchValue }),
       },
     }),
-    enabled: open,
   });
 
-  const getIconName = (name: string): DuoToneIconName =>
-    `d-${name}` as DuoToneIconName;
-
-  const triggerButton = (
-    <Button
-      variant="outline"
-      role="combobox"
-      className="min-w-60 w-full justify-start"
-      disabled={isLoading}
-    >
-      {selected ? (
-        <div className="flex items-center gap-2">
-          <div className="relative size-6 rounded-sm flex items-center justify-center">
-            <ColoredIndicator
-              id={selected.id}
-              className="absolute inset-0 rounded-sm opacity-20"
-            />
-            <CareIcon
-              icon={
-                selected.styling_metadata?.careIcon
-                  ? getIconName(selected.styling_metadata.careIcon)
-                  : "d-health-worker"
-              }
-              className="size-4 relative z-1"
-            />
-          </div>
-          <span className="truncate">{selected.name}</span>
-        </div>
-      ) : (
-        <span className="text-gray-400">{t("select_healthcare_service")}</span>
-      )}
-      <CaretDownIcon className="ml-auto" />
-    </Button>
-  );
-
-  const commandContent = (
-    <Command shouldFilter={false}>
-      <CommandInput
-        placeholder={t("search")}
-        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm"
-        value={searchValue}
-        onValueChange={setSearchValue}
-        autoFocus
-      />
-      <CommandList>
-        <CommandEmpty>
-          {isFetching ? t("searching") : t("no_services_found")}
-        </CommandEmpty>
-        <CommandGroup>
-          {selected && clearSelection && (
-            <CommandItem
-              onSelect={() => {
-                onSelect(null);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full h-9"
-            >
-              <>
-                <XIcon />
-                <span> {t("clear_selection")}</span>
-              </>
-            </CommandItem>
-          )}
-          {services?.results.map((service) => (
-            <CommandItem
-              key={service.id}
-              value={service.name}
-              onSelect={() => {
-                onSelect(service);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full"
-            >
-              <div className="flex items-center gap-2 w-full">
-                <div className="relative size-6 rounded-sm flex items-center justify-center">
-                  <ColoredIndicator
-                    id={service.id}
-                    className="absolute inset-0 rounded-sm opacity-20"
-                  />
-                  <CareIcon
-                    icon={
-                      service.styling_metadata?.careIcon
-                        ? getIconName(service.styling_metadata.careIcon)
-                        : "d-health-worker"
-                    }
-                    className="size-4 relative z-1"
-                  />
-                </div>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span
-                    className="truncate text-sm font-medium"
-                    title={service.name}
-                  >
-                    {service.name}
-                  </span>
-                  {service.extra_details && (
-                    <span className="text-xs text-gray-500 truncate">
-                      {service.extra_details}
-                    </span>
-                  )}
-                </div>
-                {selected?.id === service.id && (
-                  <CheckIcon className="ml-auto" />
-                )}
-              </div>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  );
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={setOpen} direction="bottom">
-        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-        <DrawerContent
-          aria-describedby={undefined}
-          className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
-        >
-          <DrawerTitle className="sr-only">
-            {t("select_healthcare_service")}
-          </DrawerTitle>
-          <div className="mt-6 h-full">{commandContent}</div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
+  const options: GenericAutocompleteOption<HealthcareServiceReadSpec>[] = (
+    services?.results ?? []
+  ).map((s) => ({ label: s.name, value: s }));
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild disabled={isLoading}>
-        {triggerButton}
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 w-(--radix-popover-trigger-width)"
-        align="start"
-      >
-        {commandContent}
-      </PopoverContent>
-    </Popover>
+    <GenericAutocomplete<HealthcareServiceReadSpec>
+      options={options}
+      value={selected}
+      onChange={onSelect}
+      getOptionKey={(s) => s.id}
+      isLoading={isLoading}
+      onSearch={setSearchValue}
+      placeholder={t("select_healthcare_service")}
+      noOptionsMessage={t("no_services_found")}
+      enableRadio
+      clearSelection={clearSelection}
+      renderOption={(option) => <ServiceItemContent service={option.value} />}
+      renderValue={(service) => <ServiceItemContent service={service} />}
+      className="min-w-60"
+    />
   );
 };

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -100,6 +100,7 @@ export const HealthcareServiceSelector = ({
       isLoading={isLoading}
       onSearch={setSearchValue}
       placeholder={t("select_healthcare_service")}
+      inputPlaceholder={t("search")}
       noOptionsMessage={t("no_services_found")}
       enableRadio
       clearSelection={clearSelection}


### PR DESCRIPTION
## Changes

### New: `GenericAutocomplete<T>` (`src/components/ui/generic-autocomplete.tsx`)

A generic-typed replacement for `Autocomplete` with:

- **TypeScript generics** — `value: T | null`, `onChange: (v: T | null) => void`, `getOptionKey`, `renderOption`, `renderValue`
- **Radio mode** — exported `RADIO_OPTIONS_THRESHOLD = 5` constant; renders an inline `RadioGroup` when `enableRadio && 0 < options.length ≤ 5`, otherwise falls back to the searchable popover/drawer
- **Shared render prop** — `renderOption(option, isSelected)` used in both radio rows and dropdown items, so rich content (icon + label + subtitle) looks identical in both modes
- **`emptyValue` compat prop** — migration escape hatch: pass `emptyValue=""` to keep `string`-typed state working without changes; remove once state is migrated to `null`
- Same responsive Popover/Drawer + keyboard/a11y behaviour as `Autocomplete`

### Deprecated: `Autocomplete` (`src/components/ui/autocomplete.tsx`)

Added `@deprecated` JSDoc with migration guide. No runtime change.

### Refactored: `HealthcareServiceSelector`

- Now uses `GenericAutocomplete<HealthcareServiceReadSpec>`
- `renderOption`/`renderValue` render ColoredIndicator + CareIcon + name + `extra_details` — identical in radio and dropdown mode
- Radio enabled: ≤ 5 services → inline radio buttons; > 5 → searchable dropdown
- Fetches on mount (removed `enabled: open`) so the radio threshold is always known
- Public props (`selected`, `onSelect`, `facilityId`, `clearSelection`, `internalType`) unchanged — existing consumers compile without changes

## Migration guide (for other devs)

```tsx
// Near-zero-diff rename (string case — add emptyValue to keep state type as string):
<GenericAutocomplete value={val} onChange={setVal} emptyValue="" ... />

// Full migration (null-aware state):
<GenericAutocomplete<string> value={val ?? null} onChange={(v) => setVal(v ?? "")} ... />
```

See the `@deprecated` JSDoc on `Autocomplete` for the full note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flexible autocomplete component with searchable dropdowns, radio selection, loading and empty states, custom rendering, clearing, and mobile-friendly presentation.
  * Added support for keyboard shortcuts, accessibility states, and configurable selection behavior.

* **Improvements**
  * Updated healthcare service selection with faster, streamlined searching and clearer service details.

* **Migration**
  * Marked the previous autocomplete component as deprecated and added guidance for switching to the new component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->