### PR TITLE
[QA-214] Fix flaky device service history edit flow test

### DIFF
--- a/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
+++ b/tests/facility/patient/encounter/medicine/prescriptionCreate.spec.ts
@@ -14,6 +14,16 @@ test.describe("Create Patient Prescription", () => {
   test.describe.configure({ mode: "serial" });
   let facilityId: string;
 
+  // These tests run serially against the same encounter, so every prescription
+  // they create shows up in one shared table. Pick two distinct medicines so
+  // the highlighted (non-unit) test and the unit test never land on rows that
+  // match the same medicine name — otherwise the unit test could match the
+  // other test's highlighted row and fail intermittently.
+  const [highlightedMedicine, unitMedicine] = faker.helpers.arrayElements(
+    medicineNames,
+    2,
+  );
+
   test.beforeEach(async ({ page }) => {
     facilityId = getFacilityId();
     const createdDateAfter = format(subDays(new Date(), 90), "yyyy-MM-dd");
@@ -26,7 +36,7 @@ test.describe("Create Patient Prescription", () => {
   });
 
   test("Add medication to patient prescription", async ({ page }) => {
-    const medicineName = faker.helpers.arrayElement(medicineNames);
+    const medicineName = highlightedMedicine;
     // Use a non-unit dose (value !== 1) so the dosage is highlighted
     const dosage = faker.number.int({ min: 2, max: 100 }).toString();
     const frequency = faker.helpers.arrayElement(frequencies);
@@ -119,7 +129,7 @@ test.describe("Create Patient Prescription", () => {
   test("Unit dosage is not highlighted in patient prescription", async ({
     page,
   }) => {
-    const medicineName = faker.helpers.arrayElement(medicineNames);
+    const medicineName = unitMedicine;
     // Use a unit dose (value === 1) so the dosage is NOT highlighted
     const dosage = "1";
     const frequency = faker.helpers.arrayElement(frequencies);

--- a/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
+++ b/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
@@ -56,6 +56,33 @@ test.describe("Patient Files", () => {
     return response;
   };
 
+  // Opens the preview for a specific uploaded file and closes it again,
+  // confirming the file is accessible to the current user.
+  const openFilePreview = async (page: Page, displayName: string) => {
+    // Scope to the row for this exact file so other files on the shared
+    // patient (including archived ones, whose "View" opens a different
+    // dialog) can't be picked up by mistake.
+    const fileRow = page
+      .getByRole("row")
+      .filter({ hasText: displayName })
+      .first();
+    await expect(fileRow).toBeVisible({ timeout: 10000 });
+    await fileRow.getByRole("button", { name: "View", exact: true }).click();
+
+    // The file preview dialog (not the archived-file dialog) must open.
+    const previewDialog = page.getByRole("dialog");
+    await expect(previewDialog.getByText("File Preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Close it, scoping to the dialog so page-level toasts named "Close"
+    // can't cause a strict-mode match.
+    await previewDialog
+      .getByRole("button", { name: "Close", exact: true })
+      .click();
+    await expect(previewDialog).toBeHidden({ timeout: 10000 });
+  };
+
   let facilityId: string;
 
   test.beforeEach(async ({ page }) => {
@@ -166,55 +193,35 @@ test.describe("Patient Files", () => {
     page,
     browser,
   }) => {
-    const inputFileName1 = faker.system.fileName();
+    // Unique, extension-free display name so this exact file's row can be
+    // located reliably among other files on the shared patient.
+    const uploadedFileName = `access-${faker.string.alphanumeric(10)}`;
 
-    // Upload file as first user (doctor)
-    await uploadFile(page, `tests/fixtures/images/${fileName}`, inputFileName1);
+    // Upload the file as the first user (doctor).
+    await uploadFile(
+      page,
+      `tests/fixtures/images/${fileName}`,
+      uploadedFileName,
+    );
 
-    // Wait for the file to appear in the list
-    await expect(
-      page.getByRole("button", { name: /view/i }).first(),
-    ).toBeVisible({ timeout: 10000 });
+    // Capture the stable Files-tab URL to reopen as a different user.
+    const filesUrl = page.url();
 
-    // View the uploaded file
-    await page.getByRole("button", { name: /view/i }).first().click();
+    // The uploader can preview the file they just added.
+    await openFilePreview(page, uploadedFileName);
 
-    // Wait for file viewer to load
-    await expect(
-      page.getByRole("button", { name: "Close", exact: true }),
-    ).toBeVisible({
-      timeout: 5000,
-    });
-    await page.getByRole("button", { name: "Close", exact: true }).click();
-
-    // Save current URL for navigation
-    const currentUrl = page.url();
-
-    // Create a new browser context with nurse authentication
+    // The same file must be accessible to a different user (nurse).
     const nurseContext = await browser.newContext({
       storageState: "tests/.auth/nurse.json",
     });
     const nursePage = await nurseContext.newPage();
-
-    // Navigate to the patient files page as nurse
-    await nursePage.goto(currentUrl);
-
-    // Wait for the files tab to load
-    await expect(
-      nursePage.getByRole("button", { name: /view/i }).first(),
-    ).toBeVisible({ timeout: 10000 });
-
-    // View the file as nurse
-    await nursePage.getByRole("button", { name: /view/i }).first().click();
-
-    // Verify file viewer loaded for nurse
-    await expect(nursePage.getByRole("button", { name: "Close" })).toBeVisible({
-      timeout: 5000,
-    });
-
-    // Clean up
-    await nursePage.close();
-    await nurseContext.close();
+    try {
+      await nursePage.goto(filesUrl);
+      await openFilePreview(nursePage, uploadedFileName);
+    } finally {
+      await nursePage.close();
+      await nurseContext.close();
+    }
   });
 
   test("Add a new patient file and rename it", async ({ page }) => {

--- a/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
+++ b/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
@@ -69,9 +69,13 @@ test.describe("Patient Files", () => {
     await expect(fileRow).toBeVisible({ timeout: 10000 });
     await fileRow.getByRole("button", { name: "View", exact: true }).click();
 
-    // The file preview dialog (not the archived-file dialog) must open.
-    const previewDialog = page.getByRole("dialog");
-    await expect(previewDialog.getByText("File Preview")).toBeVisible({
+    // The file preview dialog (not the archived-file dialog) must open. Filter
+    // by its title so an upload sheet or other dialog that may still be mounted
+    // can't cause a strict-mode match on the Close button.
+    const previewDialog = page
+      .getByRole("dialog")
+      .filter({ hasText: "File Preview" });
+    await expect(previewDialog).toBeVisible({
       timeout: 10000,
     });
 

--- a/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
+++ b/tests/facility/patient/patientDetails/files/patientFiles.spec.ts
@@ -66,7 +66,7 @@ test.describe("Patient Files", () => {
       .getByRole("row")
       .filter({ hasText: displayName })
       .first();
-    await expect(fileRow).toBeVisible({ timeout: 10000 });
+    await expect(fileRow).toBeVisible();
     await fileRow.getByRole("button", { name: "View", exact: true }).click();
 
     // The file preview dialog (not the archived-file dialog) must open. Filter
@@ -75,16 +75,14 @@ test.describe("Patient Files", () => {
     const previewDialog = page
       .getByRole("dialog")
       .filter({ hasText: "File Preview" });
-    await expect(previewDialog).toBeVisible({
-      timeout: 10000,
-    });
+    await expect(previewDialog).toBeVisible();
 
     // Close it, scoping to the dialog so page-level toasts named "Close"
     // can't cause a strict-mode match.
     await previewDialog
       .getByRole("button", { name: "Close", exact: true })
       .click();
-    await expect(previewDialog).toBeHidden({ timeout: 10000 });
+    await expect(previewDialog).toBeHidden();
   };
 
   let facilityId: string;

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -72,6 +72,11 @@ test.describe("Device Service History", () => {
 
     await expect(page.getByText(notes)).toBeVisible();
 
+    // Wait for the "Add Service Record" sheet to fully close before editing,
+    // otherwise its Service Date picker and Notes field overlap with the edit
+    // sheet's, causing a strict-mode violation.
+    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
+
     await page
       .locator('[data-slot="card"]')
       .filter({ hasText: notes })
@@ -175,6 +180,11 @@ test.describe("Device Service History", () => {
     await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page.getByText(notes)).toBeVisible();
+
+    // Wait for the "Add Service Record" sheet to fully close before editing,
+    // otherwise its Service Date picker and Notes field overlap with the edit
+    // sheet's, causing a strict-mode violation.
+    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
 
     await page
       .locator('[data-slot="card"]')

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -72,6 +72,11 @@ test.describe("Device Service History", () => {
 
     await expect(page.getByText(notes)).toBeVisible();
 
+    // Wait for the Add sheet to fully close before opening Edit; otherwise its
+    // controls linger in the DOM during the close animation and collide with
+    // the edit sheet's controls.
+    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
+
     await page
       .locator('[data-slot="card"]')
       .filter({ hasText: notes })
@@ -79,11 +84,9 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
-    // Scope all edit-sheet interactions to its dialog to avoid strict-mode
-    // violations when the Add sheet is still in the DOM during its close animation.
-    const editSheet = page.getByRole("dialog", {
-      name: "Edit Service Record",
-    });
+    // With the Add sheet closed, the edit sheet is the only open dialog, so
+    // scope interactions to it (locale-independent, no hard-coded title).
+    const editSheet = page.getByRole("dialog");
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 
     const pastYear = new Date().getFullYear() - 1;
@@ -185,6 +188,11 @@ test.describe("Device Service History", () => {
 
     await expect(page.getByText(notes)).toBeVisible();
 
+    // Wait for the Add sheet to fully close before opening Edit; otherwise its
+    // controls linger in the DOM during the close animation and collide with
+    // the edit sheet's controls.
+    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
+
     await page
       .locator('[data-slot="card"]')
       .filter({ hasText: notes })
@@ -192,17 +200,17 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
-    // Scope all edit-sheet interactions to its dialog to avoid strict-mode
-    // violations when the Add sheet is still in the DOM during its close animation.
-    const editSheet = page.getByRole("dialog", {
-      name: "Edit Service Record",
-    });
+    // With the Add sheet closed, the edit sheet is the only open dialog, so
+    // scope interactions to it (locale-independent, no hard-coded title).
+    const editSheet = page.getByRole("dialog");
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 
     const updateButton = editSheet.getByRole("button", { name: "Update" });
     await expect(updateButton).toBeDisabled();
 
-    await editSheet.getByRole("textbox", { name: "Notes *" }).fill(updatedNotes);
+    await editSheet
+      .getByRole("textbox", { name: "Notes *" })
+      .fill(updatedNotes);
 
     await expect(updateButton).toBeEnabled();
 

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -84,9 +84,10 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
-    // With the Add sheet closed, the edit sheet is the only open dialog, so
-    // scope interactions to it instead of matching a hard-coded dialog title.
-    const editSheet = page.getByRole("dialog");
+    // With the Add sheet closed, the edit sheet is the only open dialog. Use
+    // .last() to target the most recently opened dialog so a still-unmounting
+    // sheet can't reintroduce a strict-mode match.
+    const editSheet = page.getByRole("dialog").last();
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 
     const pastYear = new Date().getFullYear() - 1;
@@ -200,9 +201,10 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
-    // With the Add sheet closed, the edit sheet is the only open dialog, so
-    // scope interactions to it instead of matching a hard-coded dialog title.
-    const editSheet = page.getByRole("dialog");
+    // With the Add sheet closed, the edit sheet is the only open dialog. Use
+    // .last() to target the most recently opened dialog so a still-unmounting
+    // sheet can't reintroduce a strict-mode match.
+    const editSheet = page.getByRole("dialog").last();
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 
     const updateButton = editSheet.getByRole("button", { name: "Update" });

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -85,7 +85,7 @@ test.describe("Device Service History", () => {
       .click();
 
     // With the Add sheet closed, the edit sheet is the only open dialog, so
-    // scope interactions to it (locale-independent, no hard-coded title).
+    // scope interactions to it instead of matching a hard-coded dialog title.
     const editSheet = page.getByRole("dialog");
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 
@@ -201,7 +201,7 @@ test.describe("Device Service History", () => {
       .click();
 
     // With the Add sheet closed, the edit sheet is the only open dialog, so
-    // scope interactions to it (locale-independent, no hard-coded title).
+    // scope interactions to it instead of matching a hard-coded dialog title.
     const editSheet = page.getByRole("dialog");
     await expect(editSheet).toBeVisible({ timeout: 10000 });
 

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -72,11 +72,6 @@ test.describe("Device Service History", () => {
 
     await expect(page.getByText(notes)).toBeVisible();
 
-    // Wait for the "Add Service Record" sheet to fully close before editing,
-    // otherwise its Service Date picker and Notes field overlap with the edit
-    // sheet's, causing a strict-mode violation.
-    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
-
     await page
       .locator('[data-slot="card"]')
       .filter({ hasText: notes })
@@ -84,8 +79,15 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
+    // Scope all edit-sheet interactions to its dialog to avoid strict-mode
+    // violations when the Add sheet is still in the DOM during its close animation.
+    const editSheet = page.getByRole("dialog", {
+      name: "Edit Service Record",
+    });
+    await expect(editSheet).toBeVisible({ timeout: 10000 });
+
     const pastYear = new Date().getFullYear() - 1;
-    await page
+    await editSheet
       .locator('[data-slot="form-item"]')
       .filter({ hasText: "Service Date" })
       .locator('[data-slot="popover-trigger"]')
@@ -93,9 +95,11 @@ test.describe("Device Service History", () => {
     await page.locator(".rdp-years_dropdown").selectOption(pastYear.toString());
     await page.locator('[role="gridcell"]:not([data-outside])').first().click();
 
-    await page.getByRole("textbox", { name: "Notes *" }).fill(updatedNotes);
+    await editSheet
+      .getByRole("textbox", { name: "Notes *" })
+      .fill(updatedNotes);
 
-    await page.getByRole("button", { name: "Update" }).click();
+    await editSheet.getByRole("button", { name: "Update" }).click();
 
     const updatedCard = page
       .locator('[data-slot="card"]')
@@ -181,11 +185,6 @@ test.describe("Device Service History", () => {
 
     await expect(page.getByText(notes)).toBeVisible();
 
-    // Wait for the "Add Service Record" sheet to fully close before editing,
-    // otherwise its Service Date picker and Notes field overlap with the edit
-    // sheet's, causing a strict-mode violation.
-    await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
-
     await page
       .locator('[data-slot="card"]')
       .filter({ hasText: notes })
@@ -193,14 +192,21 @@ test.describe("Device Service History", () => {
       .first()
       .click();
 
-    const updateButton = page.getByRole("button", { name: "Update" });
+    // Scope all edit-sheet interactions to its dialog to avoid strict-mode
+    // violations when the Add sheet is still in the DOM during its close animation.
+    const editSheet = page.getByRole("dialog", {
+      name: "Edit Service Record",
+    });
+    await expect(editSheet).toBeVisible({ timeout: 10000 });
+
+    const updateButton = editSheet.getByRole("button", { name: "Update" });
     await expect(updateButton).toBeDisabled();
 
-    await page.getByRole("textbox", { name: "Notes *" }).fill(updatedNotes);
+    await editSheet.getByRole("textbox", { name: "Notes *" }).fill(updatedNotes);
 
     await expect(updateButton).toBeEnabled();
 
-    await page.getByRole("textbox", { name: "Notes *" }).fill(notes);
+    await editSheet.getByRole("textbox", { name: "Notes *" }).fill(notes);
 
     await expect(updateButton).toBeDisabled();
   });

--- a/tests/facility/settings/devices/deviceServiceHistory.spec.ts
+++ b/tests/facility/settings/devices/deviceServiceHistory.spec.ts
@@ -88,7 +88,7 @@ test.describe("Device Service History", () => {
     // .last() to target the most recently opened dialog so a still-unmounting
     // sheet can't reintroduce a strict-mode match.
     const editSheet = page.getByRole("dialog").last();
-    await expect(editSheet).toBeVisible({ timeout: 10000 });
+    await expect(editSheet).toBeVisible();
 
     const pastYear = new Date().getFullYear() - 1;
     await editSheet
@@ -205,7 +205,7 @@ test.describe("Device Service History", () => {
     // .last() to target the most recently opened dialog so a still-unmounting
     // sheet can't reintroduce a strict-mode match.
     const editSheet = page.getByRole("dialog").last();
-    await expect(editSheet).toBeVisible({ timeout: 10000 });
+    await expect(editSheet).toBeVisible();
 
     const updateButton = editSheet.getByRole("button", { name: "Update" });
     await expect(updateButton).toBeDisabled();


### PR DESCRIPTION
### Proposed Changes

Fixes flaky Playwright E2E tests. Originally scoped to the device service history edit flow, this PR was expanded to fold in two additional flakiness fixes surfaced while validating the same CI shards.

#### 1. Device service history edit flow (`deviceServiceHistory.spec.ts`)

**Failure:** The "Edit an existing service record and verify changes" test intermittently failed with a Playwright strict-mode violation:

```
locator.click: Error: strict mode violation:
locator('[data-slot="form-item"]').filter({ hasText: 'Service Date' })
  .locator('[data-slot="popover-trigger"]') resolved to 2 elements
```

**Root cause:** After saving a new record, the test clicked the edit button before the "Add Service Record" sheet finished its close animation/unmount. Both the Add sheet and the Edit sheet momentarily rendered a Service Date popover-trigger, so the locator matched 2 elements.

**Fix:** Wait for the Add sheet to fully close (its `Save` button to become hidden) before opening the edit sheet, scope all edit interactions to the edit dialog, and target the most recently opened dialog via `.last()`. Applied to both edit-flow tests in the file.

#### 2. Prescription unit-dose highlight (`prescriptionCreate.spec.ts`)

**Root cause:** Two serial tests share one encounter/medication table, but both picked a medicine via `faker.helpers.arrayElement(medicineNames)`. From a 5-item list they occasionally picked the same medicine, so the unit-dose test's row filter matched the highlighted (non-unit) test's row and the `.bg-yellow-100` count assertion failed.

**Fix:** Allocate two distinct medicines at describe scope via `faker.helpers.arrayElements(medicineNames, 2)`.

#### 3. Patient files cross-user access (`patientFiles.spec.ts`)

**Root cause:** The "file accessible to another user" test clicked the first `/view/i` button on a shared patient whose first row could be an archived file, opening the `ArchivedFileDialog` (which has two "Close" buttons) and triggering a strict-mode violation.

**Fix:** Upload a uniquely named file, target that specific row by name, use an exact "View", assert the "File Preview" dialog (filtered by title), and scope the Close to that dialog. Repeated for the nurse context.

- [x] I have gone through the CONTRIBUTING guidelines.

@ohcnetwork/care-fe-code-reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved UI test reliability for editing device service records by waiting for the Add sheet to finish closing and performing all edit actions within the “Edit Service Record” dialog.
  * Made prescription creation UI tests deterministic by selecting distinct medicine names per scenario to avoid intermittent medicine table matching conflicts consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
