### PR TITLE
[ENG-797] Disable titrated dosage input for read-only medication requests

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -1697,7 +1697,12 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
     >
       {/* Medicine Name */}
       {desktopLayout && (
-        <div className="lg:p-4 lg:px-2 lg:py-1 flex flex-col justify-between lg:col-span-1 lg:border-r border-gray-200 font-medium overflow-hidden text-sm">
+        <div
+          className={cn(
+            "lg:p-4 lg:px-2 lg:py-1 flex flex-col lg:col-span-1 lg:border-r border-gray-200 font-medium overflow-hidden text-sm",
+            isReadOnly ? "justify-center" : "justify-between",
+          )}
+        >
           <span
             className={cn(
               "wrap-break-word line-clamp-2 hidden lg:block",
@@ -1744,6 +1749,7 @@ const MedicationRequestGridRow: React.FC<MedicationRequestGridRowProps> = ({
                         "h-9 text-sm cursor-pointer",
                         hasError(fieldKey) && "border-red-500",
                       )}
+                      disabled={disabled || isReadOnly}
                     />
                   ) : (
                     <>


### PR DESCRIPTION
## Proposed Changes

- ENG-797

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the alignment of medicine names in read-only medication rows.
  * Prevented dose-range fields from being edited when medication rows are disabled or read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->