### PR TITLE
[ENG-744] Highlight dosages when they aren't 1

### DIFF
--- a/src/components/Medicine/FormattedDosage.tsx
+++ b/src/components/Medicine/FormattedDosage.tsx
@@ -22,7 +22,7 @@ export function FormattedDosage({
   instruction,
   highlight = true,
   className,
-  fallback = "-",
+  fallback = "",
 }: FormattedDosageProps) {
   const text = formatDosage(instruction);
   if (!text) return <>{fallback}</>;

--- a/src/components/Medicine/FormattedDosage.tsx
+++ b/src/components/Medicine/FormattedDosage.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+import { MedicationRequestDosageInstruction } from "@/types/emr/medicationRequest/medicationRequest";
+
+import { formatDosage, isNonUnitDose } from "./utils";
+
+interface FormattedDosageProps {
+  instruction?: MedicationRequestDosageInstruction;
+  /**
+   * Highlight dosages whose value is not a single unit
+   */
+  highlight?: boolean;
+  className?: string;
+  fallback?: string;
+}
+
+/**
+ * Renders a formatted dosage string and, by default, visually highlights
+ * non-unit dosages
+ */
+export function FormattedDosage({
+  instruction,
+  highlight = true,
+  className,
+  fallback = "-",
+}: FormattedDosageProps) {
+  const text = formatDosage(instruction);
+  if (!text) return <>{fallback}</>;
+
+  if (highlight && isNonUnitDose(instruction)) {
+    return (
+      <span
+        className={cn(
+          "rounded bg-yellow-100 px-1.5 py-0.5 font-semibold text-yellow-900",
+          className,
+        )}
+      >
+        {text}
+      </span>
+    );
+  }
+
+  return <span className={className}>{text}</span>;
+}

--- a/src/components/Medicine/FormattedDosage.tsx
+++ b/src/components/Medicine/FormattedDosage.tsx
@@ -7,7 +7,7 @@ import { formatDosage, isNonUnitDose } from "./utils";
 interface FormattedDosageProps {
   instruction?: MedicationRequestDosageInstruction;
   /**
-   * Highlight dosages whose value is not a single unit
+   * Highlight dosages that are dose ranges or whose value is not a single unit
    */
   highlight?: boolean;
   className?: string;
@@ -16,7 +16,7 @@ interface FormattedDosageProps {
 
 /**
  * Renders a formatted dosage string and, by default, visually highlights
- * non-unit dosages
+ * non-unit dosages (dose ranges and quantities ≠ 1)
  */
 export function FormattedDosage({
   instruction,

--- a/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
+++ b/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/tooltip";
 
 import { DosageInstructionList } from "@/components/Medicine/DosageInstructionList";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import { formatDosage, formatFrequency } from "@/components/Medicine/utils";
 
 import { MedicationAdministrationRead } from "@/types/emr/medicationAdministration/medicationAdministration";
@@ -133,16 +134,21 @@ const IndividualMedicationRow: React.FC<{
             )}
             gap="sm"
             renderItem={(di) => {
-              const text = [
-                formatDosage(di),
-                formatFrequency(di),
-                di.method?.display,
-              ]
+              const dosage = formatDosage(di);
+              const instructionText = [formatFrequency(di), di.method?.display]
                 .filter(Boolean)
                 .join(", ");
               return (
                 <div>
-                  {text && <div>{text}</div>}
+                  {(dosage || instructionText) && (
+                    <div>
+                      {dosage && (
+                        <FormattedDosage instruction={di} fallback="" />
+                      )}
+                      {dosage && instructionText && ", "}
+                      {instructionText}
+                    </div>
+                  )}
                   {di.route?.display && (
                     <Badge variant="blue" className="text-xs mt-0.5">
                       {di.route.display}
@@ -397,7 +403,7 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
                     return (
                       <div>
                         <div>
-                          {formatDosage(di)}
+                          <FormattedDosage instruction={di} />
                           {freq && <span className="text-gray-400"> · </span>}
                           {freq}
                           {di.method?.display && (

--- a/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
+++ b/src/components/Medicine/MedicationAdministration/MedicineAdminForm.tsx
@@ -22,12 +22,9 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import { getDosageFromInstruction } from "@/components/Medicine/MedicationAdministration/utils";
-import {
-  formatDosage,
-  formatDuration,
-  formatFrequency,
-} from "@/components/Medicine/utils";
+import { formatDuration, formatFrequency } from "@/components/Medicine/utils";
 
 import { formatName } from "@/Utils/utils";
 import {
@@ -124,7 +121,9 @@ const DosageInstructionSelector: React.FC<DosageInstructionSelectorProps> = ({
           >
             <div>
               <Label className="text-xs text-gray-500">{t("dosage")}</Label>
-              <p className="font-medium">{formatDosage(di)}</p>
+              <p className="font-medium">
+                <FormattedDosage instruction={di} />
+              </p>
             </div>
             <div>
               <Label className="text-xs text-gray-500">{t("frequency")}</Label>
@@ -173,7 +172,9 @@ const DosageInstructionSelector: React.FC<DosageInstructionSelectorProps> = ({
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 gap-4">
                 <div>
                   <Label className="text-xs text-gray-500">{t("dosage")}</Label>
-                  <p className="font-medium">{formatDosage(di)}</p>
+                  <p className="font-medium">
+                    <FormattedDosage instruction={di} />
+                  </p>
                 </div>
                 <div>
                   <Label className="text-xs text-gray-500">
@@ -619,9 +620,8 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
               const isCurrentMedication = req.id === medication.id;
               const canSelect = !isCurrentMedication && onMedicationChange;
               const instructionSummaries = req.dosage_instruction.map((di) => {
-                const dosage = formatDosage(di);
                 const freq = formatFrequency(di);
-                return { dosage, freq };
+                return { di, freq };
               });
               return (
                 <button
@@ -653,7 +653,7 @@ export const MedicineAdminForm: React.FC<MedicineAdminFormProps> = ({
                                 : "text-gray-700"
                             }
                           >
-                            {summary.dosage}
+                            <FormattedDosage instruction={summary.di} />
                           </span>
                           {summary.freq && (
                             <span

--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -19,7 +19,8 @@ import { DispenseButton } from "@/components/Consumable/DispenseButton";
 import { EmptyState } from "@/components/ui/empty-state";
 
 import { DosageInstructionList } from "@/components/Medicine/DosageInstructionList";
-import { formatDosage, formatFrequency } from "@/components/Medicine/utils";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
+import { formatFrequency } from "@/components/Medicine/utils";
 
 import { round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
@@ -172,7 +173,7 @@ export function DispenseHistory({
                   <TableCell className="text-gray-950">
                     <DosageInstructionList
                       instructions={instructions}
-                      renderItem={(di) => formatDosage(di) || "-"}
+                      renderItem={(di) => <FormattedDosage instruction={di} />}
                     />
                   </TableCell>
                   <TableCell className="text-gray-950">

--- a/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
+++ b/src/components/Medicine/MedicationRequestTable/DispenseHistory.tsx
@@ -173,7 +173,9 @@ export function DispenseHistory({
                   <TableCell className="text-gray-950">
                     <DosageInstructionList
                       instructions={instructions}
-                      renderItem={(di) => <FormattedDosage instruction={di} />}
+                      renderItem={(di) => (
+                        <FormattedDosage instruction={di} fallback="-" />
+                      )}
                     />
                   </TableCell>
                   <TableCell className="text-gray-950">

--- a/src/components/Medicine/MedicationsTable.tsx
+++ b/src/components/Medicine/MedicationsTable.tsx
@@ -99,7 +99,9 @@ export const MedicationsTable = ({
                   <TableCell className="py-2 px-3 break-words whitespace-normal">
                     <DosageInstructionList
                       instructions={instructions}
-                      renderItem={(di) => <FormattedDosage instruction={di} />}
+                      renderItem={(di) => (
+                        <FormattedDosage instruction={di} fallback="-" />
+                      )}
                     />
                   </TableCell>
                   <TableCell className="py-2 px-3 break-words whitespace-normal">

--- a/src/components/Medicine/MedicationsTable.tsx
+++ b/src/components/Medicine/MedicationsTable.tsx
@@ -21,12 +21,8 @@ import {
 } from "@/types/emr/medicationRequest/medicationRequest";
 
 import { DosageInstructionList } from "./DosageInstructionList";
-import {
-  formatDosage,
-  formatDuration,
-  formatFrequency,
-  formatSig,
-} from "./utils";
+import { FormattedDosage } from "./FormattedDosage";
+import { formatDuration, formatFrequency, formatSig } from "./utils";
 
 interface MedicationsTableProps {
   medications: MedicationRequestRead[];
@@ -103,7 +99,7 @@ export const MedicationsTable = ({
                   <TableCell className="py-2 px-3 break-words whitespace-normal">
                     <DosageInstructionList
                       instructions={instructions}
-                      renderItem={(di) => formatDosage(di) || "-"}
+                      renderItem={(di) => <FormattedDosage instruction={di} />}
                     />
                   </TableCell>
                   <TableCell className="py-2 px-3 break-words whitespace-normal">

--- a/src/components/Medicine/utils.ts
+++ b/src/components/Medicine/utils.ts
@@ -32,8 +32,8 @@ export function isNonUnitDose(
 
   const { dose_range, dose_quantity } = doseAndRate;
   if (dose_range) return true;
-  if (dose_quantity) return Number(dose_quantity.value) !== 1;
-  return false;
+  if (!dose_quantity?.value) return false;
+  return round(dose_quantity.value) !== round(1);
 }
 
 // Helper function to format dosage instructions in Rx style

--- a/src/components/Medicine/utils.ts
+++ b/src/components/Medicine/utils.ts
@@ -22,7 +22,8 @@ export function formatDosage(instruction?: MedicationRequestDosageInstruction) {
 }
 
 /**
- * Whether a dosage should be highlighted (dose range, or quantity ≠ 1).
+ * Whether a dosage should be highlighted — true for dose ranges and for
+ * quantities whose rounded display value is not exactly 1.
  */
 export function isNonUnitDose(
   instruction?: MedicationRequestDosageInstruction,
@@ -32,7 +33,7 @@ export function isNonUnitDose(
 
   const { dose_range, dose_quantity } = doseAndRate;
   if (dose_range) return true;
-  if (!dose_quantity?.value) return false;
+  if (dose_quantity?.value == null) return false;
   return round(dose_quantity.value) !== round(1);
 }
 

--- a/src/components/Medicine/utils.ts
+++ b/src/components/Medicine/utils.ts
@@ -22,7 +22,7 @@ export function formatDosage(instruction?: MedicationRequestDosageInstruction) {
 }
 
 /**
- * Whether a dosage represents a quantity other than a single unit (value ≠ 1).
+ * Whether a dosage should be highlighted (dose range, or quantity ≠ 1).
  */
 export function isNonUnitDose(
   instruction?: MedicationRequestDosageInstruction,

--- a/src/components/Medicine/utils.ts
+++ b/src/components/Medicine/utils.ts
@@ -21,6 +21,21 @@ export function formatDosage(instruction?: MedicationRequestDosageInstruction) {
   return "";
 }
 
+/**
+ * Whether a dosage represents a quantity other than a single unit (value ≠ 1).
+ */
+export function isNonUnitDose(
+  instruction?: MedicationRequestDosageInstruction,
+): boolean {
+  const doseAndRate = instruction?.dose_and_rate;
+  if (!doseAndRate) return false;
+
+  const { dose_range, dose_quantity } = doseAndRate;
+  if (dose_range) return true;
+  if (dose_quantity) return Number(dose_quantity.value) !== 1;
+  return false;
+}
+
 // Helper function to format dosage instructions in Rx style
 export function formatSig(instruction?: MedicationRequestDosageInstruction) {
   if (!instruction) return "";

--- a/src/components/Questionnaire/ManageResponseTemplatesSheet.tsx
+++ b/src/components/Questionnaire/ManageResponseTemplatesSheet.tsx
@@ -23,6 +23,7 @@ import * as z from "zod";
 
 import { cn } from "@/lib/utils";
 
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import {
   formatDosage,
   formatDuration,
@@ -205,12 +206,14 @@ function MedicationsPreview({
 
           const instructions = med.dosage_instruction ?? [];
           const dosageLines = instructions
-            .map((di) =>
-              [formatDosage(di), formatFrequency(di), formatDuration(di)]
+            .map((di) => ({
+              di,
+              dosage: formatDosage(di),
+              instructionText: [formatFrequency(di), formatDuration(di)]
                 .filter(Boolean)
                 .join(" • "),
-            )
-            .filter(Boolean);
+            }))
+            .filter((line) => line.dosage || line.instructionText);
 
           return (
             <Button
@@ -237,7 +240,13 @@ function MedicationsPreview({
                 {dosageLines.length > 0 && (
                   <div className="text-xs text-gray-500 mt-0.5 leading-tight">
                     {dosageLines.map((line, i) => (
-                      <div key={i}>{line}</div>
+                      <div key={i}>
+                        {line.dosage && (
+                          <FormattedDosage instruction={line.di} fallback="" />
+                        )}
+                        {line.dosage && line.instructionText && " • "}
+                        {line.instructionText}
+                      </div>
                     ))}
                   </div>
                 )}

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -969,7 +969,7 @@ export function MedicationRequestQuestion({
                               const freq = formatFrequency(di) || "";
                               return (
                                 <div className="flex flex-col">
-                                  <FormattedDosage instruction={di} />
+                                  <FormattedDosage instruction={di} fallback="" />
                                   {freq && <span>{freq}</span>}
                                 </div>
                               );

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -969,7 +969,10 @@ export function MedicationRequestQuestion({
                               const freq = formatFrequency(di) || "";
                               return (
                                 <div className="flex flex-col">
-                                  <FormattedDosage instruction={di} fallback="" />
+                                  <FormattedDosage
+                                    instruction={di}
+                                    fallback=""
+                                  />
                                   {freq && <span>{freq}</span>}
                                 </div>
                               );

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -70,7 +70,7 @@ import useAuthUser from "@/hooks/useAuthUser";
 import useBreakpoints from "@/hooks/useBreakpoints";
 
 import { Avatar } from "@/components/Common/Avatar";
-import { formatDosage } from "@/components/Medicine/utils";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import { Code } from "@/types/base/code/code";
 import {
@@ -966,9 +966,13 @@ export function MedicationRequestQuestion({
                           <DosageInstructionList
                             instructions={instructions}
                             renderItem={(di) => {
-                              const dosage = formatDosage(di) || "";
                               const freq = formatFrequency(di) || "";
-                              return [dosage, freq].filter(Boolean).join("\n");
+                              return (
+                                <div className="flex flex-col">
+                                  <FormattedDosage instruction={di} />
+                                  {freq && <span>{freq}</span>}
+                                </div>
+                              );
                             }}
                             gap="sm"
                           />

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -32,11 +32,8 @@ import {
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { HistoricalRecordSelector } from "@/components/HistoricalRecordSelector";
 import { DosageInstructionList } from "@/components/Medicine/DosageInstructionList";
-import {
-  formatDosage,
-  formatDuration,
-  formatFrequency,
-} from "@/components/Medicine/utils";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
+import { formatDuration, formatFrequency } from "@/components/Medicine/utils";
 import { EntitySelectionDrawer } from "@/components/Questionnaire/EntitySelectionDrawer";
 import ValueSetSelect from "@/components/Questionnaire/ValueSetSelect";
 
@@ -348,9 +345,13 @@ export function MedicationStatementQuestion({
                       <DosageInstructionList
                         instructions={instructions}
                         renderItem={(di) => {
-                          const dosage = formatDosage(di) || "";
                           const freq = formatFrequency(di) || "";
-                          return [dosage, freq].filter(Boolean).join("\n");
+                          return (
+                            <div className="flex flex-col">
+                              <FormattedDosage instruction={di} />
+                              {freq && <span>{freq}</span>}
+                            </div>
+                          );
                         }}
                         gap="sm"
                       />

--- a/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationStatementQuestion.tsx
@@ -348,7 +348,7 @@ export function MedicationStatementQuestion({
                           const freq = formatFrequency(di) || "";
                           return (
                             <div className="flex flex-col">
-                              <FormattedDosage instruction={di} />
+                              <FormattedDosage instruction={di} fallback="" />
                               {freq && <span>{freq}</span>}
                             </div>
                           );

--- a/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
+++ b/src/pages/Facility/services/pharmacy/DispensedMedicationList.tsx
@@ -40,6 +40,7 @@ import Decimal from "decimal.js";
 import { useMemo, useState } from "react";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import { formatDosage, formatFrequency } from "@/components/Medicine/utils";
 import {
   AlertDialog,
@@ -66,7 +67,6 @@ import { useShortcutSubContext } from "@/context/ShortcutContext";
 import { CreateInvoiceSheet } from "@/pages/Facility/billing/account/components/CreateInvoiceSheet";
 import ViewDefaultAccountButton from "@/pages/Facility/billing/account/ViewDefaultAccountButton";
 import { PaymentReconciliationSheet } from "@/pages/Facility/billing/PaymentReconciliationSheet";
-import batchApi from "@/types/base/batch/batchApi";
 import accountApi from "@/types/billing/account/accountApi";
 import {
   INVOICE_STATUS_COLORS,
@@ -90,8 +90,11 @@ import { PatientListRead } from "@/types/emr/patient/patient";
 
 import { round } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
+import { BatchRequestObject, useBatchRequest } from "@/Utils/request/batch";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
+import { HttpMethod, Type } from "@/Utils/request/types";
+import { formatDateTime } from "@/Utils/utils";
 import {
   ArrowUpRightSquare,
   BanknoteIcon,
@@ -185,12 +188,13 @@ function MedicationTable({ medications }: MedicationTableProps) {
                       {medication.item.product.product_knowledge.name}
                     </span>
                     {instructions.map((di, idx) => {
-                      const text = [formatDosage(di), formatFrequency(di)]
-                        .filter(Boolean)
-                        .join(" · ");
-                      return text ? (
+                      const dosage = formatDosage(di);
+                      const freq = formatFrequency(di);
+                      return dosage || freq ? (
                         <span key={idx} className="text-sm text-gray-500">
-                          {text}
+                          {dosage && <FormattedDosage instruction={di} />}
+                          {dosage && freq && " · "}
+                          {freq}
                         </span>
                       ) : null;
                     })}
@@ -597,21 +601,14 @@ function InvoiceCard({
                               </span>
                               {getPaymentReference(payment) && (
                                 <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
-                                  Ref: {getPaymentReference(payment)}
+                                  {t("reference")}:{" "}
+                                  {getPaymentReference(payment)}
                                 </span>
                               )}
                             </div>
                             {payment.payment_datetime && (
                               <p className="text-xs text-gray-500 mt-0.5">
-                                {new Date(
-                                  payment.payment_datetime,
-                                ).toLocaleDateString("en-US", {
-                                  year: "numeric",
-                                  month: "short",
-                                  day: "numeric",
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                })}
+                                {formatDateTime(payment.payment_datetime)}
                               </p>
                             )}
                           </div>
@@ -1067,8 +1064,7 @@ export default function DispensedMedicationList({
   });
 
   const { mutate: updateDispenseOrder, isPending: isUpdatingDispenseOrder } =
-    useMutation({
-      mutationFn: mutate(batchApi.batchRequest),
+    useBatchRequest({
       onSuccess: () => {
         queryClient.invalidateQueries({
           queryKey: ["dispenseOrder", facilityId, dispenseOrder.id],
@@ -1086,16 +1082,15 @@ export default function DispensedMedicationList({
   const handleUpdateDispenseOrder = (
     newDispenseOrderStatus: DispenseOrderStatus = DispenseOrderStatus.completed,
   ) => {
-    const requests: Array<{
-      url: string;
-      method: string;
-      reference_id: string;
-      body: unknown;
-    }> = [
+    const requests: BatchRequestObject[] = [
       {
-        url: `/api/v1/facility/${facilityId}/order/dispense/${dispenseOrder.id}/`,
-        method: "PATCH",
-        reference_id: `update_dispense_order_${dispenseOrder.id}`,
+        api: {
+          path: "/api/v1/facility/{facilityId}/order/dispense/{id}/",
+          method: HttpMethod.PATCH,
+          TRes: Type<DispenseOrderRead>(),
+        },
+        pathParams: { facilityId, id: dispenseOrder.id },
+        referenceId: `update_dispense_order_${dispenseOrder.id}`,
         body: { status: newDispenseOrderStatus },
       },
     ];
@@ -1136,14 +1131,13 @@ export default function DispensedMedicationList({
         }),
       );
       requests.push({
-        url: `/api/v1/medication/dispense/upsert/`,
-        method: "POST",
-        reference_id: `update_medication_dispenses`,
+        api: medicationDispenseApi.upsert,
+        referenceId: `update_medication_dispenses`,
         body: { datapoints: updates },
       });
     }
 
-    updateDispenseOrder({ requests });
+    updateDispenseOrder(requests);
   };
 
   // Filter medications by status

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
@@ -34,8 +34,8 @@ import {
 import ConfirmActionDialog from "@/components/Common/ConfirmActionDialog";
 import { TableSkeleton } from "@/components/Common/SkeletonLoading";
 import { DosageInstructionList } from "@/components/Medicine/DosageInstructionList";
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import {
-  formatDoseRange,
   formatDuration,
   formatFrequency,
   formatTotalUnits,
@@ -52,7 +52,6 @@ import {
 } from "@/types/emr/medicationRequest/medicationRequest";
 import prescriptionApi from "@/types/emr/prescription/prescriptionApi";
 
-import { round } from "@/Utils/decimal";
 import { ShortcutBadge } from "@/Utils/keyboardShortcutComponents";
 import mutate from "@/Utils/request/mutate";
 import { formatDateTime, formatName } from "@/Utils/utils";
@@ -145,13 +144,7 @@ function MedicationTable({
                 <TableCell className="text-gray-950 font-medium">
                   <DosageInstructionList
                     instructions={instructions}
-                    renderItem={(di) => {
-                      const dosage = di.dose_and_rate?.dose_quantity;
-                      const text = dosage
-                        ? `${round(dosage.value)} ${dosage.unit.display}`
-                        : formatDoseRange(di.dose_and_rate?.dose_range);
-                      return text || "-";
-                    }}
+                    renderItem={(di) => <FormattedDosage instruction={di} />}
                   />
                 </TableCell>
                 <TableCell className="text-gray-950 font-medium">

--- a/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
+++ b/src/pages/Facility/services/pharmacy/MedicationDispenseList.tsx
@@ -144,7 +144,9 @@ function MedicationTable({
                 <TableCell className="text-gray-950 font-medium">
                   <DosageInstructionList
                     instructions={instructions}
-                    renderItem={(di) => <FormattedDosage instruction={di} />}
+                    renderItem={(di) => (
+                      <FormattedDosage instruction={di} fallback="-" />
+                    )}
                   />
                 </TableCell>
                 <TableCell className="text-gray-950 font-medium">

--- a/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
+++ b/src/pages/Facility/services/pharmacy/components/MedicationBillRow.tsx
@@ -41,6 +41,7 @@ import {
   MedicationBillLotItem,
 } from "@/pages/Facility/services/pharmacy/types";
 
+import { FormattedDosage } from "@/components/Medicine/FormattedDosage";
 import {
   formatDosage,
   formatDuration,
@@ -304,8 +305,8 @@ export function MedicationBillRow({
             {field.medication ? (
               <div className="text-sm text-gray-700 font-medium">
                 {field.dosageInstructions?.map((di, idx) => {
-                  const line = [
-                    formatDosage(di),
+                  const dosage = formatDosage(di);
+                  const instructionText = [
                     formatFrequency(di),
                     formatDuration(di) || "-",
                   ]
@@ -313,7 +314,9 @@ export function MedicationBillRow({
                     .join(" × ");
                   return (
                     <div key={idx} className="flex items-center gap-1">
-                      {line}
+                      {dosage && <FormattedDosage instruction={di} />}
+                      {dosage && instructionText && " × "}
+                      {instructionText}
                     </div>
                   );
                 })}
@@ -338,8 +341,10 @@ export function MedicationBillRow({
                   if (currentDosageInstructions?.dose_and_rate?.dose_quantity) {
                     return (
                       <div className="text-sm text-gray-700 font-medium flex items-center gap-1">
-                        {formatDosage(currentDosageInstructions)} ×{" "}
-                        {formatFrequency(currentDosageInstructions)} ×{" "}
+                        <FormattedDosage
+                          instruction={currentDosageInstructions}
+                        />{" "}
+                        × {formatFrequency(currentDosageInstructions)} ×{" "}
                         {formatDuration(currentDosageInstructions) || "-"} ={" "}
                         <span className="text-gray-700 font-semibold text-sm">
                           {formatTotalUnits(

--- a/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
@@ -110,7 +110,9 @@ test.describe("Create Patient Prescription", () => {
       const medicationRow = table
         .getByRole("row")
         .filter({ hasText: medicineName });
-      await expect(medicationRow.locator(".bg-yellow-100")).toBeVisible();
+      const highlightedDosage = medicationRow.locator(".bg-yellow-100");
+      await expect(highlightedDosage).toHaveCount(1);
+      await expect(highlightedDosage.first()).toBeVisible();
     });
   });
 
@@ -194,6 +196,7 @@ test.describe("Create Patient Prescription", () => {
       const table = page.getByRole("table");
       await expect(table).toBeVisible();
       await expect(table).toContainText(medicineName);
+      await expect(table).toContainText(dosage);
       // Unit dosages (value === 1) are NOT visually highlighted
       const medicationRow = table.getByRole("row").filter({
         hasText: medicineName,

--- a/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
@@ -26,7 +26,8 @@ test.describe("Create Patient Prescription", () => {
 
   test("Add medication to patient prescription", async ({ page }) => {
     const medicineName = faker.helpers.arrayElement(medicineNames);
-    const dosage = faker.number.int({ min: 1, max: 100 }).toString();
+    // Use a non-unit dose (value !== 1) so the dosage is highlighted
+    const dosage = faker.number.int({ min: 2, max: 100 }).toString();
     const frequency = faker.helpers.arrayElement(frequencies);
     const selectedInstruction = faker.helpers.arrayElement(instructions);
     const notes = "testing notes";
@@ -104,6 +105,10 @@ test.describe("Create Patient Prescription", () => {
       await expect(table).toContainText(dosage);
       await expect(table).toContainText(frequency.display);
       await expect(table).toContainText(selectedInstruction);
+      // Non-unit dosages (value !== 1) are visually highlighted
+      await expect(
+        table.locator(".bg-yellow-100").filter({ hasText: dosage }).first(),
+      ).toBeVisible();
     });
   });
 });

--- a/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
@@ -11,6 +11,7 @@ import {
 test.use({ storageState: "tests/.auth/user.json" });
 
 test.describe("Create Patient Prescription", () => {
+  test.describe.configure({ mode: "serial" });
   let facilityId: string;
 
   test.beforeEach(async ({ page }) => {
@@ -106,9 +107,10 @@ test.describe("Create Patient Prescription", () => {
       await expect(table).toContainText(frequency.display);
       await expect(table).toContainText(selectedInstruction);
       // Non-unit dosages (value !== 1) are visually highlighted
-      await expect(
-        table.locator(".bg-yellow-100").filter({ hasText: dosage }).first(),
-      ).toBeVisible();
+      const medicationRow = table
+        .getByRole("row")
+        .filter({ hasText: medicineName });
+      await expect(medicationRow.locator(".bg-yellow-100")).toBeVisible();
     });
   });
 

--- a/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
@@ -111,4 +111,92 @@ test.describe("Create Patient Prescription", () => {
       ).toBeVisible();
     });
   });
+
+  test("Unit dosage is not highlighted in patient prescription", async ({
+    page,
+  }) => {
+    const medicineName = faker.helpers.arrayElement(medicineNames);
+    // Use a unit dose (value === 1) so the dosage is NOT highlighted
+    const dosage = "1";
+    const frequency = faker.helpers.arrayElement(frequencies);
+    const selectedInstruction = faker.helpers.arrayElement(instructions);
+    const notes = "testing notes";
+
+    await test.step("Open prescription form", async () => {
+      await page.getByRole("link", { name: /Create/i }).click();
+      // Wait for the "Add Medication" button to be visible instead of networkidle
+      await expect(
+        page.getByText(/Add Medication|Add another Medication/i),
+      ).toBeVisible();
+    });
+
+    await test.step("Add medication", async () => {
+      await page.getByText(/Add Medication|Add another Medication/i).click();
+    });
+
+    await test.step("Select medicine from list", async () => {
+      await page.getByRole("tab", { name: "Medication" }).click();
+      await page.locator("input[data-slot='command-input']").fill(medicineName);
+      await page.getByRole("option", { name: medicineName }).first().click();
+      await expect(page.getByText(medicineName).first()).toBeVisible();
+    });
+
+    await test.step("Fill medication details", async () => {
+      await page.getByPlaceholder("Enter a number...").first().click();
+      await page.getByPlaceholder("Enter a number...").first().fill(dosage);
+      await page.keyboard.press("Enter");
+
+      await page.getByText("eg. 1-0-1").first().click();
+      await page.getByPlaceholder("Type eg. 1-0-1").fill(frequency.input);
+      await page
+        .getByRole("option", { name: frequency.display })
+        .nth(0)
+        .click();
+
+      // expand
+      await page.getByTitle("Show Advanced Fields").first().click();
+
+      await page
+        .getByRole("button", { name: "No instructions selected" })
+        .last()
+        .click();
+      await page.getByRole("option", { name: selectedInstruction }).click();
+
+      await page.getByPlaceholder("Notes").last().fill(notes);
+    });
+
+    await test.step("Submit prescription", async () => {
+      await page.getByRole("button", { name: "Submit" }).click();
+      await expect(
+        page
+          .locator("li[data-sonner-toast]")
+          .getByText("Questionnaire submitted successfully"),
+      ).toBeVisible();
+    });
+
+    await test.step("Verify medication is not highlighted in table", async () => {
+      // Wait for prescriptions API to respond after clicking tab
+      await Promise.all([
+        page.getByRole("tab", { name: "Medicines" }).click(),
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes("/medication/prescription/") &&
+            resp.status() === 200,
+        ),
+      ]);
+      // Click "All Prescriptions" sidebar card to see all medicines
+      await page
+        .locator("[data-slot='card']")
+        .filter({ hasText: "View all medications" })
+        .click();
+      const table = page.getByRole("table");
+      await expect(table).toBeVisible();
+      await expect(table).toContainText(medicineName);
+      // Unit dosages (value === 1) are NOT visually highlighted
+      const medicationRow = table.getByRole("row").filter({
+        hasText: medicineName,
+      });
+      await expect(medicationRow.locator(".bg-yellow-100")).toHaveCount(0);
+    });
+  });
 });


### PR DESCRIPTION
Highlight everywhere except prints

<img width="2182" height="261" alt="image" src="https://github.com/user-attachments/assets/9207edd7-7bdf-4df1-893a-11fbe2e42be7" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared dosage formatting component and rolled it out across medication lists, administration views, dispense history, pharmacy workflows, and questionnaire/record screens.
  * Dosage values classified as non-unit (e.g., ranges or non-1 quantities) are now visually highlighted.
  * When dosage data is missing, a configurable fallback (such as `-`) is shown.

* **Improvements**
  * Refined pharmacy payment displays (localized reference label and improved timestamp formatting).
  * Medication dispense updates now use a consolidated batch update approach.

* **Tests**
  * Added assertions for yellow highlight presence for non-unit dosages and absence for unit dosages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->