### PR TITLE
fix: remove unnecessary padding from dosage highlight

### DIFF
--- a/src/components/Medicine/FormattedDosage.tsx
+++ b/src/components/Medicine/FormattedDosage.tsx
@@ -31,7 +31,7 @@ export function FormattedDosage({
     return (
       <span
         className={cn(
-          "rounded bg-yellow-100 px-1.5 py-0.5 font-semibold text-yellow-900",
+          "rounded bg-yellow-100 font-semibold text-yellow-900",
           className,
         )}
       >


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted highlighted dosage formatting by removing extra padding for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->