### PR TITLE
Auto-focus first input field of Login (as staff and patient)

### DIFF
--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -108,6 +108,8 @@ const Login = (props: LoginProps) => {
   const [otpError, setOtpError] = useState<string>("");
   const [otpValidationError, setOtpValidationError] = useState<string>("");
   const [resendOtpCountdown, setResendOtpCountdown] = useState(0);
+  const activeMode =
+    !disablePatientLogin && mode === "patient" ? "patient" : "staff";
 
   // Timer Function for resend OTP
   useEffect(() => {
@@ -129,10 +131,11 @@ const Login = (props: LoginProps) => {
 
   // Autofocuses when switching tabs
   useEffect(() => {
-    requestAnimationFrame(() => {
+    const frame = requestAnimationFrame(() => {
       document.getElementById(mode === "staff" ? "username" : "phone")?.focus();
     });
-  }, [mode]);
+    return cancelAnimationFrame(frame);
+  }, [activeMode]);
 
   // Send OTP Mutation
   const { mutate: sendOtp, isPending: sendOtpPending } = useMutation({

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -134,7 +134,7 @@ const Login = (props: LoginProps) => {
     const frame = requestAnimationFrame(() => {
       document.getElementById(mode === "staff" ? "username" : "phone")?.focus();
     });
-    return cancelAnimationFrame(frame);
+    return () => cancelAnimationFrame(frame);
   }, [activeMode]);
 
   // Send OTP Mutation

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -132,7 +132,9 @@ const Login = (props: LoginProps) => {
   // Autofocuses when switching tabs
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      document.getElementById(mode === "staff" ? "username" : "phone")?.focus();
+      document
+        .getElementById(activeMode === "staff" ? "username" : "phone")
+        ?.focus();
     });
     return () => cancelAnimationFrame(frame);
   }, [activeMode]);

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -127,6 +127,13 @@ const Login = (props: LoginProps) => {
     localStorage.setItem(LocalStorageKeys.loginPreference, mode);
   }, [mode]);
 
+  // Autofocuses when switching tabs
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      document.getElementById(mode === "staff" ? "username" : "phone")?.focus();
+    });
+  }, [mode]);
+
   // Send OTP Mutation
   const { mutate: sendOtp, isPending: sendOtpPending } = useMutation({
     mutationFn: mutate(otpApi.send),


### PR DESCRIPTION
## Proposed Changes

Fixes #16604
- added a useEffect so whenever the mode changes the inputs autofocus
- added requestAnimationFrame(), so it first waits for the DOM to change and then perform the fn afterwards


https://github.com/user-attachments/assets/f0f1fbb9-a635-401d-8619-1c6100d2958c



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [X] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [X] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Usability Improvements**
  * Automatically focuses the appropriate username or phone field when switching sign-in modes.
  * Defaults to staff sign-in when patient sign-in is unavailable.
  * Makes switching between available sign-in modes smoother and more intuitive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->