### PR TITLE
[ENG-748] fix: text overflow in Administration Table

### DIFF
--- a/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
+++ b/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
@@ -139,7 +139,7 @@ const IndividualMedicationRow: React.FC<{
                 .filter(Boolean)
                 .join(", ");
               return (
-                <div>
+                <div className="text-wrap break-all">
                   {(dosage || instructionText) && (
                     <div>
                       {dosage && (
@@ -170,7 +170,7 @@ const IndividualMedicationRow: React.FC<{
             {t(medication.status)}
           </Badge>
         </div>
-        <div className="text-xs text-gray-500 mt-0.5">
+        <div className="text-xs text-gray-500 mt-0.5 text-wrap break-all">
           {t("added_on")}:{" "}
           {format(
             new Date(medication.authored_on || medication.created_date),
@@ -402,7 +402,7 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
                     const freq = formatFrequency(di);
                     return (
                       <div>
-                        <div>
+                        <div className="text-wrap break-all">
                           <FormattedDosage instruction={di} />
                           {freq && <span className="text-gray-400"> · </span>}
                           {freq}
@@ -445,7 +445,7 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
 
               {/* Last administered */}
               {group.lastAdministeredTime && (
-                <div className="text-xs text-gray-500 mt-1">
+                <div className="text-xs text-gray-500 mt-1 text-wrap break-all">
                   {t("last_administered")}:{" "}
                   {formatDistanceToNow(new Date(group.lastAdministeredTime))}{" "}
                   {t("ago")}

--- a/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
+++ b/src/components/Medicine/MedicationAdministration/GroupedMedicationRow.tsx
@@ -139,7 +139,7 @@ const IndividualMedicationRow: React.FC<{
                 .filter(Boolean)
                 .join(", ");
               return (
-                <div className="text-wrap break-all">
+                <div className="text-wrap wrap-break-word">
                   {(dosage || instructionText) && (
                     <div>
                       {dosage && (
@@ -170,7 +170,7 @@ const IndividualMedicationRow: React.FC<{
             {t(medication.status)}
           </Badge>
         </div>
-        <div className="text-xs text-gray-500 mt-0.5 text-wrap break-all">
+        <div className="text-xs text-gray-500 mt-0.5 text-wrap wrap-break-word">
           {t("added_on")}:{" "}
           {format(
             new Date(medication.authored_on || medication.created_date),
@@ -402,7 +402,7 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
                     const freq = formatFrequency(di);
                     return (
                       <div>
-                        <div className="text-wrap break-all">
+                        <div className="text-wrap wrap-break-word">
                           <FormattedDosage instruction={di} />
                           {freq && <span className="text-gray-400"> · </span>}
                           {freq}
@@ -445,7 +445,7 @@ export const GroupedMedicationRow: React.FC<GroupedMedicationRowProps> = ({
 
               {/* Last administered */}
               {group.lastAdministeredTime && (
-                <div className="text-xs text-gray-500 mt-1 text-wrap break-all">
+                <div className="text-xs text-gray-500 mt-1 text-wrap wrap-break-word">
                   {t("last_administered")}:{" "}
                   {formatDistanceToNow(new Date(group.lastAdministeredTime))}{" "}
                   {t("ago")}


### PR DESCRIPTION
Enhance text wrapping and prevent overflow issues in Mobile View. The main change is the addition of the `text-wrap` class to various elements to ensure long text displays correctly.

Before:
<img width="410" height="827" alt="image" src="https://github.com/user-attachments/assets/4c05f5ab-38e0-4aca-807b-8b0fc59d1c54" />

After:
<img width="408" height="741" alt="image" src="https://github.com/user-attachments/assets/3191f339-938c-4221-9649-b01f38830d87" />

Tagging: @ohcnetwork/care-fe-code-reviewers
[ENG-748]

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-748]: https://openhealthcarenetwork.atlassian.net/browse/ENG-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for medication dosage instructions and administration timestamps so long content breaks cleanly.
  * Enhanced readability of grouped and individual medication details across varying screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->