### PR TITLE
Add Playwright test for dispense with insufficient stock

### DIFF
--- a/tests/facility/patient/encounter/medicine/dispense/insufficientStock.spec.ts
+++ b/tests/facility/patient/encounter/medicine/dispense/insufficientStock.spec.ts
@@ -1,0 +1,146 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+import { expectToast } from "tests/helper/ui";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+const MEDICINE_NAME = "Paracetamol";
+const DISPENSE_LOCATION = "Pharmacy";
+const INSUFFICIENT_STOCK_ERROR = "Inventory item does not have enough stock";
+const GENERIC_ERROR = "Something went wrong";
+const EMPTY_DISPENSE_HISTORY = "No dispense history found";
+const MINIMUM_STOCK = 3;
+
+/**
+ * The dispense drawer sends one batch request with one sub-request for each
+ * line item. The front-end checks the quantity of each line item against the
+ * stock, but it does not add the quantities of the line items together. So two
+ * line items of the same medicine pass the front-end check and the backend
+ * rejects the second sub-request.
+ *
+ * This test makes sure that the batch error handler shows the error of the
+ * failed sub-request, and that it shows no generic error for the sub-request
+ * that passed.
+ */
+test.describe("Dispense with a total quantity that is more than the stock", () => {
+  let facilityId: string;
+  let patientId: string;
+  let encounterId: string;
+
+  function getDispenseSheet(page: Page) {
+    return page.locator('[data-slot="sheet-content"]');
+  }
+
+  function getLineItems(sheet: Locator) {
+    return sheet.locator('[data-slot="table-body"] tr');
+  }
+
+  async function openDispenseSheet(page: Page) {
+    await page.getByRole("tab", { name: "Dispense History" }).click();
+    await page
+      .getByRole("button", { name: "Dispense", exact: true })
+      .first()
+      .click();
+
+    const locationDialog = page.getByRole("dialog");
+    await locationDialog.getByPlaceholder("Search").fill(DISPENSE_LOCATION);
+    await locationDialog
+      .getByRole("option", { name: DISPENSE_LOCATION })
+      .first()
+      .click();
+
+    const sheet = getDispenseSheet(page);
+    await expect(sheet).toBeVisible();
+    return sheet;
+  }
+
+  async function addLineItem(page: Page, sheet: Locator, name: string) {
+    await sheet
+      .getByRole("combobox")
+      .filter({ hasText: "Add Item" })
+      .first()
+      .click();
+
+    const picker = page.locator("[data-radix-popper-content-wrapper]").last();
+    await picker.locator('[data-slot="command-input"]').fill(name);
+    await picker.getByRole("option", { name }).first().click();
+  }
+
+  /**
+   * Reads the stock of the lot that the drawer selects for a line item.
+   *
+   * The lot button holds 2 badges: the unit price and the stock. Only the
+   * price badge holds a monetary value, so the filter keeps the stock badge.
+   */
+  async function readAvailableStock(page: Page, lineItem: Locator) {
+    const stockBadge = lineItem
+      .locator('[data-slot="badge"]')
+      .filter({ hasNot: page.locator('[data-slot="monetary-value"]') })
+      .first();
+    await expect(stockBadge).toBeVisible();
+
+    const badgeText = await stockBadge.innerText();
+    const stock = Number.parseFloat(badgeText);
+    if (Number.isNaN(stock)) {
+      throw new Error(`Failed to read the stock from the badge: "${badgeText}"`);
+    }
+    return stock;
+  }
+
+  test.beforeEach(async ({ page }) => {
+    facilityId = getFacilityId();
+    patientId = getPatientId();
+    encounterId = getEncounterId();
+    await page.goto(
+      `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/medicines`,
+    );
+  });
+
+  test("shows the error of the failed sub-request only", async ({ page }) => {
+    const sheet = await openDispenseSheet(page);
+    let stock = 0;
+
+    await test.step("Add the first line item and read the stock", async () => {
+      await addLineItem(page, sheet, MEDICINE_NAME);
+      await expect(getLineItems(sheet)).toHaveCount(1);
+
+      stock = await readAvailableStock(page, getLineItems(sheet).first());
+      expect(stock).toBeGreaterThanOrEqual(MINIMUM_STOCK);
+    });
+
+    // Each quantity stays below the stock, but the 2 quantities together are
+    // more than the stock.
+    const quantity = String(Math.floor(stock / 2) + 1);
+
+    await test.step("Add a second line item of the same medicine", async () => {
+      await addLineItem(page, sheet, MEDICINE_NAME);
+      await expect(getLineItems(sheet)).toHaveCount(2);
+    });
+
+    await test.step("Set the quantity of both line items", async () => {
+      for (const lineItem of await getLineItems(sheet).all()) {
+        await lineItem.getByRole("spinbutton").first().fill(quantity);
+      }
+    });
+
+    await test.step("Confirm the dispense", async () => {
+      await sheet.getByRole("button", { name: "Confirm Dispense" }).click();
+    });
+
+    await test.step("Verify the error messages", async () => {
+      await expectToast(page, INSUFFICIENT_STOCK_ERROR);
+      await expect(
+        page.locator(".toaster.group").getByText(GENERIC_ERROR),
+      ).toHaveCount(0);
+      await expect(sheet).toBeVisible();
+    });
+
+    await test.step("Verify that the dispense created no record", async () => {
+      await sheet.getByRole("button", { name: "Cancel" }).click();
+      await expect(sheet).not.toBeVisible();
+      await expect(page.getByText(EMPTY_DISPENSE_HISTORY)).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes

This PR stacks on top of `ENG-846/fix-batch-request-error-handling`. It adds the Playwright test that shows the bug the parent PR corrects.

Before the parent fix, a failed batch request showed one generic `Something went wrong..!` toast for each sub-request, and hid the real backend message. The parent PR makes the batch error handler read each sub-request result and show the real error. This test locks that behaviour in.

- Adds `tests/facility/patient/encounter/medicine/dispense/insufficientStock.spec.ts`.
- The test dispenses 2 line items of the same medicine (`Paracetamol`) from an encounter. Each quantity stays below the stock, but the 2 quantities together are more than the stock. The front-end check compares each lot line against the stock independently, so it lets the request through. The backend then accepts sub-request 1 and rejects sub-request 2.
- The test asserts that the toast `Inventory item does not have enough stock` is visible, that no `Something went wrong` toast is present, that the dispense sheet stays open, and that the dispense history is still empty after Cancel.

Notes for the reviewer:

- 2 line items are necessary. A single line item cannot reach the backend, because the front-end check blocks it first.
- The test reads the available stock from the lot badge in the UI and then computes `floor(stock / 2) + 1` for each quantity. There is no hard-coded stock number, so a different fixture stock does not break the test.
- The test uses a local `addLineItem` helper instead of `selectFromDefinitionCategoryPicker`. The shared helper looks for `page.getByRole("dialog").last()`, but the dispense sheet itself has `role="dialog"`, so the shared helper would search in the wrong element.

Verification:

- With the parent fix: the test passes in about 4.5 s.
- With `src/Utils/request/batch.ts` reverted to the pre-fix version: the test fails, because the expected toast never appears.
- `npx tsc --noEmit -p tests/tsconfig.json` exits with 0.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network). N/A
- [ ] Ensure that UI text is placed in I18n files. N/A
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue. N/A
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices. N/A
- [ ] Complete QA on desktop devices. N/A
- [x] Add or update Playwright tests for related changes