### PR TITLE
feat(inventory): add expiry date column to supply delivery table (ENG-613)

### DIFF
--- a/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
+++ b/src/pages/Facility/services/inventory/SupplyDeliveryTable.tsx
@@ -190,6 +190,7 @@ export function SupplyDeliveryTable({
           <TableHead rowSpan={2}>{t("#")}</TableHead>
           <TableHead rowSpan={2}>{t("item")}</TableHead>
           <TableHead rowSpan={2}>{t("batch")}</TableHead>
+          <TableHead rowSpan={2}>{t("expiry_date")}</TableHead>
           <TableHead rowSpan={2}>{t("requested_qty")}</TableHead>
           {!internal && <TableHead rowSpan={2}>{t("pack_size")}</TableHead>}
           {!internal && <TableHead rowSpan={2}>{t("pack_qty")}</TableHead>}
@@ -285,6 +286,16 @@ export function SupplyDeliveryTable({
             <TableCell>
               {delivery.supplied_inventory_item?.product?.batch?.lot_number ||
                 "-"}
+            </TableCell>
+            <TableCell>
+              {(() => {
+                const expiryDate = internal
+                  ? delivery.supplied_inventory_item?.product?.expiration_date
+                  : delivery.supplied_item?.expiration_date;
+                return expiryDate
+                  ? formatDate(new Date(expiryDate), "dd/MM/yyyy")
+                  : "-";
+              })()}
             </TableCell>
             <TableCell>
               {delivery.supply_request


### PR DESCRIPTION
## Summary

Adds an **Expiry Date** column after the Batch column in the Supply Delivery Table.

- For **external** deliveries: reads `supplied_item.expiration_date` (from `ProductRead`)
- For **internal** deliveries: reads `supplied_inventory_item.product.expiration_date` (from `InventoryRead.product`)
- Displays date formatted as `dd/MM/yyyy`, falls back to `-` when absent

Closes ENG-613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expiry date column to the supply delivery table.
  * Expiry dates are displayed in `dd/MM/yyyy` format, with “-” shown when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->