### PR TITLE
Feature:  Adds an extension point to support external payment integrations for creating and completing invoice payments.

### DIFF
--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -51,7 +51,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
-import { ChevronUp } from "lucide-react";
+// Remove this line and add ChevronUp to the existing lucide-react import above
 
 import { paymentReconcilationLocationAtom } from "@/atoms/paymentReconcilationLocationAtom";
 import { LocationPicker } from "@/components/Location/LocationPicker";

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -1,27 +1,27 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { t } from "i18next";
-import { useAtom } from "jotai";
-import { useEffect, useMemo, useRef } from "react";
-import { useForm } from "react-hook-form";
-import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
-import * as z from "zod";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { t } from "i18next";
+import { useAtom } from "jotai";
 import {
   Banknote,
   BanknoteArrowUp,
+  ChevronUp,
   CreditCard,
   Landmark,
   Signature,
-  ChevronUp,
 } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import * as z from "zod";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
@@ -59,7 +59,6 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
 import { useCareApps } from "@/hooks/useCareApps";
-import { PLUGIN_Component } from "@/PluginEngine";
 import {
   ExtensionEntityType,
   getCombinedExtensionProps,
@@ -68,6 +67,7 @@ import {
   useExtensionSchemas,
 } from "@/hooks/useExtensions";
 import { register } from "@/lib/override/register";
+import { PLUGIN_Component } from "@/PluginEngine";
 import { AccountRead } from "@/types/billing/account/Account";
 import { InvoiceRead } from "@/types/billing/invoice/invoice";
 import {
@@ -271,7 +271,6 @@ const PaymentReconciliationSheetBase = ({
     }
   }, [selectedLocationObject, form]);
 
-
   const careApps = useCareApps();
   const isInvoiceRecordPaymentPluginsPresent = careApps.some(
     (plugin) =>
@@ -393,11 +392,11 @@ const PaymentReconciliationSheetBase = ({
             {invoice
               ? isCreditNote
                 ? t("recording_refund_for_invoice", {
-                  id: invoice.number,
-                })
+                    id: invoice.number,
+                  })
                 : t("recording_payment_for_invoice", {
-                  id: invoice.number,
-                })
+                    id: invoice.number,
+                  })
               : isCreditNote
                 ? t("recording_refund")
                 : t("recording_payment")}
