### PR TITLE
[ENG-845] Adds `mutate.atomic` for atomic batch requests, ⚒️ fixes error handling of batch requests

### DIFF
--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -2653,6 +2653,7 @@
   "file_preview_not_supported": "Can't preview this file. Try downloading it.",
   "file_saved_successfully": "File saved successfully",
   "file_success__upload_complete": "File upload complete",
+  "file_too_large": "File too large",
   "file_type": "File Type",
   "file_upload_error": "Error uploading file",
   "file_upload_success": "File uploaded successfully",

--- a/src/Utils/request/README.md
+++ b/src/Utils/request/README.md
@@ -178,3 +178,75 @@ function UpdatePatient({ patientId }: { patientId: string }) {
   return <PatientForm onSubmit={handleSubmit} />;
 }
 ```
+
+### Send atomic batch requests with `mutate.atomic`
+
+Use `mutate.atomic` to send more than one request as one atomic batch
+request. The server runs all of the requests together. The batch is atomic:
+if one request fails, the server stops all of the requests. Then no request
+in the batch changes the data.
+
+Give `mutate.atomic` an array of request objects. Each request object has
+these properties:
+
+- `api`: the API route to call.
+- `pathParams`: the path parameters for the route. This property is optional.
+- `body`: the data to send in the request.
+- `referenceId`: a unique name for the request.
+
+```tsx
+import { useMutation } from "@tanstack/react-query";
+
+import { BatchRequestObject } from "@/Utils/request/batch";
+import mutate from "@/Utils/request/mutate";
+
+function DispenseMedications({ patientId }: { patientId: string }) {
+  const { mutate: dispense, isPending } = useMutation({
+    mutationFn: mutate.atomic(),
+    onSuccess: (response) => {
+      // The response has one result for each request in the batch.
+      // Each result has the reference_id, the status_code, and the data.
+      toast.success("The medications are dispensed.");
+    },
+  });
+
+  const handleDispense = () => {
+    const requests: BatchRequestObject[] = [
+      {
+        api: medicationDispenseApi.create,
+        body: dispenseData,
+        referenceId: "dispense_1",
+      },
+      {
+        api: prescriptionApi.upsert,
+        pathParams: { patientId },
+        body: { datapoints },
+        referenceId: "prescription_completion",
+      },
+    ];
+
+    dispense(requests);
+  };
+
+  return (
+    <Button onClick={handleDispense} disabled={isPending}>
+      Dispense
+    </Button>
+  );
+}
+```
+
+On success, the response contains a `results` array. The array has one
+result for each request. Each result contains the `reference_id`, the
+`status_code`, and the `data`.
+
+On failure, `mutate.atomic` shows an error for each request that failed. It
+does not show an error for the other requests in the batch. The mutation
+goes to the error state. Add an `onError` function if you must do more steps
+after a failure.
+
+To stop the error notifications, set the `silent` option:
+
+```tsx
+mutationFn: mutate.atomic({ silent: true });
+```

--- a/src/Utils/request/batch.ts
+++ b/src/Utils/request/batch.ts
@@ -2,7 +2,7 @@ import {
   BatchRequestBody,
   BatchRequestResponse,
 } from "@/types/base/batch/batch";
-import mutate from "@/Utils/request/mutate";
+import { callApi } from "@/Utils/request/query";
 import { ApiRoute, HttpMethod, Type } from "@/Utils/request/types";
 import { makeUrl } from "@/Utils/request/utils";
 import {
@@ -12,11 +12,55 @@ import {
   UseMutationOptions,
 } from "@tanstack/react-query";
 
+export const batchRequestRoute = {
+  path: "/api/v1/batch_requests/",
+  method: HttpMethod.POST,
+  TRes: Type<BatchRequestResponse>(),
+  TBody: Type<BatchRequestBody>(),
+} as const;
+
 export interface BatchRequestObject<T = unknown> {
   api: ApiRoute<unknown, unknown>;
   pathParams?: Record<string, string>;
   body: T;
   referenceId: string;
+}
+
+/**
+ * Maps an array of {@link BatchRequestObject}s to the body expected by the
+ * batch request endpoint.
+ */
+export function buildBatchRequestBody(
+  requests: BatchRequestObject[],
+): BatchRequestBody {
+  return {
+    requests: requests.map((request) => ({
+      url: makeUrl(request.api.path, undefined, request.pathParams),
+      method: request.api.method ?? HttpMethod.GET,
+      reference_id: request.referenceId,
+      body: request.body,
+    })),
+  };
+}
+
+/**
+ * Type guard that narrows an {@link HTTPError} cause to a batch request
+ * response (an object with a `results` array of per-sub-request results).
+ */
+export function isBatchResult(cause: unknown): cause is BatchRequestResponse {
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    "results" in cause &&
+    Array.isArray((cause as BatchRequestResponse).results) &&
+    (cause as BatchRequestResponse).results.every(
+      (result) =>
+        typeof result === "object" &&
+        result !== null &&
+        "reference_id" in result &&
+        "status_code" in result,
+    )
+  );
 }
 
 export function useBatchRequest<TError = DefaultError, TContext = unknown>(
@@ -31,18 +75,8 @@ export function useBatchRequest<TError = DefaultError, TContext = unknown>(
   const mutation = useMutation(
     {
       mutationFn: (requests: BatchRequestObject[]) =>
-        mutate({
-          path: "/api/v1/batch_requests/",
-          method: HttpMethod.POST,
-          TRes: Type<BatchRequestResponse>(),
-          TBody: Type<BatchRequestBody>(),
-        })({
-          requests: requests.map((request) => ({
-            url: makeUrl(request.api.path, undefined, request.pathParams),
-            method: request.api.method ?? HttpMethod.GET,
-            reference_id: request.referenceId,
-            body: request.body,
-          })),
+        callApi(batchRequestRoute, {
+          body: buildBatchRequestBody(requests),
         }),
       ...options,
     },

--- a/src/Utils/request/errorHandler.ts
+++ b/src/Utils/request/errorHandler.ts
@@ -2,7 +2,9 @@ import { t } from "i18next";
 import { navigate } from "raviger";
 import { toast } from "sonner";
 
+import { BatchRequestResult } from "@/types/base/batch/batch";
 import * as Notifications from "@/Utils/Notifications";
+import { isBatchResult } from "@/Utils/request/batch";
 import { HTTPError, StructuredError } from "@/Utils/request/types";
 
 export function handleHttpError(error: Error) {
@@ -18,12 +20,30 @@ export function handleHttpError(error: Error) {
 
   const cause = error.cause;
 
-  if (isNotFound(error)) {
+  // Batch responses carry a result per sub-request. Only the failed ones
+  // should be surfaced; the succeeded ones must not toast a generic error.
+  if (isBatchResult(cause)) {
+    handleBatchErrors(cause.results);
+    return;
+  }
+
+  handleErrorCause(error.status, cause);
+}
+
+function handleBatchErrors(results: BatchRequestResult[]) {
+  for (const result of results) {
+    if (result.status_code < 400) continue;
+    handleErrorCause(result.status_code, result.data as HTTPError["cause"]);
+  }
+}
+
+function handleErrorCause(status: number, cause: HTTPError["cause"]) {
+  if (isNotFound(status)) {
     toast.error((cause?.detail as string) || t("not_found"));
     return;
   }
 
-  if (contentTooLarge(error)) {
+  if (contentTooLarge(status)) {
     toast.error(t("file_too_large"));
     return;
   }
@@ -33,7 +53,7 @@ export function handleHttpError(error: Error) {
     return;
   }
 
-  if (isBadRequest(error)) {
+  if (isBadRequest(status)) {
     if (Array.isArray(cause)) {
       let handled = false;
       for (const obj of cause) {
@@ -80,16 +100,16 @@ function handleSessionExpired() {
   }
 }
 
-function isBadRequest(error: HTTPError) {
-  return error.status === 400 || error.status === 406;
+function isBadRequest(status: number) {
+  return status === 400 || status === 406;
 }
 
-function isNotFound(error: HTTPError) {
-  return error.status === 404;
+function isNotFound(status: number) {
+  return status === 404;
 }
 
-function contentTooLarge(error: HTTPError) {
-  return error.status === 413;
+function contentTooLarge(status: number) {
+  return status === 413;
 }
 
 type PydanticError = {

--- a/src/Utils/request/mutate.ts
+++ b/src/Utils/request/mutate.ts
@@ -1,5 +1,13 @@
+import {
+  BatchRequestObject,
+  batchRequestRoute,
+  buildBatchRequestBody,
+  isBatchResult,
+} from "@/Utils/request/batch";
+import { handleHttpError } from "@/Utils/request/errorHandler";
 import { callApi } from "@/Utils/request/query";
-import { ApiCallOptions, ApiRoute } from "@/Utils/request/types";
+import { ApiCallOptions, ApiRoute, HTTPError } from "@/Utils/request/types";
+import { BatchRequestResponse } from "@/types/base/batch/batch";
 
 /**
  * Creates a TanStack Query compatible mutation function.
@@ -24,3 +32,66 @@ export default function mutate<Route extends ApiRoute<unknown, unknown>>(
     return callApi(route, { ...options, body: variables });
   };
 }
+
+type AtomicOptions = Pick<
+  ApiCallOptions<typeof batchRequestRoute>,
+  "silent" | "headers" | "signal"
+>;
+
+/**
+ * Executes an array of requests as a single atomic batch request.
+ */
+export async function callAtomicApi<T = unknown>(
+  requests: BatchRequestObject[],
+  options?: AtomicOptions,
+): Promise<BatchRequestResponse<T>> {
+  try {
+    const response = await callApi(batchRequestRoute, {
+      ...options,
+      body: buildBatchRequestBody(requests),
+    });
+    return response as unknown as BatchRequestResponse<T>;
+  } catch (error) {
+    if (error instanceof HTTPError && isBatchResult(error.cause)) {
+      for (const result of error.cause.results) {
+        if (result.status_code < 400) continue;
+        handleHttpError(
+          new HTTPError({
+            message: error.message,
+            status: result.status_code,
+            silent: error.silent,
+            cause: result.data as Record<string, unknown>,
+          }),
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Creates a TanStack Query compatible mutation function that dispatches an
+ * array of requests as a single atomic batch request.
+ *
+ * Unlike a raw batch request, sub-response errors are handled per-request: on
+ * failure only the non-2xx sub-responses are surfaced to the error handler.
+ *
+ * Example:
+ * ```tsx
+ * const { mutate: dispense } = useMutation({
+ *   mutationFn: mutate.atomic(),
+ *   onSuccess: (response) => {
+ *     // response.results is the array of successful sub-responses
+ *   },
+ * });
+ *
+ * dispense([
+ *   { api: medicationDispenseApi.create, body: dispenseData, referenceId: "d1" },
+ *   { api: prescriptionApi.upsert, pathParams: { patientId }, body, referenceId: "p1" },
+ * ]);
+ * ```
+ */
+mutate.atomic = <T = unknown>(options?: AtomicOptions) => {
+  return (requests: BatchRequestObject[]) =>
+    callAtomicApi<T>(requests, options);
+};

--- a/src/pages/Facility/services/pharmacy/hooks/useMedicationBill.ts
+++ b/src/pages/Facility/services/pharmacy/hooks/useMedicationBill.ts
@@ -14,7 +14,6 @@ import {
 } from "@/pages/Facility/services/pharmacy/types";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 
-import batchApi from "@/types/base/batch/batchApi";
 import {
   calculateTotalPriceWithQuantity,
   MonetaryComponentType,
@@ -39,6 +38,7 @@ import {
   MedicationDispenseCreate,
   MedicationDispenseStatus,
 } from "@/types/emr/medicationDispense/medicationDispense";
+import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
 import {
   ACTIVE_MEDICATION_STATUSES,
   computeMedicationDispenseQuantity,
@@ -56,6 +56,7 @@ import inventoryApi from "@/types/inventory/product/inventoryApi";
 import { ProductKnowledgeBase } from "@/types/inventory/productKnowledge/productKnowledge";
 import { isGreaterThan, isZero, round, roundWhole } from "@/Utils/decimal";
 import { isLotAllowedForDispensing } from "@/Utils/inventory";
+import { BatchRequestObject } from "@/Utils/request/batch";
 import mutate from "@/Utils/request/mutate";
 import query from "@/Utils/request/query";
 import { HTTPError } from "@/Utils/request/types";
@@ -460,8 +461,8 @@ export function useMedicationBill({
 
   // Dispense mutation
   const { mutate: dispense, isPending } = useMutation({
-    mutationFn: mutate(batchApi.batchRequest),
-    onSuccess: (response: unknown) => {
+    mutationFn: mutate.atomic(),
+    onSuccess: (response) => {
       toast.success(t("medications_billed_and_prescriptions_completed"));
 
       // Invalidate appropriate queries
@@ -507,31 +508,6 @@ export function useMedicationBill({
         });
       } else {
         onDispenseSuccess?.(newDispenseOrderId);
-      }
-    },
-    onError: (error) => {
-      try {
-        const errorData = error.cause as {
-          results?: {
-            data?: { detail?: string; errors?: { msg: string }[] };
-          }[];
-        };
-
-        const errorMessages = errorData?.results
-          ?.flatMap(
-            (result) =>
-              result?.data?.errors?.map((err) => err.msg) ||
-              (result?.data?.detail ? [result.data.detail] : []),
-          )
-          .filter(Boolean);
-
-        if (errorMessages?.length) {
-          errorMessages.forEach((msg) => toast.error(msg));
-        } else {
-          toast.error(t("error_dispensing_medications"));
-        }
-      } catch {
-        toast.error(t("error_dispensing_medications"));
       }
     },
   });
@@ -652,12 +628,7 @@ export function useMedicationBill({
     }
 
     // Build dispense requests
-    const requests: {
-      url: string;
-      method: string;
-      reference_id: string;
-      body: unknown;
-    }[] = [];
+    const requests: BatchRequestObject[] = [];
     const defaultEncounterId = prescriptionId
       ? prescription?.encounter?.id
       : (allMedicationsResponse?.results[0]?.encounter ?? encounterId);
@@ -713,10 +684,9 @@ export function useMedicationBill({
         }
 
         requests.push({
-          url: `/api/v1/medication/dispense/`,
-          method: "POST",
-          reference_id: `dispense_${item.reference_id}_lot_${lot.selectedInventoryId}`,
+          api: medicationDispenseApi.create,
           body: dispenseData,
+          referenceId: `dispense_${item.reference_id}_lot_${lot.selectedInventoryId}`,
         });
       });
     });
@@ -741,9 +711,9 @@ export function useMedicationBill({
 
     if (prescriptionIds.size > 0) {
       requests.push({
-        url: `/api/v1/patient/${patientId}/medication/prescription/upsert/`,
-        method: "POST",
-        reference_id: "prescription_completion_upsert",
+        api: prescriptionApi.upsert,
+        pathParams: { patientId },
+        referenceId: "prescription_completion_upsert",
         body: {
           datapoints: Array.from(prescriptionIds).map((pId) => ({
             id: pId,
@@ -753,7 +723,7 @@ export function useMedicationBill({
       });
     }
 
-    dispense({ requests });
+    dispense(requests);
   };
 
   const handleRemoveMedication = (


### PR DESCRIPTION
## [ENG-845]

Jira: ENG-845

## Description

This PR adds `mutate.atomic`. Use `mutate.atomic` to send more than one request
as one atomic batch request. The server runs all of the requests together. The
batch is atomic: if one request fails, the server stops all of the requests.
Then no request in the batch changes the data.

## Problem

The batch request sends an array of requests. The response contains one
sub-response for each request. Before this change, the global error handler
showed an error for each sub-response that did not fail. It showed a
`something_went_wrong` message for these sub-responses.

## Changes

- Add `mutate.atomic` in `mutate.ts`. It sends the requests as one atomic batch
  request.
- On failure, `mutate.atomic` shows an error for each request that failed. It
  does not show an error for the other requests in the batch.
- `mutate.atomic` re-throws the error silently. Thus the global error handler
  does not show a second error.
- Add `buildBatchRequestBody` and `isBatchResult` in `batch.ts`. Both functions
  are shared with `useBatchRequest`.
- Change `useMedicationBill` to use `mutate.atomic` for the dispense flow.
- Add documentation for `mutate.atomic` in the request README.

## Notes

- This PR does not change the other batch requests.

[ENG-845]: https://openhealthcarenetwork.atlassian.net/browse/ENG-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added atomic batch request support, allowing multiple API operations to succeed or fail together.
  - Improved handling of individual failures within batch responses.
  - Updated pharmacy medication billing with streamlined batch dispensing and prescription completion requests.

- **Documentation**
  - Added guidance for atomic batch requests, including usage, response handling, failure behavior, and silent error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->