### PR TITLE
[ENG-737] Add pagination and search for user departments.

### DIFF
--- a/src/components/Users/UserDepartmentsTab.tsx
+++ b/src/components/Users/UserDepartmentsTab.tsx
@@ -177,8 +177,10 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
         <CareIcon
           icon="l-search"
           className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 size-4"
+          aria-hidden="true"
         />
         <Input
+          aria-label={t("search_by_department_team_name")}
           placeholder={t("search_by_department_team_name")}
           value={qParams.search || ""}
           onChange={(e) => {
@@ -188,28 +190,32 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
         />
       </div>
 
-      {departments.length === 0 ? (
-        hasSearch ? (
-          <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
-            <CareIcon icon="l-search" className="h-16 w-16 text-gray-400" />
-            <p className="mt-4 text-lg font-medium text-gray-600">
-              {t("no_departments_found")}
-            </p>
-            <p className="mt-2 text-sm text-gray-500">
-              {t("search_no_results")}
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
-            <CareIcon icon="l-building" className="h-16 w-16 text-gray-400" />
-            <p className="mt-4 text-lg font-medium text-gray-600">
-              {t("no_departments_assigned")}
-            </p>
-            <p className="mt-2 text-sm text-gray-500">
-              {t("click_link_department_to_get_started")}
-            </p>
-          </div>
-        )
+      {totalCount === 0 && !hasSearch ? (
+        <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
+          <CareIcon
+            icon="l-building"
+            className="h-16 w-16 text-gray-400"
+            aria-hidden="true"
+          />
+          <p className="mt-4 text-lg font-medium text-gray-600">
+            {t("no_departments_assigned")}
+          </p>
+          <p className="mt-2 text-sm text-gray-500">
+            {t("click_link_department_to_get_started")}
+          </p>
+        </div>
+      ) : departments.length === 0 && (hasSearch || totalCount > 0) ? (
+        <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
+          <CareIcon
+            icon="l-search"
+            className="h-16 w-16 text-gray-400"
+            aria-hidden="true"
+          />
+          <p className="mt-4 text-lg font-medium text-gray-600">
+            {t("no_departments_found")}
+          </p>
+          <p className="mt-2 text-sm text-gray-500">{t("search_no_results")}</p>
+        </div>
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/Users/UserDepartmentsTab.tsx
+++ b/src/components/Users/UserDepartmentsTab.tsx
@@ -7,11 +7,14 @@ import CareIcon from "@/CAREUI/icons/CareIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 import { CardGridSkeleton } from "@/components/Common/SkeletonLoading";
 
 import { userChildProps } from "@/components/Common/UserColumns";
 import LinkUserToDepartmentSheet from "@/components/Users/LinkUserToDepartmentSheet";
+
+import useFilters from "@/hooks/useFilters";
 
 import query from "@/Utils/request/query";
 import EditFacilityUserRoleSheet from "@/pages/Facility/settings/organizations/components/EditFacilityUserRoleSheet";
@@ -114,12 +117,28 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
   const { t } = useTranslation();
   const { facilityId } = useCurrentFacility();
 
+  const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
+    limit: 12,
+    disableCache: true,
+  });
+
   const { data: departmentsData, isLoading } = useQuery({
-    queryKey: ["facilityOrganizations", "byUser", facilityId, userData.id],
-    queryFn: query(facilityOrganizationApi.list, {
+    queryKey: [
+      "facilityOrganizations",
+      "byUser",
+      facilityId,
+      userData.id,
+      qParams.page,
+      resultsPerPage,
+      qParams.search,
+    ],
+    queryFn: query.debounced(facilityOrganizationApi.list, {
       pathParams: { facilityId: facilityId! },
       queryParams: {
         containing_user: userData.id,
+        offset: ((qParams.page || 1) - 1) * resultsPerPage,
+        limit: resultsPerPage,
+        name: qParams.search || undefined,
       },
     }),
     enabled: !!facilityId,
@@ -139,6 +158,8 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
   }
 
   const departments = departmentsData?.results ?? [];
+  const totalCount = departmentsData?.count ?? 0;
+  const hasSearch = !!qParams.search;
 
   return (
     <div className="mt-8 space-y-4">
@@ -152,27 +173,61 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
         />
       </div>
 
+      <div className="relative w-full sm:w-72 max-w-full">
+        <CareIcon
+          icon="l-search"
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 size-4"
+        />
+        <Input
+          placeholder={t("search_by_department_team_name")}
+          value={qParams.search || ""}
+          onChange={(e) => {
+            updateQuery({ search: e.target.value || undefined, page: 1 });
+          }}
+          className="w-full pl-8"
+        />
+      </div>
+
       {departments.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
-          <CareIcon icon="l-building" className="h-16 w-16 text-gray-400" />
-          <p className="mt-4 text-lg font-medium text-gray-600">
-            {t("no_departments_assigned")}
-          </p>
-          <p className="mt-2 text-sm text-gray-500">
-            {t("click_link_department_to_get_started")}
-          </p>
-        </div>
+        hasSearch ? (
+          <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
+            <CareIcon icon="l-search" className="h-16 w-16 text-gray-400" />
+            <p className="mt-4 text-lg font-medium text-gray-600">
+              {t("no_departments_found")}
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              {t("search_no_results")}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
+            <CareIcon icon="l-building" className="h-16 w-16 text-gray-400" />
+            <p className="mt-4 text-lg font-medium text-gray-600">
+              {t("no_departments_assigned")}
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              {t("click_link_department_to_get_started")}
+            </p>
+          </div>
+        )
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {departments.map((department) => (
-            <DepartmentCard
-              key={department.id}
-              department={department}
-              userData={userData}
-              facilityId={facilityId}
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {departments.map((department) => (
+              <DepartmentCard
+                key={department.id}
+                department={department}
+                userData={userData}
+                facilityId={facilityId}
+              />
+            ))}
+          </div>
+          {totalCount > resultsPerPage && (
+            <div className="flex justify-center">
+              <Pagination totalCount={totalCount} />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/Users/UserDepartmentsTab.tsx
+++ b/src/components/Users/UserDepartmentsTab.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "raviger";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
@@ -144,6 +145,32 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
     enabled: !!facilityId,
   });
 
+  const departments = departmentsData?.results ?? [];
+  const totalCount = departmentsData?.count ?? 0;
+  const hasSearch = !!qParams.search;
+
+  // Auto-reset to page 1 when the current page is out of range (e.g., after
+  // filtering reduces the total below the current offset). Only fires when
+  // there is no active search so we don't wrongly reset during a search.
+  useEffect(() => {
+    if (
+      !isLoading &&
+      !hasSearch &&
+      totalCount > 0 &&
+      departments.length === 0 &&
+      (qParams.page || 1) > 1
+    ) {
+      updateQuery({ page: 1 });
+    }
+  }, [
+    isLoading,
+    hasSearch,
+    totalCount,
+    departments.length,
+    qParams.page,
+    updateQuery,
+  ]);
+
   if (isLoading) {
     return (
       <div className="mt-8 space-y-4">
@@ -156,10 +183,6 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
       </div>
     );
   }
-
-  const departments = departmentsData?.results ?? [];
-  const totalCount = departmentsData?.count ?? 0;
-  const hasSearch = !!qParams.search;
 
   return (
     <div className="mt-8 space-y-4">
@@ -204,7 +227,7 @@ export default function UserDepartmentsTab({ userData }: userChildProps) {
             {t("click_link_department_to_get_started")}
           </p>
         </div>
-      ) : departments.length === 0 && (hasSearch || totalCount > 0) ? (
+      ) : departments.length === 0 && hasSearch ? (
         <div className="flex flex-col items-center justify-center py-12 border border-dashed border-gray-300 rounded-lg">
           <CareIcon
             icon="l-search"

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -137,13 +137,20 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await page.waitForLoadState("networkidle");
   }
 
-  /** Wait for the organizations API response that is specifically fetching departments for a user. */
-  function waitForOrgsResponse(page: import("@playwright/test").Page) {
+  /** Wait for the organizations API response that is specifically fetching departments for a user.
+   * Pass an optional `pin` substring to require that substring also be present in the URL,
+   * preventing a concurrent/debounce-delayed prior request from resolving the promise early.
+   */
+  function waitForOrgsResponse(
+    page: import("@playwright/test").Page,
+    pin?: string,
+  ) {
     return page.waitForResponse(
       (resp) =>
         resp.request().method() === "GET" &&
         resp.url().includes("/organizations/") &&
         resp.url().includes("containing_user=") &&
+        (pin === undefined || resp.url().includes(pin)) &&
         resp.status() === 200,
     );
   }
@@ -175,7 +182,7 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     const page1Names = await cards1.allTextContents();
 
     // navigate to page 2 using the stable id set by the Pagination component
-    const responsePromise = waitForOrgsResponse(page);
+    const responsePromise = waitForOrgsResponse(page, "offset=12");
     await page.locator("#page-2").click();
     await responsePromise;
 
@@ -201,7 +208,7 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await goToDepartmentsTab(page);
 
     const searchTerm = DEPT_PREFIX;
-    const responsePromise = waitForOrgsResponse(page);
+    const responsePromise = waitForOrgsResponse(page, `name=${encodeURIComponent(searchTerm)}`);
     await page
       .getByPlaceholder("Search by department/team name")
       .fill(searchTerm);
@@ -228,12 +235,12 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     const baselineNames = await cards.allTextContents();
 
     // type a search and wait for the filtered response
-    const searchResponse = waitForOrgsResponse(page);
+    const searchResponse = waitForOrgsResponse(page, `name=${encodeURIComponent(DEPT_PREFIX)}`);
     await input.fill(DEPT_PREFIX);
     await searchResponse;
 
     // clear it and wait for the restored response
-    const clearResponse = waitForOrgsResponse(page);
+    const clearResponse = waitForOrgsResponse(page, "offset=0");
     await input.fill("");
     await clearResponse;
 
@@ -247,7 +254,7 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
   }) => {
     await goToDepartmentsTab(page);
 
-    const responsePromise = waitForOrgsResponse(page);
+    const responsePromise = waitForOrgsResponse(page, "name=zzz_no_match_xyz_999");
     await page
       .getByPlaceholder("Search by department/team name")
       .fill("zzz_no_match_xyz_999");

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -72,6 +72,20 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
   if (!usersData.results.length) throw new Error("No users found in facility");
   const userId = usersData.results[0].id;
 
+  // --- fetch a valid role id once (role ID is the same for all departments) ---
+  const roleListRes = await fetch(
+    `${apiUrl}/api/v1/role/?limit=1`,
+    { headers },
+  );
+  if (!roleListRes.ok)
+    throw new Error(`Failed to fetch roles: ${roleListRes.status}`);
+  const roleListData = (await roleListRes.json()) as {
+    results: Array<{ id: string }>;
+  };
+  if (!roleListData.results.length)
+    throw new Error(`No roles available — cannot link departments to user ${userId}`);
+  const roleId = roleListData.results[0].id;
+
   // --- link each department to the user (best-effort; ignore 409 duplicates) ---
   for (const dept of allDepts) {
     // get already-linked users for this org
@@ -90,22 +104,6 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
       (r) => r.user.id === userId,
     );
     if (alreadyLinked) continue;
-
-    // fetch a valid role id
-    const roleListRes = await fetch(
-      `${apiUrl}/api/v1/role/?limit=1`,
-      { headers },
-    );
-    if (!roleListRes.ok)
-      throw new Error(`Failed to fetch roles: ${roleListRes.status}`);
-    const roleListData = (await roleListRes.json()) as {
-      results: Array<{ id: string }>;
-    };
-    if (!roleListData.results.length)
-      throw new Error(
-        `No roles available — cannot link dept ${dept.id} to user ${userId}`,
-      );
-    const roleId = roleListData.results[0].id;
 
     const linkRes = await fetch(
       `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -67,10 +67,10 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
   if (!usersRes.ok)
     throw new Error(`Failed to list users: ${usersRes.status}`);
   const usersData = (await usersRes.json()) as {
-    results: Array<{ user: { id: string } }>;
+    results: Array<{ id: string }>;
   };
   if (!usersData.results.length) throw new Error("No users found in facility");
-  const userId = usersData.results[0].user.id;
+  const userId = usersData.results[0].id;
 
   // --- link each department to the user (best-effort; ignore 409 duplicates) ---
   for (const dept of allDepts) {

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -79,7 +79,10 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
       `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,
       { headers },
     );
-    if (!rolesRes.ok) continue;
+    if (!rolesRes.ok)
+      throw new Error(
+        `Failed to list users for dept ${dept.id}: ${rolesRes.status}`,
+      );
     const rolesData = (await rolesRes.json()) as {
       results: Array<{ user: { id: string }; role: { id: string } }>;
     };
@@ -93,11 +96,15 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
       `${apiUrl}/api/v1/role/?limit=1`,
       { headers },
     );
-    if (!roleListRes.ok) continue;
+    if (!roleListRes.ok)
+      throw new Error(`Failed to fetch roles: ${roleListRes.status}`);
     const roleListData = (await roleListRes.json()) as {
       results: Array<{ id: string }>;
     };
-    if (!roleListData.results.length) continue;
+    if (!roleListData.results.length)
+      throw new Error(
+        `No roles available — cannot link dept ${dept.id} to user ${userId}`,
+      );
     const roleId = roleListData.results[0].id;
 
     const linkRes = await fetch(
@@ -254,10 +261,11 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
   }) => {
     await goToDepartmentsTab(page);
 
-    const responsePromise = waitForOrgsResponse(page, "name=zzz_no_match_xyz_999");
+    const noMatchTerm = `ZZZ-NoMatch-${faker.string.alphanumeric(12)}`;
+    const responsePromise = waitForOrgsResponse(page, `name=${encodeURIComponent(noMatchTerm)}`);
     await page
       .getByPlaceholder("Search by department/team name")
-      .fill("zzz_no_match_xyz_999");
+      .fill(noMatchTerm);
     await responsePromise;
 
     await expect(page.getByText("No departments found")).toBeVisible();

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -137,10 +137,14 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await page.waitForLoadState("networkidle");
   }
 
-  /** Wait for the organizations API response after an action. */
+  /** Wait for the organizations API response that is specifically fetching departments for a user. */
   function waitForOrgsResponse(page: import("@playwright/test").Page) {
     return page.waitForResponse(
-      (resp) => resp.url().includes("/organizations/") && resp.status() === 200,
+      (resp) =>
+        resp.request().method() === "GET" &&
+        resp.url().includes("/organizations/") &&
+        resp.url().includes("containing_user=") &&
+        resp.status() === 200,
     );
   }
 

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -1,0 +1,239 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import { getApiHeaders, getApiUrl } from "tests/helper/utils";
+import { getFacilityId } from "tests/support/facilityId";
+
+const PAGE_SIZE = 12;
+const DEPT_COUNT = PAGE_SIZE + 3; // 15 — enough to trigger pagination
+const DEPT_PREFIX = "PaginationTest";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+/** Ensure at least DEPT_COUNT departments with the prefix exist, and link them to the first user. */
+async function ensureDepartmentsAndLinkToUser(): Promise<{
+  userId: string;
+  deptNames: string[];
+}> {
+  const facilityId = getFacilityId();
+  const apiUrl = getApiUrl();
+  const headers = getApiHeaders();
+
+  // --- ensure departments exist ---
+  const listRes = await fetch(
+    `${apiUrl}/api/v1/facility/${facilityId}/organizations/?name=${DEPT_PREFIX}&limit=50`,
+    { headers },
+  );
+  if (!listRes.ok) throw new Error(`Failed to list orgs: ${listRes.status}`);
+  const listData = (await listRes.json()) as {
+    count: number;
+    results: Array<{ id: string; name: string }>;
+  };
+
+  const existing = listData.results;
+  const toCreate = Math.max(0, DEPT_COUNT - existing.length);
+
+  const created: Array<{ id: string; name: string }> = [];
+  for (let i = 0; i < toCreate; i++) {
+    const name = `${DEPT_PREFIX} ${faker.string.alphanumeric(6)}`;
+    const res = await fetch(
+      `${apiUrl}/api/v1/facility/${facilityId}/organizations/`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          name,
+          description: "Test department for pagination",
+          org_type: "dept",
+          facility: facilityId,
+        }),
+      },
+    );
+    if (!res.ok) {
+      const txt = await res.text();
+      throw new Error(`Failed to create dept: ${res.status} — ${txt}`);
+    }
+    const dept = (await res.json()) as { id: string; name: string };
+    created.push(dept);
+  }
+
+  const allDepts = [...existing, ...created].slice(0, DEPT_COUNT);
+  const deptNames = allDepts.map((d) => d.name);
+
+  // --- pick the first user in the facility ---
+  const usersRes = await fetch(
+    `${apiUrl}/api/v1/facility/${facilityId}/users/?limit=1`,
+    { headers },
+  );
+  if (!usersRes.ok)
+    throw new Error(`Failed to list users: ${usersRes.status}`);
+  const usersData = (await usersRes.json()) as {
+    results: Array<{ user: { id: string } }>;
+  };
+  if (!usersData.results.length) throw new Error("No users found in facility");
+  const userId = usersData.results[0].user.id;
+
+  // --- link each department to the user (best-effort; ignore 409 duplicates) ---
+  for (const dept of allDepts) {
+    // get available roles for this org
+    const rolesRes = await fetch(
+      `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,
+      { headers },
+    );
+    const rolesData = (await rolesRes.json()) as {
+      results: Array<{ user: { id: string }; role: { id: string } }>;
+    };
+    const alreadyLinked = rolesData.results.some(
+      (r) => r.user.id === userId,
+    );
+    if (alreadyLinked) continue;
+
+    // fetch a valid role id
+    const roleListRes = await fetch(
+      `${apiUrl}/api/v1/role/?limit=1`,
+      { headers },
+    );
+    if (!roleListRes.ok) continue;
+    const roleListData = (await roleListRes.json()) as {
+      results: Array<{ id: string }>;
+    };
+    if (!roleListData.results.length) continue;
+    const roleId = roleListData.results[0].id;
+
+    await fetch(
+      `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ user: userId, role: roleId }),
+      },
+    );
+  }
+
+  return { userId, deptNames };
+}
+
+test.describe("UserDepartmentsTab — search and pagination", () => {
+  let deptNames: string[] = [];
+
+  test.beforeAll(async () => {
+    const result = await ensureDepartmentsAndLinkToUser();
+    deptNames = result.deptNames;
+  });
+
+  async function goToDepartmentsTab(page: import("@playwright/test").Page) {
+    const facilityId = getFacilityId();
+    await page.goto(`/facility/${facilityId}/users`);
+    await expect(
+      page.getByRole("button", { name: "See Details" }).first(),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "See Details" }).first().click();
+    await page.waitForLoadState("networkidle");
+    await page.getByText("Departments", { exact: true }).click();
+    await page.waitForLoadState("networkidle");
+  }
+
+  test("search input is visible above the department cards", async ({
+    page,
+  }) => {
+    await goToDepartmentsTab(page);
+    await expect(
+      page.getByPlaceholder("Search by department/team name"),
+    ).toBeVisible();
+  });
+
+  test("pagination controls appear when dept count exceeds page size", async ({
+    page,
+  }) => {
+    await goToDepartmentsTab(page);
+    // Pagination component renders when count > PAGE_SIZE
+    const pagination = page.getByRole("navigation");
+    await expect(pagination).toBeVisible();
+  });
+
+  test("page 2 shows a different set of cards", async ({ page }) => {
+    await goToDepartmentsTab(page);
+
+    // collect page 1 names
+    const cards1 = page.locator(".grid h3");
+    await expect(cards1.first()).toBeVisible();
+    const page1Names = await cards1.allTextContents();
+
+    // navigate to page 2
+    await page.getByRole("button", { name: "2" }).click();
+    await page.waitForLoadState("networkidle");
+
+    const cards2 = page.locator(".grid h3");
+    await expect(cards2.first()).toBeVisible();
+    const page2Names = await cards2.allTextContents();
+
+    // pages must differ
+    expect(page1Names).not.toEqual(page2Names);
+  });
+
+  test("each page shows at most 12 department cards", async ({ page }) => {
+    await goToDepartmentsTab(page);
+    const cards = page.locator(".grid h3");
+    await expect(cards.first()).toBeVisible();
+    const count = await cards.count();
+    expect(count).toBeLessThanOrEqual(PAGE_SIZE);
+  });
+
+  test("typing a search substring filters cards to matching names", async ({
+    page,
+  }) => {
+    await goToDepartmentsTab(page);
+
+    const searchTerm = DEPT_PREFIX;
+    await page
+      .getByPlaceholder("Search by department/team name")
+      .fill(searchTerm);
+    await page.waitForLoadState("networkidle");
+
+    const cards = page.locator(".grid h3");
+    await expect(cards.first()).toBeVisible();
+    const names = await cards.allTextContents();
+    for (const name of names) {
+      expect(name.toLowerCase()).toContain(searchTerm.toLowerCase());
+    }
+  });
+
+  test("clearing search restores the full first-page list", async ({
+    page,
+  }) => {
+    await goToDepartmentsTab(page);
+
+    const input = page.getByPlaceholder("Search by department/team name");
+
+    // collect baseline first-page names
+    const cards = page.locator(".grid h3");
+    await expect(cards.first()).toBeVisible();
+    const baselineNames = await cards.allTextContents();
+
+    // type a search
+    await input.fill(DEPT_PREFIX);
+    await page.waitForLoadState("networkidle");
+
+    // clear it
+    await input.fill("");
+    await page.waitForLoadState("networkidle");
+
+    await expect(cards.first()).toBeVisible();
+    const restoredNames = await cards.allTextContents();
+    expect(restoredNames).toEqual(baselineNames);
+  });
+
+  test("no results message renders when search matches nothing", async ({
+    page,
+  }) => {
+    await goToDepartmentsTab(page);
+
+    await page
+      .getByPlaceholder("Search by department/team name")
+      .fill("zzz_no_match_xyz_999");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText("No departments found")).toBeVisible();
+    // the pre-existing zero-departments state must NOT appear
+    await expect(page.getByText("No departments assigned")).not.toBeVisible();
+  });
+});

--- a/tests/facility/users/userDepartmentsPagination.spec.ts
+++ b/tests/facility/users/userDepartmentsPagination.spec.ts
@@ -5,14 +5,15 @@ import { getFacilityId } from "tests/support/facilityId";
 
 const PAGE_SIZE = 12;
 const DEPT_COUNT = PAGE_SIZE + 3; // 15 — enough to trigger pagination
-const DEPT_PREFIX = "PaginationTest";
+// Per-run unique prefix avoids stale records from prior runs satisfying the
+// count without being linked to the current test user.
+const DEPT_PREFIX = `PaginationTest-${faker.string.alphanumeric(8)}`;
 
 test.use({ storageState: "tests/.auth/user.json" });
 
 /** Ensure at least DEPT_COUNT departments with the prefix exist, and link them to the first user. */
 async function ensureDepartmentsAndLinkToUser(): Promise<{
   userId: string;
-  deptNames: string[];
 }> {
   const facilityId = getFacilityId();
   const apiUrl = getApiUrl();
@@ -57,7 +58,6 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
   }
 
   const allDepts = [...existing, ...created].slice(0, DEPT_COUNT);
-  const deptNames = allDepts.map((d) => d.name);
 
   // --- pick the first user in the facility ---
   const usersRes = await fetch(
@@ -74,11 +74,12 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
 
   // --- link each department to the user (best-effort; ignore 409 duplicates) ---
   for (const dept of allDepts) {
-    // get available roles for this org
+    // get already-linked users for this org
     const rolesRes = await fetch(
       `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,
       { headers },
     );
+    if (!rolesRes.ok) continue;
     const rolesData = (await rolesRes.json()) as {
       results: Array<{ user: { id: string }; role: { id: string } }>;
     };
@@ -99,7 +100,7 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
     if (!roleListData.results.length) continue;
     const roleId = roleListData.results[0].id;
 
-    await fetch(
+    const linkRes = await fetch(
       `${apiUrl}/api/v1/facility/${facilityId}/organizations/${dept.id}/users/`,
       {
         method: "POST",
@@ -107,17 +108,21 @@ async function ensureDepartmentsAndLinkToUser(): Promise<{
         body: JSON.stringify({ user: userId, role: roleId }),
       },
     );
+    // 409 = already linked (race or duplicate); anything else is an unexpected failure
+    if (!linkRes.ok && linkRes.status !== 409) {
+      const txt = await linkRes.text();
+      throw new Error(
+        `Failed to link dept ${dept.id} to user ${userId}: ${linkRes.status} — ${txt}`,
+      );
+    }
   }
 
-  return { userId, deptNames };
+  return { userId };
 }
 
 test.describe("UserDepartmentsTab — search and pagination", () => {
-  let deptNames: string[] = [];
-
   test.beforeAll(async () => {
-    const result = await ensureDepartmentsAndLinkToUser();
-    deptNames = result.deptNames;
+    await ensureDepartmentsAndLinkToUser();
   });
 
   async function goToDepartmentsTab(page: import("@playwright/test").Page) {
@@ -130,6 +135,13 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await page.waitForLoadState("networkidle");
     await page.getByText("Departments", { exact: true }).click();
     await page.waitForLoadState("networkidle");
+  }
+
+  /** Wait for the organizations API response after an action. */
+  function waitForOrgsResponse(page: import("@playwright/test").Page) {
+    return page.waitForResponse(
+      (resp) => resp.url().includes("/organizations/") && resp.status() === 200,
+    );
   }
 
   test("search input is visible above the department cards", async ({
@@ -145,8 +157,8 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     page,
   }) => {
     await goToDepartmentsTab(page);
-    // Pagination component renders when count > PAGE_SIZE
-    const pagination = page.getByRole("navigation");
+    // Scope to the pagination container (nav rendered inside useFilters Pagination)
+    const pagination = page.locator("nav").filter({ has: page.locator("#page-2") });
     await expect(pagination).toBeVisible();
   });
 
@@ -158,9 +170,10 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await expect(cards1.first()).toBeVisible();
     const page1Names = await cards1.allTextContents();
 
-    // navigate to page 2
-    await page.getByRole("button", { name: "2" }).click();
-    await page.waitForLoadState("networkidle");
+    // navigate to page 2 using the stable id set by the Pagination component
+    const responsePromise = waitForOrgsResponse(page);
+    await page.locator("#page-2").click();
+    await responsePromise;
 
     const cards2 = page.locator(".grid h3");
     await expect(cards2.first()).toBeVisible();
@@ -184,10 +197,11 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await goToDepartmentsTab(page);
 
     const searchTerm = DEPT_PREFIX;
+    const responsePromise = waitForOrgsResponse(page);
     await page
       .getByPlaceholder("Search by department/team name")
       .fill(searchTerm);
-    await page.waitForLoadState("networkidle");
+    await responsePromise;
 
     const cards = page.locator(".grid h3");
     await expect(cards.first()).toBeVisible();
@@ -209,13 +223,15 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
     await expect(cards.first()).toBeVisible();
     const baselineNames = await cards.allTextContents();
 
-    // type a search
+    // type a search and wait for the filtered response
+    const searchResponse = waitForOrgsResponse(page);
     await input.fill(DEPT_PREFIX);
-    await page.waitForLoadState("networkidle");
+    await searchResponse;
 
-    // clear it
+    // clear it and wait for the restored response
+    const clearResponse = waitForOrgsResponse(page);
     await input.fill("");
-    await page.waitForLoadState("networkidle");
+    await clearResponse;
 
     await expect(cards.first()).toBeVisible();
     const restoredNames = await cards.allTextContents();
@@ -227,10 +243,11 @@ test.describe("UserDepartmentsTab — search and pagination", () => {
   }) => {
     await goToDepartmentsTab(page);
 
+    const responsePromise = waitForOrgsResponse(page);
     await page
       .getByPlaceholder("Search by department/team name")
       .fill("zzz_no_match_xyz_999");
-    await page.waitForLoadState("networkidle");
+    await responsePromise;
 
     await expect(page.getByText("No departments found")).toBeVisible();
     // the pre-existing zero-departments state must NOT appear


### PR DESCRIPTION
## Changes

Add pagination and search for user departments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debounced, server-side search and filtering to the user’s **Departments** tab.
  * Added server-side pagination for department/team results with automatic page reset when search is cleared or no longer applicable.
  * Improved empty-state messages to distinguish **“no departments assigned”** vs **“no departments found”** during search.
* **Bug Fixes**
  * Fixed pagination getting stuck on empty pages after pagination changes.
* **Tests**
  * Added Playwright end-to-end tests validating search, page-to-page results, per-page limits, case-insensitive matching, clearing search, and correct empty-state text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->