### PR TITLE
[ENG-753] Resolve react-hooks/preserve-manual-memoization violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -159,7 +159,6 @@ const config = [
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/refs": "warn",
       "react-hooks/static-components": "warn",
-      "react-hooks/preserve-manual-memoization": "warn",
       "react-hooks/immutability": "warn",
       "react-hooks/purity": "warn",
     },

--- a/src/components/Common/RoleOrgSelector.tsx
+++ b/src/components/Common/RoleOrgSelector.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Building, ChevronDown, Loader2, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -244,13 +244,10 @@ export default function RoleOrgSelector(props: RoleOrgSelectorProps) {
     );
   };
 
-  const isDisabled = useMemo(() => {
-    return (
-      selectedOrganizations.some((org) => org.id === currentSelection?.id) ||
-      (!!currentOrganizations &&
-        currentOrganizations.some((org) => org.id === currentSelection?.id))
-    );
-  }, [currentSelection, currentOrganizations, selectedOrganizations]);
+  const isDisabled =
+    selectedOrganizations.some((org) => org.id === currentSelection?.id) ||
+    (!!currentOrganizations &&
+      currentOrganizations.some((org) => org.id === currentSelection?.id));
 
   return (
     <div className="space-y-4">

--- a/src/components/Location/LocationMultiSelect.tsx
+++ b/src/components/Location/LocationMultiSelect.tsx
@@ -395,8 +395,9 @@ export default function LocationMultiSelect({
     });
   }, []);
 
