### PR TITLE
[QA-210] Allow QA project key in PR title JIRA validation

### DIFF
--- a/.github/workflows/pr-title-jira.yml
+++ b/.github/workflows/pr-title-jira.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             // Configure JIRA project keys here
-            const jiraProjectKeys = ['ENG'];
+            const jiraProjectKeys = ['ENG', 'QA'];
 
             const prTitle = context.payload.pull_request.title;
 


### PR DESCRIPTION
## Proposed Changes

The `PR Title JIRA Validation` workflow (`.github/workflows/pr-title-jira.yml`) only allowed the `ENG` project key. PRs referencing valid QA-project tickets (e.g. [QA-32] in #16317) fail the check because `QA` is not recognized.

This adds `QA` to the allowed `jiraProjectKeys` list so titles like `[QA-123] ...` pass validation.

- Fixes the failing JIRA validation on #16317

Ref: QA-210

[QA-32]: https://openhealthcarenetwork.atlassian.net/browse/QA-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-123]: https://openhealthcarenetwork.atlassian.net/browse/QA-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request title validation to accept titles beginning with either an ENG or QA JIRA issue key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->