### PR TITLE
[ENG-735] Add pagination in Dispense History selector

### DIFF
--- a/src/components/Medicine/DispenseOrderListSelector.tsx
+++ b/src/components/Medicine/DispenseOrderListSelector.tsx
@@ -67,7 +67,13 @@ export default function DispenseOrderListSelector({
     [data],
   );
 
-  const loadMoreRef = useOnInView<HTMLDivElement>((inView) => {
+  const loadMoreRefMobile = useOnInView<HTMLDivElement>((inView) => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
+
+  const loadMoreRefDesktop = useOnInView<HTMLDivElement>((inView) => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
@@ -114,7 +120,7 @@ export default function DispenseOrderListSelector({
           dispenseOrders={dispenseOrders}
           selectedDispenseOrderId={selectedDispenseOrderId}
           onSelectDispenseOrder={onSelectDispenseOrder}
-          loadMoreRef={loadMoreRef}
+          loadMoreRef={loadMoreRefDesktop}
           isFetchingNextPage={isFetchingNextPage}
         />
       </div>
@@ -159,7 +165,7 @@ export default function DispenseOrderListSelector({
                 dispenseOrders={dispenseOrders}
                 selectedDispenseOrderId={selectedDispenseOrderId}
                 onSelectDispenseOrder={handleSelectDispenseOrder}
-                loadMoreRef={loadMoreRef}
+                loadMoreRef={loadMoreRefMobile}
                 isFetchingNextPage={isFetchingNextPage}
               />
             </div>

--- a/src/components/Medicine/DispenseOrderListSelector.tsx
+++ b/src/components/Medicine/DispenseOrderListSelector.tsx
@@ -1,7 +1,9 @@
 import { cn } from "@/lib/utils";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import * as React from "react";
+import { useEffect, useMemo } from "react";
 
+import { RESULTS_PER_PAGE_LIMIT } from "@/common/constants";
 import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -18,6 +20,7 @@ import query from "@/Utils/request/query";
 import { formatDateTime } from "@/Utils/utils";
 import { ChevronDown, PackageIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useOnInView } from "react-intersection-observer";
 
 interface DispenseOrderListSelectorProps {
   patientId: string;
@@ -34,15 +37,40 @@ export default function DispenseOrderListSelector({
 }: DispenseOrderListSelectorProps) {
   const { t } = useTranslation();
   const [openDrawer, setOpenDrawer] = React.useState(false);
-  const { data: dispenseOrders, isLoading } = useQuery({
-    queryKey: ["dispenseOrders", patientId, facilityId],
-    queryFn: query(dispenseOrderApi.list, {
-      pathParams: { facilityId: facilityId ?? "" },
-      queryParams: {
-        patient: patientId,
+
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["infinite-dispenseOrders", patientId, facilityId],
+      queryFn: async ({ pageParam = 0, signal }) => {
+        const response = await query(dispenseOrderApi.list, {
+          pathParams: { facilityId: facilityId ?? "" },
+          queryParams: {
+            patient: patientId,
+            limit: String(RESULTS_PER_PAGE_LIMIT),
+            offset: String(pageParam),
+          },
+        })({
+          signal,
+        });
+        return response;
       },
-    }),
-    enabled: !!patientId && !!facilityId,
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const currentOffset = allPages.length * RESULTS_PER_PAGE_LIMIT;
+        return currentOffset < lastPage.count ? currentOffset : null;
+      },
+      enabled: !!facilityId,
+    });
+
+  const dispenseOrders = useMemo(
+    () => data?.pages.flatMap((page) => page.results) ?? [],
+    [data],
+  );
+
+  const loadMoreRef = useOnInView<HTMLDivElement>((inView) => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
   });
 
   function handleSelectDispenseOrder(
@@ -53,10 +81,10 @@ export default function DispenseOrderListSelector({
   }
 
   // Select first dispense order by default
-  React.useEffect(() => {
-    if (dispenseOrders?.results?.length) {
+  useEffect(() => {
+    if (dispenseOrders.length) {
       if (!selectedDispenseOrderId) {
-        onSelectDispenseOrder(dispenseOrders.results[0] as DispenseOrderRead);
+        onSelectDispenseOrder(dispenseOrders[0]);
       }
     } else {
       onSelectDispenseOrder(undefined);
@@ -71,23 +99,23 @@ export default function DispenseOrderListSelector({
     );
   }
 
-  if (!dispenseOrders?.results?.length) {
+  if (!dispenseOrders.length) {
     return null;
   }
 
   const selectedDispenseOrder = selectedDispenseOrderId
-    ? dispenseOrders?.results.find(
-        (order) => order.id === selectedDispenseOrderId,
-      )
+    ? dispenseOrders.find((order) => order.id === selectedDispenseOrderId)
     : undefined;
 
   return (
     <>
       <div className="hidden lg:block h-full overflow-y-auto pr-1">
         <DispenseOrderList
-          dispenseOrders={dispenseOrders.results as DispenseOrderRead[]}
+          dispenseOrders={dispenseOrders}
           selectedDispenseOrderId={selectedDispenseOrderId}
           onSelectDispenseOrder={onSelectDispenseOrder}
+          loadMoreRef={loadMoreRef}
+          isFetchingNextPage={isFetchingNextPage}
         />
       </div>
       <div className="lg:hidden">
@@ -128,9 +156,11 @@ export default function DispenseOrderListSelector({
             </DrawerHeader>
             <div className="overflow-y-auto pr-2">
               <DispenseOrderList
-                dispenseOrders={dispenseOrders.results as DispenseOrderRead[]}
+                dispenseOrders={dispenseOrders}
                 selectedDispenseOrderId={selectedDispenseOrderId}
                 onSelectDispenseOrder={handleSelectDispenseOrder}
+                loadMoreRef={loadMoreRef}
+                isFetchingNextPage={isFetchingNextPage}
               />
             </div>
           </DrawerContent>
@@ -144,15 +174,19 @@ function DispenseOrderList({
   dispenseOrders,
   selectedDispenseOrderId,
   onSelectDispenseOrder,
+  isFetchingNextPage,
+  loadMoreRef,
 }: {
   dispenseOrders: DispenseOrderRead[];
   selectedDispenseOrderId: string | undefined;
   onSelectDispenseOrder: (dispenseOrder: DispenseOrderRead | undefined) => void;
+  isFetchingNextPage: boolean;
+  loadMoreRef: React.Ref<HTMLDivElement>;
 }) {
   const { t } = useTranslation();
   return (
     <div className="space-y-2 p-2">
-      {dispenseOrders.map((dispenseOrder) => {
+      {dispenseOrders.map((dispenseOrder, i) => {
         const isSelected = selectedDispenseOrderId === dispenseOrder.id;
         return (
           <Card
@@ -164,6 +198,7 @@ function DispenseOrderList({
                 : "bg-gray-100 hover:bg-gray-100 shadow-none",
             )}
             onClick={() => onSelectDispenseOrder(dispenseOrder)}
+            ref={i === dispenseOrders.length - 1 ? loadMoreRef : undefined}
           >
             {isSelected && (
               <div className="absolute right-0 h-8 w-1 bg-primary-600 rounded-l inset-y-1/2 -translate-y-1/2" />
@@ -193,6 +228,7 @@ function DispenseOrderList({
           </Card>
         );
       })}
+      {isFetchingNextPage && <CardListSkeleton count={5} />}
     </div>
   );
 }


### PR DESCRIPTION
## Proposed Changes

Fix : [ENG-735]

https://github.com/user-attachments/assets/b19a561f-1027-41a2-a9f0-51b33fd7ce36


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-735]: https://openhealthcarenetwork.atlassian.net/browse/ENG-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infinite scrolling to dispense order lists, automatically loading additional orders as users reach the end.
  * Added a loading indicator while more dispense orders are being fetched.

* **Bug Fixes**
  * Improved default selection behavior by automatically selecting the first available dispense order.
  * Prevented the list from rendering when no dispense orders are available.
  * Improved list handling as additional dispense orders are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->