+  const searchLocations = searchResultsData?.results;
   const searchResults = useMemo(() => {
-    if (!searchQuery.trim() || !searchResultsData?.results) return [];
+    if (!searchQuery.trim() || !searchLocations) return [];
 
     const results: Array<{
       location: LocationRead;
@@ -418,13 +419,13 @@ export default function LocationMultiSelect({
       return path;
     };
 
-    searchResultsData.results.forEach((location) => {
+    searchLocations.forEach((location) => {
       const path = buildPath(location);
       results.push({ location, level: path.length, path });
     });
 
     return results;
-  }, [searchQuery, searchResultsData?.results]);
+  }, [searchQuery, searchLocations]);
 
   // Create a map of all available locations for quick lookup
   const locationsMap = useMemo(() => {

--- a/src/components/Medicine/MedicationAdministration/AdministrationTab.tsx
+++ b/src/components/Medicine/MedicationAdministration/AdministrationTab.tsx
@@ -297,17 +297,18 @@ export const AdministrationTab: React.FC<AdministrationTabProps> = ({
     useState<GroupedMedication | null>(null);
 
   // Calculate last modified date
+  const administrationResults = administrations?.results;
   const lastModifiedDate = useMemo(() => {
-    if (!administrations?.results?.length) return null;
+    if (!administrationResults?.length) return null;
 
-    const sortedAdmins = [...administrations.results].sort(
+    const sortedAdmins = [...administrationResults].sort(
       (a, b) =>
         new Date(b.occurrence_period_start).getTime() -
         new Date(a.occurrence_period_start).getTime(),
     );
 
     return new Date(sortedAdmins[0].occurrence_period_start);
-  }, [administrations?.results]);
+  }, [administrationResults]);
 
   // Mutations
   const { mutate: discontinueMedication } = useMutation({

--- a/src/components/ui/sidebar/app-sidebar.tsx
+++ b/src/components/ui/sidebar/app-sidebar.tsx
@@ -91,10 +91,11 @@ export function AppSidebar({
   const [selectedFacility, setSelectedFacility] =
     React.useState<FacilityBareMinimum | null>(null);
 
+  const userOrganizations = user?.organizations;
   const selectedOrganization = React.useMemo(() => {
-    if (!user?.organizations || !organizationId) return undefined;
-    return user.organizations.find((org) => org.id === organizationId);
-  }, [user?.organizations, organizationId]);
+    if (!userOrganizations || !organizationId) return undefined;
+    return userOrganizations.find((org) => org.id === organizationId);
+  }, [userOrganizations, organizationId]);
 
   React.useEffect(() => {
     if (!user?.facilities || !facilityId || !facilitySidebar) {

--- a/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
+++ b/src/pages/Facility/billing/account/components/BedChargeItemsTable.tsx
@@ -244,12 +244,13 @@ function BedChargeItemsTable({
     isLoading: boolean;
   };
 
+  const chargeItemResults = chargeItems?.results;
   const groupedChargeItems = useMemo(() => {
-    if (!chargeItems?.results?.length) {
+    if (!chargeItemResults?.length) {
       return {};
     }
-    return groupChargeItemsByLocation(chargeItems.results);
-  }, [chargeItems?.results]);
+    return groupChargeItemsByLocation(chargeItemResults);
+  }, [chargeItemResults]);
 
   const toggleItemExpand = (itemId: string) => {
     setExpandedItems((prev) => ({

--- a/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
+++ b/src/pages/Facility/settings/organizations/components/FacilityOrganizationSelector.tsx
@@ -572,13 +572,10 @@ export default function FacilityOrganizationSelector(
     );
   };
 
-  const isDisabled = useMemo(() => {
-    return (
-      selectedOrganizations.some((org) => org.id === currentSelection?.id) ||
-      (!!currentOrganizations &&
-        currentOrganizations.some((org) => org.id === currentSelection?.id))
-    );
-  }, [currentSelection, currentOrganizations, selectedOrganizations]);
+  const isDisabled =
+    selectedOrganizations.some((org) => org.id === currentSelection?.id) ||
+    (!!currentOrganizations &&
+      currentOrganizations.some((org) => org.id === currentSelection?.id));
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
> [!NOTE]
> JIRA Ticket: ENG-753

## Proposed Changes

When we upgraded `eslint-plugin-react-hooks` to v7, its `recommended` config started shipping the React Compiler rules. To avoid blocking that (already large) PR, these rules were downgraded to `warn` and slated to be addressed incrementally. This PR fully resolves one of them: `react-hooks/preserve-manual-memoization`.

React Compiler is **not** enabled in the build, so the existing `useMemo`s do real runtime work. Every fix preserves behavior. There were two distinct causes:

- **Optional-chaining dependency mismatch** (4 files): dependency arrays used `x?.results` while the memo body accessed `x.results`, so the compiler inferred a different/broader dependency than declared. Hoisted the accessed value into a local const so the manual deps match exactly what the compiler infers, keeping memoization intact.
  - `LocationMultiSelect.tsx` (`searchLocations`)
  - `AdministrationTab.tsx` (`administrationResults`)
  - `app-sidebar.tsx` (`userOrganizations`)
  - `BedChargeItemsTable.tsx` (`chargeItemResults`)
- **Compiler declines to memoize a primitive** (2 files): `isDisabled` is a boolean derived from cheap `.some()` calls with no downstream identity benefit, so the compiler correctly drops the memoization. Replaced `useMemo` with a plain expression (identical value each render).
  - `RoleOrgSelector.tsx` (also dropped the now-unused `useMemo` import)
  - `FacilityOrganizationSelector.tsx`
- Removed the `"react-hooks/preserve-manual-memoization": "warn"` override in `eslint.config.mjs` so the recommended `error` level now applies and prevents regressions.

Verified: full-project ESLint reports **0** `preserve-manual-memoization` messages at `error` severity, and `tsc --noEmit` shows no new type errors in the edited files. The remaining React Compiler rules (`set-state-in-effect`, `refs`, etc.) stay at `warn` and are out of scope here.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes

N/A - lint-only refactor with no behavioral or UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified organization and role selector disabled-state calculations without changing behavior.
  * Streamlined data processing for locations, medication administrations, sidebar organization selection, and billing charge items.
* **Chores**
  * Updated linting configuration to remove an outdated React hooks warning while retaining other hook checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->