### PR TITLE
fix: sidebar nav tooltips not showing on leaf items (fixes #16644)

### DIFF
--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -136,17 +136,16 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                 )
               ) : (
                 <SidebarMenuItem>
-                  <SidebarMenuButton
-                    asChild
-                    tooltip={link.name}
-                    className={
-                      "text-gray-600 transition font-normal hover:bg-gray-200 hover:text-green-700"
-                    }
+                  <NavLink
+                    href={link.url}
+                    isSelected={isSelected(link.url)}
+                    activeClass="bg-white text-green-700 shadow-sm"
                   >
-                    <NavLink
-                      href={link.url}
-                      isSelected={isSelected(link.url)}
-                      activeClass="bg-white text-green-700 shadow-sm"
+                    <SidebarMenuButton
+                      tooltip={link.name}
+                      className={
+                        "text-gray-600 transition font-normal hover:bg-gray-200 hover:text-green-700"
+                      }
                     >
                       {link.icon ? (
                         link.icon
@@ -160,8 +159,8 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
                       <span className="group-data-[collapsible=icon]:hidden ml-1">
                         {link.name}
                       </span>
-                    </NavLink>
-                  </SidebarMenuButton>
+                    </SidebarMenuButton>
+                  </NavLink>
                 </SidebarMenuItem>
               )}
             </Fragment>

--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -1,7 +1,7 @@
 import { useAtom } from "jotai";
 import { ChevronRight } from "lucide-react";
 import { ActiveLink, useFullPath, usePath } from "raviger";
-import { Fragment, ReactNode, useMemo, useState } from "react";
+import { forwardRef, Fragment, ReactNode, useMemo, useState } from "react";
 
 import { navExpansionAtom } from "@/atoms/navExpansionAtom";
 import { cn } from "@/lib/utils";
@@ -22,8 +22,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
   useSidebar,
 } from "@/components/ui/sidebar";
 
@@ -54,28 +52,35 @@ export interface NavigationLink {
   children?: NavigationLink[];
 }
 
-function NavLink({
-  href,
-  isSelected,
-  activeClass,
-  exactActiveClass,
-  className,
-  onClick,
-  children,
-}: {
-  href: string;
-  isSelected: boolean;
-  activeClass?: string;
-  exactActiveClass?: string;
-  className?: string;
-  onClick?: (e: React.MouseEvent) => void;
-  children: ReactNode;
-}) {
+const NavLink = forwardRef<
+  HTMLAnchorElement,
+  {
+    href: string;
+    isSelected: boolean;
+    activeClass?: string;
+    exactActiveClass?: string;
+    className?: string;
+    onClick?: (e: React.MouseEvent) => void;
+    children: ReactNode;
+  }
+>(function NavLink(
+  {
+    href,
+    isSelected,
+    activeClass,
+    exactActiveClass,
+    className,
+    onClick,
+    children,
+  },
+  ref,
+) {
   const resolvedExact = exactActiveClass ?? activeClass;
   const { toggleSidebar, isMobile } = useSidebar();
 
   return (
     <ActiveLink
+      ref={ref}
       href={href}
       className={className}
       activeClass={activeClass}
@@ -93,7 +98,7 @@ function NavLink({
       {children}
     </ActiveLink>
   );
-}
+});
 
 export function NavMain({ links }: { links: NavigationLink[] }) {
   const { state } = useSidebar();
@@ -172,7 +177,7 @@ export function NavMain({ links }: { links: NavigationLink[] }) {
 
 function CollapsibleNavItem({
   link,
-  fullPathMap,
+  fullPathMap: _fullPathMap,
   path,
 }: {
   link: NavigationLink;
@@ -221,29 +226,33 @@ function CollapsibleNavItem({
                       </span>
                     </div>
                   )}
-                  <SidebarMenuSubItem>
-                    <SidebarMenuSubButton
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
                       asChild
+                      tooltip={link.name}
                       className={
                         "text-gray-600 transition font-normal hover:bg-gray-200 hover:text-green-700"
                       }
                     >
                       <NavLink
-                        href={subItem.url}
-                        isSelected={isSubItemSelected(subItem.url)}
-                        className="w-full"
-                        activeClass={cn(
-                          subItem.url
-                            .split("/")
-                            .every((part) => fullPathMap[part]) &&
-                            "bg-white text-green-700 shadow",
-                        )}
-                        exactActiveClass="bg-white text-green-700 shadow"
+                        href={link.url}
+                        isSelected={isSubItemSelected(link.url)}
+                        activeClass="bg-white text-green-700 shadow-sm"
                       >
-                        {subItem.name}
+                        {link.icon ? (
+                          link.icon
+                        ) : (
+                          <Avatar
+                            name={link.name}
+                            className="size-6 -m-1 rounded-sm"
+                          />
+                        )}
+                        <span className="group-data-[collapsible=icon]:hidden ml-1">
+                          {link.name}
+                        </span>
                       </NavLink>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
                 </Fragment>
               ))}
           </SidebarMenuSub>

--- a/src/components/ui/sidebar/nav-main.tsx
+++ b/src/components/ui/sidebar/nav-main.tsx
@@ -229,26 +229,26 @@ function CollapsibleNavItem({
                   <SidebarMenuItem>
                     <SidebarMenuButton
                       asChild
-                      tooltip={link.name}
+                      tooltip={subItem.name}
                       className={
                         "text-gray-600 transition font-normal hover:bg-gray-200 hover:text-green-700"
                       }
                     >
                       <NavLink
-                        href={link.url}
-                        isSelected={isSubItemSelected(link.url)}
+                        href={subItem.url}
+                        isSelected={isSubItemSelected(subItem.url)}
                         activeClass="bg-white text-green-700 shadow-sm"
                       >
-                        {link.icon ? (
-                          link.icon
+                        {subItem.icon ? (
+                          subItem.icon
                         ) : (
                           <Avatar
-                            name={link.name}
+                            name={subItem.name}
                             className="size-6 -m-1 rounded-sm"
                           />
                         )}
                         <span className="group-data-[collapsible=icon]:hidden ml-1">
-                          {link.name}
+                          {subItem.name}
                         </span>
                       </NavLink>
                     </SidebarMenuButton>


### PR DESCRIPTION
## Proposed Changes

Fixes #16644
- Removed `asChild` from `SidebarMenuButton` in the leaf nav item branch (items without children ...Overview, Appointments, Queues, Services, Resource, Users).
- Restructured nesting so `NavLink` wraps `SidebarMenuButton` instead of being passed as its child via Radix `Slot`.

This resolves a broken ref-forwarding chain (`TooltipTrigger asChild` → `SidebarMenuButton asChild` → `Slot` → `ActiveLink`) that silently prevented tooltips from firing on hover for these items, while items with children (rendered via `PopoverMenu`, which doesn't use `asChild`) worked correctly.

**Screen recording:**

https://github.com/user-attachments/assets/b60705bb-d644-41f7-b1cc-5936bb045876



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar navigation for standalone and nested items.
  * Sidebar links now navigate more reliably and maintain the correct active state between sections.
  * Updated nested navigation presentation for a more consistent experience across sidebar items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->