### PR TITLE
Set up Cursor Cloud dev environment + document setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Naming**: PascalCase for components/classes, camelCase for variables/functions
 - **Components**: Organized by feature, maintain separation of concerns
 - **Error Handling**: Use dedicated error handlers, TypeScript strict null checks
+
+## Cursor Cloud specific instructions
+
+This is the CARE frontend (`care_fe`, React 19 + Vite). Standard commands live in `CLAUDE.md` and `package.json` scripts — refer to those; notes below only cover non-obvious environment caveats.
+
+### Node version
+- `.node-version` pins **Node 24**, but the base image's `/exec-daemon/node` is **v22** and shadows nvm in `PATH`. Login shells (e.g. new `tmux` sessions) already get Node 24 via a line appended to `~/.bashrc`. If a non-login/non-interactive shell reports v22, prepend it manually: `export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH"`. The startup update script only runs `npm install`; Node 22 handles that fine.
+
+### Frontend
+- `npm run dev` serves on **http://localhost:4000**. `.env.local` sets `REACT_CARE_API_URL=http://127.0.0.1:9000` so the app talks to the local backend. `.env.local` is gitignored; it persists in the VM snapshot but recreate it with that single line if missing. Without it, the committed `.env` points to the hosted `https://careapi.ohc.network` (which does NOT have the fixture accounts, so local login fails).
+
+### Local backend (required for login / full E2E)
+- The separate `ohcnetwork/care` Django backend is checked out at **`~/care`** (pipenv venv at `~/care/.venv`, Python 3.13) with the DB migrated + fixtures loaded. Login credentials are in `CLAUDE.md`.
+- PostgreSQL 16 and Redis are installed but NOT started by systemd — start them each boot:
+  `sudo pg_ctlcluster 16 main start` and `sudo redis-server --daemonize yes`.
+- Start the API on port 9000 from `~/care`:
+  `DJANGO_SETTINGS_MODULE=config.settings.local DJANGO_READ_DOT_ENV_FILE=true .venv/bin/python manage.py runserver 0.0.0.0:9000`
+  (backend `~/care/.env` points `DATABASE_URL` at `localhost:5432/care` and `REDIS_URL` at `localhost:6379`).
+- Refresh backend deps only when the backend repo changes: `cd ~/care && PATH="$HOME/.local/bin:$PATH" PIPENV_VENV_IN_PROJECT=1 pipenv sync --dev`.
+
+### Playwright
+- Requires the backend on 9000. Set `CARE_BACKEND_DIR=~/care` for the `playwright:db-*` scripts (snapshot at `/tmp/care_playwright_snapshot.dump`); `globalSetup` auto-restores it locally. Per `CLAUDE.md`, tests are meant to run against the production build (`npm run build` + `npm run preview`); `reuseExistingServer` will reuse whatever is on port 4000, and running against the `npm run dev` server can be flaky under parallel workers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the full development environment for `care_fe` in Cursor Cloud and documents non-obvious startup caveats for future agents.

The only code change is an `AGENTS.md` addition (a `## Cursor Cloud specific instructions` section). All other setup (Node 24 via nvm, npm deps, local CARE backend, Postgres/Redis, Playwright browser) is environment/VM state, captured via the startup update script (`npm install`) and the VM snapshot.

## What was set up

- **Frontend** (`care_fe`): Node 24 (per `.node-version`), `npm install`, dev server on `http://localhost:4000` pointed at the local backend via `.env.local` (`REACT_CARE_API_URL=http://127.0.0.1:9000`).
- **Local backend** (`ohcnetwork/care`, cloned to `~/care`): Python 3.13 + pipenv venv, PostgreSQL 16 + Redis, migrations + `load_fixtures`, running on port 9000. Needed because the hosted backend has no fixture accounts.
- **Playwright**: chromium installed, DB snapshot created; validated `setup` projects (DB restore, auth, token refresh) pass.

## Verification

| Task | Command | Result |
| --- | --- | --- |
| Lint | `npm run lint` | 0 errors (warnings only) |
| Build | `npm run build` | ✓ built |
| Run (dev) | `npm run dev` | serves 200 on :4000 |
| Backend | `manage.py runserver 0.0.0.0:9000` | login 200 |
| Tests | `npx playwright test tests/setup/... ` | setup projects pass (DB restore + auth) |

## Hello-world demo

Logged in as `admin` and registered a new patient ("Jane Testpatient") end-to-end against the local backend, ending in a "Patient Registered Successfully" confirmation.

[care_patient_registration_demo.mp4](https://cursor.com/agents/bc-3e76c3c6-8217-4912-9477-47d4e6d85c07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcare_patient_registration_demo.mp4)

[Patient registered success](https://cursor.com/agents/bc-3e76c3c6-8217-4912-9477-47d4e6d85c07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcare_patient_registered_success.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e76c3c6-8217-4912-9477-47d4e6d85c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e76c3c6-8217-4912-9477-47d4e6d85c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

