### PR TITLE
fix: align UserColumns label with card content on desktop

### DIFF
--- a/src/components/Common/UserColumns.tsx
+++ b/src/components/Common/UserColumns.tsx
@@ -19,7 +19,7 @@ export default function UserColumns({
 }) {
   return (
     <section
-      className="flex flex-col gap-5 sm:flex-row"
+      className="flex flex-col gap-5 sm:flex-row sm:items-center"
       aria-labelledby="section-heading"
     >
       <div className="sm:w-1/4">


### PR DESCRIPTION
## What
On the user profile page, section labels (e.g. "Personal Information", "Contact Information") weren't aligned with their content cards they'd stretch to match card height, leaving labels floating awkwardly next to shorter cards. Made the page feel visually inconsistent.

## Fix
Added `sm:items-center` to the flex container in `UserColumns.tsx` so labels align naturally with their cards on desktop. Verified mobile layout is unaffected (stacked view stays the same).

## Screenshots
**Before:** [
<img width="1511" height="816" alt="Screenshot 2026-07-24 013506" src="https://github.com/user-attachments/assets/4a80b407-c280-47d8-9345-321c985cddfe" />
]
**After:** [
<img width="1536" height="532" alt="Screenshot 2026-07-24 013527" src="https://github.com/user-attachments/assets/f352efa2-2684-46d2-983b-939d9f03e308" />
]
 
Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist
- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment of the user columns layout on small-screen devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->