@@ -747,7 +746,9 @@ const PaymentReconciliationSheetBase = ({
                     type="submit"
                     disabled={isPending || isExtensionsLoading}
                     aria-label={
-                      isCreditNote ? t("record_credit_note") : t("record_payment")
+                      isCreditNote
+                        ? t("record_credit_note")
+                        : t("record_payment")
                     }
                   >
                     {isPending ? (
@@ -771,7 +772,7 @@ const PaymentReconciliationSheetBase = ({
                         <Button
                           variant="outline_primary"
                           size="icon"
-                          aria-label="More Options"
+                          aria-label={t("more_options")}
                         >
                           <ChevronUp />
                         </Button>

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -8,7 +8,12 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import * as z from "zod";
-
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Banknote,
   BanknoteArrowUp,
@@ -22,6 +27,7 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import careConfig from "@careConfig";
 
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import {
   Form,
   FormControl,
@@ -45,12 +51,15 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
+import { ChevronUp } from "lucide-react";
 
 import { paymentReconcilationLocationAtom } from "@/atoms/paymentReconcilationLocationAtom";
 import { LocationPicker } from "@/components/Location/LocationPicker";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useShortcutSubContext } from "@/context/ShortcutContext";
+import { useCareApps } from "@/hooks/useCareApps";
+import { PLUGIN_Component } from "@/PluginEngine";
 import {
   ExtensionEntityType,
   getCombinedExtensionProps,
@@ -262,6 +271,13 @@ const PaymentReconciliationSheetBase = ({
     }
   }, [selectedLocationObject, form]);
 
+
+  const careApps = useCareApps();
+  const isInvoiceRecordPaymentPluginsPresent = careApps.some(
+    (plugin) =>
+      !plugin.isLoading && plugin.components?.InvoiceRecordPaymentOptions,
+  );
+
   const { mutate: submitPayment, isPending } = useMutation({
     mutationFn: mutate(paymentReconciliationApi.createPaymentReconciliation, {
       pathParams: { facilityId },
@@ -377,11 +393,11 @@ const PaymentReconciliationSheetBase = ({
             {invoice
               ? isCreditNote
                 ? t("recording_refund_for_invoice", {
-                    id: invoice.number,
-                  })
+                  id: invoice.number,
+                })
                 : t("recording_payment_for_invoice", {
-                    id: invoice.number,
-                  })
+                  id: invoice.number,
+                })
               : isCreditNote
                 ? t("recording_refund")
                 : t("recording_payment")}
@@ -726,28 +742,51 @@ const PaymentReconciliationSheetBase = ({
                   <ShortcutBadge actionId="cancel-action" />
                 </Button>
 
-                <Button
-                  type="submit"
-                  disabled={isPending || isExtensionsLoading}
-                  aria-label={
-                    isCreditNote ? t("record_credit_note") : t("record_payment")
-                  }
-                >
-                  {isPending ? (
-                    <>
-                      <CareIcon
-                        icon="l-spinner"
-                        className="mr-2 size-4 animate-spin"
-                      />
-                      {t("processing_with_dots")}
-                    </>
-                  ) : isCreditNote ? (
-                    t("record_credit_note")
-                  ) : (
-                    t("record_payment")
+                <ButtonGroup className="w-full">
+                  <Button
+                    type="submit"
+                    disabled={isPending}
+                    aria-label={t("record_payment")}
+                  >
+                    {isPending ? (
+                      <>
+                        <CareIcon
+                          icon="l-spinner"
+                          className="mr-2 size-4 animate-spin"
+                        />
+                        {t("processing_with_dots")}
+                      </>
+                    ) : isCreditNote ? (
+                      t("record_credit_note")
+                    ) : (
+                      t("record_payment")
+                    )}
+                    <ShortcutBadge actionId="submit-action" />
+                  </Button>
+                  {isInvoiceRecordPaymentPluginsPresent && invoice && (
+                    <DropdownMenu modal={false}>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline_primary"
+                          size="icon"
+                          aria-label="More Options"
+                        >
+                          <ChevronUp />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-full">
+                        <DropdownMenuGroup>
+                          <PLUGIN_Component
+                            __name="InvoiceRecordPaymentOptions"
+                            facilityId={facilityId}
+                            invoice={invoice}
+                            form={form}
+                          />
+                        </DropdownMenuGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   )}
-                  <ShortcutBadge actionId="submit-action" />
-                </Button>
+                </ButtonGroup>
               </div>
             </SheetFooter>
           </form>

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -745,8 +745,10 @@ const PaymentReconciliationSheetBase = ({
                 <ButtonGroup className="w-full">
                   <Button
                     type="submit"
-                    disabled={isPending}
-                    aria-label={t("record_payment")}
+                    disabled={isPending || isExtensionsLoading}
+                    aria-label={
+                      isCreditNote ? t("record_credit_note") : t("record_payment")
+                    }
                   >
                     {isPending ? (
                       <>

--- a/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
+++ b/src/pages/Facility/billing/PaymentReconciliationSheet.tsx
@@ -20,6 +20,7 @@ import {
   CreditCard,
   Landmark,
   Signature,
+  ChevronUp,
 } from "lucide-react";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -51,7 +52,6 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
-// Remove this line and add ChevronUp to the existing lucide-react import above
 
 import { paymentReconcilationLocationAtom } from "@/atoms/paymentReconcilationLocationAtom";
 import { LocationPicker } from "@/components/Location/LocationPicker";

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -68,6 +68,7 @@ export type PatientDetailsTabDemographyGeneralInfoComponentType = React.FC<{
 export type InvoiceRecordPaymentOptionsComponentType = React.FC<{
   facilityId: string;
   invoice: InvoiceRead;
+  form: UseFormReturn<any>;
 }>;
 
 export type PatientSearchActionsComponentType = React.FC<{


### PR DESCRIPTION
## Proposed Changes

This change introduces an extension point in the payment reconciliation flow to support external payment integrations. It enables third-party payment providers (e.g., POS/payment gateway integrations) to initiate and complete invoice payments while leveraging the existing billing and reconciliation workflow.

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin-driven “More Options” dropdown in the reconciliation sheet footer for invoice payment actions when supported.
  * Expanded the footer to render the invoice-specific payment options component and improved the submit area layout with a full-width button group.
* **Bug Fixes**
  * Updated invoice-related recording text (payments and refunds/credit notes) to include the invoice number for clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->