### PR TITLE
[ENG-648] Adds a new generic autocomplete with radio options (enabled thru props; renders if options is <= 5). Enabled for Healthcare Service Selector.

### DIFF
--- a/src/components/Schedule/ResourceSelector.tsx
+++ b/src/components/Schedule/ResourceSelector.tsx
@@ -79,6 +79,7 @@ export const ScheduleResourceSelector = ({
             });
           }}
           internalType={InternalType.scheduling}
+          radio
         />
       );
 

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -155,6 +155,20 @@ export function GenericAutocomplete<T>({
       ? (options.find((o) => o.key === resolveKey(value)) ?? null)
       : null;
 
+  // When the query hasn't run yet (e.g. open=false, non-radio mode) options is
+  // empty and selectedOption would be null even though a value is set.  Build a
+  // synthetic option from the value itself so renderTrigger / defaultRenderTrigger
+  // can still display something meaningful — label falls back to the resolved key.
+  const effectiveSelected: GenericAutocompleteOption<T> | null =
+    selectedOption ??
+    (value != null
+      ? {
+          key: resolveKey(value),
+          label: resolveKey(value),
+          value,
+        }
+      : null);
+
   // A value is considered "set" when it is not null/undefined.
   // We intentionally do NOT treat empty-string as "unset" here; callers that
   // want to represent "cleared" should pass null instead.
@@ -184,8 +198,8 @@ export function GenericAutocomplete<T>({
     );
 
   const triggerContent = renderTrigger
-    ? renderTrigger(selectedOption, resolvedPlaceholder)
-    : defaultRenderTrigger(selectedOption, resolvedPlaceholder);
+    ? renderTrigger(effectiveSelected, resolvedPlaceholder)
+    : defaultRenderTrigger(effectiveSelected, resolvedPlaceholder);
 
   const handleSelect = (option: GenericAutocompleteOption<T>) => {
     onChange(option.value);
@@ -198,6 +212,13 @@ export function GenericAutocomplete<T>({
     onChange(null);
     handleOpenChange(false);
   };
+
+  // ── Radio loading skeleton ───────────────────────────────────────────────────
+  // When radio is requested but data hasn't arrived yet, show a skeleton rather
+  // than the combobox trigger button to avoid a flash from combobox → radio.
+  if (radio && isLoading) {
+    return <CardListSkeleton count={3} />;
+  }
 
   // ── Radio mode ──────────────────────────────────────────────────────────────
   if (showRadio) {

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -132,6 +132,7 @@ export function GenericAutocomplete<T>({
 }: GenericAutocompleteProps<T>) {
   const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
+  const [searchValue, setSearchValue] = React.useState("");
   const isMobile = useBreakpoints({ default: true, sm: false });
 
   // Apply translation defaults here so they are always localised.
@@ -142,6 +143,7 @@ export function GenericAutocomplete<T>({
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
+    if (!next) setSearchValue("");
     onOpenChange?.(next);
   };
 
@@ -268,7 +270,11 @@ export function GenericAutocomplete<T>({
       <CommandInput
         placeholder={resolvedInputPlaceholder}
         disabled={disabled}
-        onValueChange={(v) => onSearch?.(v)}
+        value={searchValue}
+        onValueChange={(v) => {
+          setSearchValue(v);
+          onSearch?.(v);
+        }}
         className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
         autoFocus
       />
@@ -329,7 +335,7 @@ export function GenericAutocomplete<T>({
       className={cn(
         "w-full justify-between",
         className,
-        hasValue && "rounded-r-none",
+        hasValue && clearSelection && "rounded-r-none",
       )}
       disabled={disabled}
       type="button"
@@ -356,7 +362,7 @@ export function GenericAutocomplete<T>({
             </div>
           </DrawerContent>
         </Drawer>
-        {hasValue && (
+        {hasValue && clearSelection && (
           <Button
             variant="outline"
             size="icon"
@@ -390,7 +396,7 @@ export function GenericAutocomplete<T>({
           <Command shouldFilter={false}>{commandContent}</Command>
         </PopoverContent>
       </Popover>
-      {hasValue && (
+      {hasValue && clearSelection && (
         <Button
           variant="outline"
           size="icon"

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -143,7 +143,10 @@ export function GenericAutocomplete<T>({
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
-    if (!next) setSearchValue("");
+    if (!next) {
+      setSearchValue("");
+      onSearch?.("");
+    }
     onOpenChange?.(next);
   };
 

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -44,8 +44,19 @@ export interface GenericAutocompleteOption<T> {
 interface GenericAutocompleteProps<T> {
   options: GenericAutocompleteOption<T>[];
   isLoading?: boolean;
-  /** Currently selected value — pass null/undefined to indicate nothing selected */
+  /**
+   * Currently selected value — pass null/undefined to indicate nothing
+   * selected. For object types, identity comparison is unreliable; the
+   * component resolves the selected option by key via `getOptionKey`.
+   */
   value: T | null | undefined;
+  /**
+   * Extract the stable key from the current value so the component can find
+   * the matching option even when the value object is a different reference
+   * than the one in `options` (e.g. loaded from an API response).
+   * Defaults to `String(value)` which works for string-typed T.
+   */
+  getOptionKey?: (value: T) => string;
   /** Called with the full value object, or null when cleared */
   onChange: (value: T | null) => void;
   onSearch?: (value: string) => void;
@@ -63,6 +74,8 @@ interface GenericAutocompleteProps<T> {
   /**
    * When true, show a "Clear selection" item at the top of the list when a
    * value is selected. Calls onChange(null).
+   * Note: "has a value" means value is not null/undefined; callers that use
+   * an empty string to represent "cleared" should pass null instead.
    */
   clearSelection?: boolean;
   /**
@@ -99,11 +112,12 @@ export function GenericAutocomplete<T>({
   options,
   isLoading = false,
   value,
+  getOptionKey,
   onChange,
   onSearch,
-  placeholder = "Select...",
-  inputPlaceholder = "Search option...",
-  noOptionsMessage = "No options found",
+  placeholder,
+  inputPlaceholder,
+  noOptionsMessage,
   disabled,
   align = "center",
   className,
@@ -120,17 +134,44 @@ export function GenericAutocomplete<T>({
   const [open, setOpen] = React.useState(false);
   const isMobile = useBreakpoints({ default: true, sm: false });
 
+  // Apply translation defaults here so they are always localised.
+  const resolvedPlaceholder = placeholder ?? t("select_an_option");
+  const resolvedInputPlaceholder = inputPlaceholder ?? t("search_options");
+  const resolvedNoOptionsMessage =
+    noOptionsMessage ?? t("no_search_options_available");
+
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     onOpenChange?.(next);
   };
 
-  // Find the option that matches the current value
-  const selectedOption = options.find((o) => o.value === value) ?? null;
+  // Resolve the selected option by key rather than by reference equality so
+  // that API-fetched objects (different instances) still match.
+  const resolveKey = (v: T): string =>
+    getOptionKey ? getOptionKey(v) : String(v);
 
-  const hasValue =
-    value !== null && value !== undefined && value !== ("" as unknown as T);
-  const showRadio = radio && !isLoading && options.length <= RADIO_THRESHOLD;
+  const selectedOption =
+    value != null
+      ? (options.find((o) => o.key === resolveKey(value)) ?? null)
+      : null;
+
+  // A value is considered "set" when it is not null/undefined.
+  // We intentionally do NOT treat empty-string as "unset" here; callers that
+  // want to represent "cleared" should pass null instead.
+  const hasValue = value !== null && value !== undefined;
+
+  // Radio mode is active only when:
+  //   • radio prop is true
+  //   • not in an initial loading state (skeleton shown instead)
+  //   • there is at least one option (avoids a blank radio group)
+  //   • options count is within the threshold
+  // We do NOT suppress radio on isFetching — background refetches should not
+  // collapse the radio group back to a popover.
+  const showRadio =
+    radio &&
+    !isLoading &&
+    options.length > 0 &&
+    options.length <= RADIO_THRESHOLD;
 
   const defaultRenderTrigger = (
     selected: GenericAutocompleteOption<T> | null,
@@ -143,8 +184,8 @@ export function GenericAutocomplete<T>({
     );
 
   const triggerContent = renderTrigger
-    ? renderTrigger(selectedOption, placeholder)
-    : defaultRenderTrigger(selectedOption, placeholder);
+    ? renderTrigger(selectedOption, resolvedPlaceholder)
+    : defaultRenderTrigger(selectedOption, resolvedPlaceholder);
 
   const handleSelect = (option: GenericAutocompleteOption<T>) => {
     onChange(option.value);
@@ -170,6 +211,7 @@ export function GenericAutocomplete<T>({
         }}
         disabled={disabled}
         className="flex flex-col gap-2"
+        aria-label={resolvedPlaceholder}
       >
         {options.map((option) => {
           const isSelected = option.key === radioValue;
@@ -203,7 +245,7 @@ export function GenericAutocomplete<T>({
   const commandContent = (
     <>
       <CommandInput
-        placeholder={inputPlaceholder}
+        placeholder={resolvedInputPlaceholder}
         disabled={disabled}
         onValueChange={(v) => onSearch?.(v)}
         className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
@@ -213,7 +255,7 @@ export function GenericAutocomplete<T>({
         {isLoading ? (
           <CardListSkeleton count={3} />
         ) : (
-          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+          <CommandEmpty>{resolvedNoOptionsMessage}</CommandEmpty>
         )}
         <CommandGroup>
           {hasValue && clearSelection && (
@@ -266,7 +308,7 @@ export function GenericAutocomplete<T>({
       className={cn(
         "w-full justify-between",
         className,
-        selectedOption && "rounded-r-none",
+        hasValue && "rounded-r-none",
       )}
       disabled={disabled}
       type="button"
@@ -293,7 +335,7 @@ export function GenericAutocomplete<T>({
             </div>
           </DrawerContent>
         </Drawer>
-        {hasValue && selectedOption && (
+        {hasValue && (
           <Button
             variant="outline"
             size="icon"
@@ -327,7 +369,7 @@ export function GenericAutocomplete<T>({
           <Command shouldFilter={false}>{commandContent}</Command>
         </PopoverContent>
       </Popover>
-      {hasValue && selectedOption && (
+      {hasValue && (
         <Button
           variant="outline"
           size="icon"

--- a/src/components/ui/generic-autocomplete.tsx
+++ b/src/components/ui/generic-autocomplete.tsx
@@ -1,0 +1,346 @@
+import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+import { CardListSkeleton } from "@/components/Common/SkeletonLoading";
+
+import useBreakpoints from "@/hooks/useBreakpoints";
+
+const RADIO_THRESHOLD = 5;
+
+export interface GenericAutocompleteOption<T> {
+  /** Unique key used for selection comparison and radio group value */
+  key: string;
+  /** Display label shown in the trigger button when selected */
+  label: string;
+  /** The actual value object */
+  value: T;
+}
+
+interface GenericAutocompleteProps<T> {
+  options: GenericAutocompleteOption<T>[];
+  isLoading?: boolean;
+  /** Currently selected value — pass null/undefined to indicate nothing selected */
+  value: T | null | undefined;
+  /** Called with the full value object, or null when cleared */
+  onChange: (value: T | null) => void;
+  onSearch?: (value: string) => void;
+  placeholder?: string;
+  inputPlaceholder?: string;
+  noOptionsMessage?: string;
+  disabled?: boolean;
+  align?: "start" | "center" | "end";
+  className?: string;
+  popoverClassName?: string;
+  popoverContentClassName?: string;
+  closeOnSelect?: boolean;
+  /** Called whenever the popover/drawer open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * When true, show a "Clear selection" item at the top of the list when a
+   * value is selected. Calls onChange(null).
+   */
+  clearSelection?: boolean;
+  /**
+   * When true, render options as an inline radio group when the number of
+   * options is <= 5 (RADIO_THRESHOLD). No popover/drawer is shown in that case.
+   */
+  radio?: boolean;
+  /**
+   * Optional render prop for each option row inside the popover/radio list.
+   * Receives the option and whether it is currently selected.
+   * Defaults to rendering option.label.
+   */
+  renderOption?: (
+    option: GenericAutocompleteOption<T>,
+    isSelected: boolean,
+  ) => React.ReactNode;
+  /**
+   * Optional render prop for the trigger button content. Receives the
+   * currently selected option (or null) and the placeholder string.
+   * Defaults to rendering the label or placeholder.
+   */
+  renderTrigger?: (
+    selected: GenericAutocompleteOption<T> | null,
+    placeholder: string,
+  ) => React.ReactNode;
+}
+
+/**
+ * GenericAutocomplete — a generic version of Autocomplete that supports any
+ * value type T.  Also supports an optional radio-group mode (radio prop) that
+ * renders options inline when there are ≤ 5 of them.
+ */
+export function GenericAutocomplete<T>({
+  options,
+  isLoading = false,
+  value,
+  onChange,
+  onSearch,
+  placeholder = "Select...",
+  inputPlaceholder = "Search option...",
+  noOptionsMessage = "No options found",
+  disabled,
+  align = "center",
+  className,
+  popoverClassName,
+  popoverContentClassName,
+  closeOnSelect = true,
+  clearSelection = false,
+  radio = false,
+  renderOption,
+  renderTrigger,
+  onOpenChange,
+}: GenericAutocompleteProps<T>) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const isMobile = useBreakpoints({ default: true, sm: false });
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    onOpenChange?.(next);
+  };
+
+  // Find the option that matches the current value
+  const selectedOption = options.find((o) => o.value === value) ?? null;
+
+  const hasValue =
+    value !== null && value !== undefined && value !== ("" as unknown as T);
+  const showRadio = radio && !isLoading && options.length <= RADIO_THRESHOLD;
+
+  const defaultRenderTrigger = (
+    selected: GenericAutocompleteOption<T> | null,
+    ph: string,
+  ) =>
+    selected ? (
+      <span className="truncate">{selected.label}</span>
+    ) : (
+      <span className="text-gray-500">{ph}</span>
+    );
+
+  const triggerContent = renderTrigger
+    ? renderTrigger(selectedOption, placeholder)
+    : defaultRenderTrigger(selectedOption, placeholder);
+
+  const handleSelect = (option: GenericAutocompleteOption<T>) => {
+    onChange(option.value);
+    if (closeOnSelect) handleOpenChange(false);
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onChange(null);
+    handleOpenChange(false);
+  };
+
+  // ── Radio mode ──────────────────────────────────────────────────────────────
+  if (showRadio) {
+    const radioValue = selectedOption?.key ?? "";
+    return (
+      <RadioGroup
+        value={radioValue}
+        onValueChange={(key) => {
+          const opt = options.find((o) => o.key === key);
+          if (opt) onChange(opt.value);
+        }}
+        disabled={disabled}
+        className="flex flex-col gap-2"
+      >
+        {options.map((option) => {
+          const isSelected = option.key === radioValue;
+          return (
+            <label
+              key={option.key}
+              className={cn(
+                "flex items-center gap-3 rounded-md border px-3 py-2 cursor-pointer transition-colors",
+                isSelected
+                  ? "border-primary bg-primary/5"
+                  : "border-gray-200 hover:bg-gray-50",
+                disabled && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              <RadioGroupItem value={option.key} id={option.key} />
+              <div className="flex-1 min-w-0">
+                {renderOption ? (
+                  renderOption(option, isSelected)
+                ) : (
+                  <span className="text-sm">{option.label}</span>
+                )}
+              </div>
+            </label>
+          );
+        })}
+      </RadioGroup>
+    );
+  }
+
+  // ── Popover / Drawer mode ────────────────────────────────────────────────────
+  const commandContent = (
+    <>
+      <CommandInput
+        placeholder={inputPlaceholder}
+        disabled={disabled}
+        onValueChange={(v) => onSearch?.(v)}
+        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm md:pr-0"
+        autoFocus
+      />
+      <CommandList className="overflow-y-auto">
+        {isLoading ? (
+          <CardListSkeleton count={3} />
+        ) : (
+          <CommandEmpty>{noOptionsMessage}</CommandEmpty>
+        )}
+        <CommandGroup>
+          {hasValue && clearSelection && (
+            <CommandItem
+              onSelect={() => {
+                onChange(null);
+                handleOpenChange(false);
+              }}
+              className="cursor-pointer w-full h-9"
+            >
+              <Cross2Icon className="mr-2 size-4" />
+              <span>{t("clear_selection")}</span>
+            </CommandItem>
+          )}
+          {options.map((option) => {
+            const isSelected = selectedOption?.key === option.key;
+            return (
+              <CommandItem
+                key={option.key}
+                value={`${option.label} - ${option.key}`}
+                onSelect={() => handleSelect(option)}
+                className="cursor-pointer w-full"
+              >
+                {renderOption ? (
+                  renderOption(option, isSelected)
+                ) : (
+                  <>
+                    <CheckIcon
+                      className={cn(
+                        "mr-2 size-4",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option.label}
+                  </>
+                )}
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </>
+  );
+
+  const triggerButton = (
+    <Button
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className={cn(
+        "w-full justify-between",
+        className,
+        selectedOption && "rounded-r-none",
+      )}
+      disabled={disabled}
+      type="button"
+    >
+      {triggerContent}
+      <CaretSortIcon className="ml-auto size-4 shrink-0 opacity-50" />
+    </Button>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="flex relative w-full">
+        <Drawer open={open} onOpenChange={handleOpenChange}>
+          <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+          <DrawerContent
+            aria-describedby={undefined}
+            className="min-h-[50vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
+          >
+            <DrawerTitle className="sr-only">
+              {t("autocomplete_options")}
+            </DrawerTitle>
+            <div className="mt-6 pb-[env(safe-area-inset-bottom)] flex-1 overflow-y-auto">
+              <Command shouldFilter={false}>{commandContent}</Command>
+            </div>
+          </DrawerContent>
+        </Drawer>
+        {hasValue && selectedOption && (
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-l-none border-l-0 text-gray-400 h-auto"
+            onClick={handleClear}
+            title={t("clear")}
+            hidden={disabled}
+            type="button"
+          >
+            <Cross2Icon />
+            <span className="sr-only">{t("clear")}</span>
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex relative w-full">
+      <Popover open={open} onOpenChange={handleOpenChange} modal={true}>
+        <PopoverTrigger asChild className={popoverClassName}>
+          {triggerButton}
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "p-0 pointer-events-auto w-[var(--radix-popover-trigger-width)]",
+            popoverContentClassName,
+          )}
+          align={align}
+        >
+          <Command shouldFilter={false}>{commandContent}</Command>
+        </PopoverContent>
+      </Popover>
+      {hasValue && selectedOption && (
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-l-none border-l-0 text-gray-400 h-auto"
+          onClick={handleClear}
+          title={t("clear")}
+          hidden={disabled}
+          type="button"
+        >
+          <Cross2Icon />
+          <span className="sr-only">{t("clear")}</span>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -46,11 +46,7 @@ export const HealthcareServiceSelector = ({
   const [searchValue, setSearchValue] = useState("");
   const [open, setOpen] = useState(false);
 
-  const {
-    data: services,
-    isLoading,
-    isFetching,
-  } = useQuery({
+  const { data: services, isLoading } = useQuery({
     queryKey: ["healthcareServices", facilityId, searchValue, internalType],
     queryFn: query.debounced(healthcareServiceApi.listHealthcareService, {
       pathParams: { facilityId },
@@ -92,6 +88,7 @@ export const HealthcareServiceSelector = ({
                 : "d-health-worker"
             }
             className="size-4 relative z-1"
+            aria-hidden="true"
           />
         </div>
         <div className="flex flex-col min-w-0 flex-1">
@@ -99,7 +96,10 @@ export const HealthcareServiceSelector = ({
             {service.name}
           </span>
           {service.extra_details && (
-            <span className="text-xs text-gray-500 truncate">
+            <span
+              className="text-xs text-gray-500 truncate"
+              title={service.extra_details}
+            >
               {service.extra_details}
             </span>
           )}
@@ -129,6 +129,7 @@ export const HealthcareServiceSelector = ({
                   : "d-health-worker"
               }
               className="size-4 relative z-1"
+              aria-hidden="true"
             />
           </div>
           <span className="truncate">{service.name}</span>
@@ -141,14 +142,15 @@ export const HealthcareServiceSelector = ({
   return (
     <GenericAutocomplete<HealthcareServiceReadSpec>
       options={options}
-      isLoading={isLoading || isFetching}
+      isLoading={isLoading}
+      getOptionKey={(service) => service.id}
       value={selected}
       onChange={onSelect}
       onSearch={setSearchValue}
       onOpenChange={setOpen}
       placeholder={t("select_healthcare_service")}
       inputPlaceholder={t("search")}
-      noOptionsMessage={isFetching ? t("searching") : t("no_services_found")}
+      noOptionsMessage={t("no_services_found")}
       clearSelection={clearSelection}
       radio={radio}
       renderOption={renderOption}

--- a/src/pages/Facility/services/HealthcareServiceSelector.tsx
+++ b/src/pages/Facility/services/HealthcareServiceSelector.tsx
@@ -1,6 +1,5 @@
-import { CaretDownIcon, CheckIcon } from "@radix-ui/react-icons";
+import { CheckIcon } from "@radix-ui/react-icons";
 import { useQuery } from "@tanstack/react-query";
-import { XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,29 +7,12 @@ import ColoredIndicator from "@/CAREUI/display/ColoredIndicator";
 import CareIcon from "@/CAREUI/icons/CareIcon";
 import duoToneIcons from "@/CAREUI/icons/DuoTonePaths.json";
 
-import { Button } from "@/components/ui/button";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  GenericAutocomplete,
+  GenericAutocompleteOption,
+} from "@/components/ui/generic-autocomplete";
 
 import query from "@/Utils/request/query";
-import useBreakpoints from "@/hooks/useBreakpoints";
 import {
   HealthcareServiceReadSpec,
   InternalType,
@@ -45,7 +27,12 @@ interface HealthcareServiceSelectorProps {
   facilityId: string;
   clearSelection?: boolean;
   internalType?: InternalType;
+  /** When true, render options as an inline radio group when count ≤ 5 */
+  radio?: boolean;
 }
+
+const getIconName = (name: string): DuoToneIconName =>
+  `d-${name}` as DuoToneIconName;
 
 export const HealthcareServiceSelector = ({
   facilityId,
@@ -53,11 +40,11 @@ export const HealthcareServiceSelector = ({
   onSelect,
   clearSelection = false,
   internalType,
+  radio = false,
 }: HealthcareServiceSelectorProps) => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
-  const isMobile = useBreakpoints({ default: true, sm: false });
+  const [open, setOpen] = useState(false);
 
   const {
     data: services,
@@ -73,149 +60,101 @@ export const HealthcareServiceSelector = ({
         ...(searchValue && { name: searchValue }),
       },
     }),
-    enabled: open,
+    // Always enabled in radio mode so we have data to decide the render mode;
+    // otherwise only fetch while the dropdown is open.
+    enabled: radio ? true : open,
   });
 
-  const getIconName = (name: string): DuoToneIconName =>
-    `d-${name}` as DuoToneIconName;
+  const options: GenericAutocompleteOption<HealthcareServiceReadSpec>[] = (
+    services?.results ?? []
+  ).map((service) => ({
+    key: service.id,
+    label: service.name,
+    value: service,
+  }));
 
-  const triggerButton = (
-    <Button
-      variant="outline"
-      role="combobox"
-      className="min-w-60 w-full justify-start"
-      disabled={isLoading}
-    >
-      {selected ? (
-        <div className="flex items-center gap-2">
-          <div className="relative size-6 rounded-sm flex items-center justify-center">
+  const renderOption = (
+    option: GenericAutocompleteOption<HealthcareServiceReadSpec>,
+    isSelected: boolean,
+  ) => {
+    const service = option.value;
+    return (
+      <div className="flex items-center gap-2 w-full">
+        <div className="relative size-6 rounded-sm flex items-center justify-center">
+          <ColoredIndicator
+            id={service.id}
+            className="absolute inset-0 rounded-sm opacity-20"
+          />
+          <CareIcon
+            icon={
+              service.styling_metadata?.careIcon
+                ? getIconName(service.styling_metadata.careIcon)
+                : "d-health-worker"
+            }
+            className="size-4 relative z-1"
+          />
+        </div>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span className="truncate text-sm font-medium" title={service.name}>
+            {service.name}
+          </span>
+          {service.extra_details && (
+            <span className="text-xs text-gray-500 truncate">
+              {service.extra_details}
+            </span>
+          )}
+        </div>
+        {isSelected && <CheckIcon className="ml-auto shrink-0" />}
+      </div>
+    );
+  };
+
+  const renderTrigger = (
+    selectedOption: GenericAutocompleteOption<HealthcareServiceReadSpec> | null,
+    placeholder: string,
+  ) => {
+    if (selectedOption) {
+      const service = selectedOption.value;
+      return (
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="relative size-6 rounded-sm flex items-center justify-center shrink-0">
             <ColoredIndicator
-              id={selected.id}
+              id={service.id}
               className="absolute inset-0 rounded-sm opacity-20"
             />
             <CareIcon
               icon={
-                selected.styling_metadata?.careIcon
-                  ? getIconName(selected.styling_metadata.careIcon)
+                service.styling_metadata?.careIcon
+                  ? getIconName(service.styling_metadata.careIcon)
                   : "d-health-worker"
               }
               className="size-4 relative z-1"
             />
           </div>
-          <span className="truncate">{selected.name}</span>
+          <span className="truncate">{service.name}</span>
         </div>
-      ) : (
-        <span className="text-gray-400">{t("select_healthcare_service")}</span>
-      )}
-      <CaretDownIcon className="ml-auto" />
-    </Button>
-  );
-
-  const commandContent = (
-    <Command shouldFilter={false}>
-      <CommandInput
-        placeholder={t("search")}
-        className="outline-hidden border-none ring-0 shadow-none text-base sm:text-sm"
-        value={searchValue}
-        onValueChange={setSearchValue}
-        autoFocus
-      />
-      <CommandList>
-        <CommandEmpty>
-          {isFetching ? t("searching") : t("no_services_found")}
-        </CommandEmpty>
-        <CommandGroup>
-          {selected && clearSelection && (
-            <CommandItem
-              onSelect={() => {
-                onSelect(null);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full h-9"
-            >
-              <>
-                <XIcon />
-                <span> {t("clear_selection")}</span>
-              </>
-            </CommandItem>
-          )}
-          {services?.results.map((service) => (
-            <CommandItem
-              key={service.id}
-              value={service.name}
-              onSelect={() => {
-                onSelect(service);
-                setOpen(false);
-              }}
-              className="cursor-pointer w-full"
-            >
-              <div className="flex items-center gap-2 w-full">
-                <div className="relative size-6 rounded-sm flex items-center justify-center">
-                  <ColoredIndicator
-                    id={service.id}
-                    className="absolute inset-0 rounded-sm opacity-20"
-                  />
-                  <CareIcon
-                    icon={
-                      service.styling_metadata?.careIcon
-                        ? getIconName(service.styling_metadata.careIcon)
-                        : "d-health-worker"
-                    }
-                    className="size-4 relative z-1"
-                  />
-                </div>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span
-                    className="truncate text-sm font-medium"
-                    title={service.name}
-                  >
-                    {service.name}
-                  </span>
-                  {service.extra_details && (
-                    <span className="text-xs text-gray-500 truncate">
-                      {service.extra_details}
-                    </span>
-                  )}
-                </div>
-                {selected?.id === service.id && (
-                  <CheckIcon className="ml-auto" />
-                )}
-              </div>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  );
-
-  if (isMobile) {
-    return (
-      <Drawer open={open} onOpenChange={setOpen} direction="bottom">
-        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
-        <DrawerContent
-          aria-describedby={undefined}
-          className="h-[50vh] px-0 pt-2 pb-0 rounded-t-lg"
-        >
-          <DrawerTitle className="sr-only">
-            {t("select_healthcare_service")}
-          </DrawerTitle>
-          <div className="mt-6 h-full">{commandContent}</div>
-        </DrawerContent>
-      </Drawer>
-    );
-  }
+      );
+    }
+    return <span className="text-gray-400">{placeholder}</span>;
+  };
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild disabled={isLoading}>
-        {triggerButton}
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 w-(--radix-popover-trigger-width)"
-        align="start"
-      >
-        {commandContent}
-      </PopoverContent>
-    </Popover>
+    <GenericAutocomplete<HealthcareServiceReadSpec>
+      options={options}
+      isLoading={isLoading || isFetching}
+      value={selected}
+      onChange={onSelect}
+      onSearch={setSearchValue}
+      onOpenChange={setOpen}
+      placeholder={t("select_healthcare_service")}
+      inputPlaceholder={t("search")}
+      noOptionsMessage={isFetching ? t("searching") : t("no_services_found")}
+      clearSelection={clearSelection}
+      radio={radio}
+      renderOption={renderOption}
+      renderTrigger={renderTrigger}
+      className="min-w-60"
+      align="start"
+    />
   );
 };


### PR DESCRIPTION
## Changes

Adds a new generic autocomplete with radio options (enabled thru props; renders if options is <= 5). Enabled for Healthcare Service Selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable, typed autocomplete selector with search, loading/empty states, and clear-selection.
  - Supports a compact inline radio mode for small option sets.
- **UI Improvements**
  - Updated healthcare service selection to use the new autocomplete experience, including richer option rows and customizable trigger/option rendering.
- **Behavior Changes**
  - In radio mode, healthcare services load automatically; otherwise they load when the selector is opened.
- **Schedule Update**
  - Enabled radio mode for the healthcare-service selector within the schedule resource flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->