### PR TITLE
[ENG-784] Encounter Action button is clipping out

### DIFF
--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -237,13 +237,13 @@ export const EncounterShow = (props: Props) => {
           />
           {selectedEncounter && (
             <div className="flex max-md:flex-col items-end justify-center gap-4">
-              <div>
+              <div className="w-full md:w-auto">
                 <PLUGIN_Component
                   __name="PatientInfoCardQuickActions"
                   encounter={selectedEncounter}
                   className={cn(
                     buttonVariants({ variant: "primary_gradient" }),
-                    "text-base font-semibold rounded-md w-full",
+                    "text-base font-semibold rounded-md w-full md:w-auto",
                   )}
                 />
               </div>

--- a/src/pages/Encounters/EncounterShow.tsx
+++ b/src/pages/Encounters/EncounterShow.tsx
@@ -237,14 +237,16 @@ export const EncounterShow = (props: Props) => {
           />
           {selectedEncounter && (
             <div className="flex max-md:flex-col items-end justify-center gap-4">
-              <PLUGIN_Component
-                __name="PatientInfoCardQuickActions"
-                encounter={selectedEncounter}
-                className={cn(
-                  buttonVariants({ variant: "primary_gradient" }),
-                  "text-base font-semibold rounded-md w-full",
-                )}
-              />
+              <div>
+                <PLUGIN_Component
+                  __name="PatientInfoCardQuickActions"
+                  encounter={selectedEncounter}
+                  className={cn(
+                    buttonVariants({ variant: "primary_gradient" }),
+                    "text-base font-semibold rounded-md w-full",
+                  )}
+                />
+              </div>
 
               <EncounterCommandDialog
                 encounter={selectedEncounter}


### PR DESCRIPTION
## Proposed Changes

Fixes [ENG-784]

<img width="1514" height="378" alt="image" src="https://github.com/user-attachments/assets/ec458ba7-5dea-4a03-b877-7848760474c4" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


[ENG-784]: https://openhealthcarenetwork.atlassian.net/browse/ENG-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the layout structure around encounter quick actions for improved rendering consistency.
  * Made the quick-actions container responsive by using full width on smaller screens and automatic width on medium and larger screens.
  * Preserved the existing appearance of the patient information quick-action button (including gradient styling and typography).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->