### PR TITLE
fix(questionnaire-v2): drop visibility conditions naming a deleted question

### DIFF
--- a/src/components/QuestionnaireV2/builder/builderReducer.test.ts
+++ b/src/components/QuestionnaireV2/builder/builderReducer.test.ts
@@ -10,7 +10,9 @@ import {
 import type { EnableWhen, Question } from "@/types/questionnaire/question";
 
 import {
+  type BuilderState,
   buildCondition,
+  builderReducer,
   migrateLegacyBooleanEnableWhen,
   normalizeExistsConditionAnswer,
 } from "./builderReducer";
@@ -40,6 +42,22 @@ function q(over: Partial<Question> & Pick<Question, "id" | "type">): Question {
     text: over.id,
     ...over,
   };
+}
+
+/** Depth-first lookup by id, so assertions can name a question without
+ *  tracking where the reducer left it in the tree. */
+function findById(questions: Question[], id: string): Question {
+  const search = (list: Question[]): Question | undefined => {
+    for (const question of list) {
+      if (question.id === id) return question;
+      const found = search(question.questions ?? []);
+      if (found) return found;
+    }
+    return undefined;
+  };
+  const found = search(questions);
+  if (!found) throw new Error(`question "${id}" not found`);
+  return found;
 }
 
 describe("normalizeExistsConditionAnswer", () => {
@@ -272,5 +290,115 @@ describe("migrateLegacyBooleanEnableWhen", () => {
     assert.deepEqual(migrated[1].questions?.[0].enable_when, [
       { question: "target", operator: "exists", answer: true },
     ]);
+  });
+});
+
+describe("removeQuestions — conditions naming the deleted question", () => {
+  const remove = (questions: Question[], ids: string[]): Question[] => {
+    const state: BuilderState = { questions, selectedId: null, dirty: false };
+    return builderReducer(state, { type: "removeQuestions", ids }).questions;
+  };
+
+  it("drops the dangling condition instead of leaving the dependent hidden forever", () => {
+    // Left in place, the condition survives the save and every evaluator
+    // resolves the missing response to false — the dependent never shows.
+    const questions = remove(
+      [
+        q({ id: "age", type: "integer" }),
+        q({
+          id: "dependent",
+          type: "string",
+          enable_when: [buildCondition("age", "equals", "18")],
+        }),
+      ],
+      ["age"],
+    );
+
+    assert.equal(questions.length, 1);
+    assert.deepEqual(questions[0].enable_when, []);
+  });
+
+  it("keeps the conditions whose targets survive the delete", () => {
+    const questions = remove(
+      [
+        q({ id: "age", type: "integer" }),
+        q({ id: "weight", type: "integer" }),
+        q({
+          id: "dependent",
+          type: "string",
+          enable_when: [
+            buildCondition("age", "equals", "18"),
+            buildCondition("weight", "greater", 50),
+          ],
+        }),
+      ],
+      ["age"],
+    );
+
+    assert.deepEqual(findById(questions, "dependent").enable_when, [
+      { question: "weight", operator: "greater", answer: 50 },
+    ]);
+  });
+
+  it("drops conditions naming a descendant of a deleted group", () => {
+    // Deleting a group takes its children's link_ids with it, so a condition
+    // on a child dangles just as one on the group itself would.
+    const questions = remove(
+      [
+        q({
+          id: "section",
+          type: "group",
+          questions: [q({ id: "nested", type: "boolean" })],
+        }),
+        q({
+          id: "dependent",
+          type: "string",
+          enable_when: [buildCondition("nested", "equals", true)],
+        }),
+      ],
+      ["section"],
+    );
+
+    assert.deepEqual(questions[0].enable_when, []);
+  });
+
+  it("cleans conditions on questions nested inside surviving groups", () => {
+    const questions = remove(
+      [
+        q({ id: "age", type: "integer" }),
+        q({
+          id: "section",
+          type: "group",
+          questions: [
+            q({
+              id: "nested-dependent",
+              type: "string",
+              enable_when: [buildCondition("age", "equals", "18")],
+            }),
+          ],
+        }),
+      ],
+      ["age"],
+    );
+
+    assert.deepEqual(findById(questions, "nested-dependent").enable_when, []);
+  });
+
+  it("leaves an untouched question at the same reference, so the tree keeps identity", () => {
+    const unrelated = q({
+      id: "dependent",
+      type: "string",
+      enable_when: [buildCondition("weight", "equals", "50")],
+    });
+    const questions = remove(
+      [
+        q({ id: "age", type: "integer" }),
+        q({ id: "weight", type: "integer" }),
+        unrelated,
+      ],
+      ["age"],
+    );
+
+    assert.equal(findById(questions, "dependent"), unrelated);
   });
 });

--- a/src/components/QuestionnaireV2/builder/builderReducer.ts
+++ b/src/components/QuestionnaireV2/builder/builderReducer.ts
@@ -218,6 +218,48 @@ function collectSubtreeIds(questions: Question[], ids: string[]): Set<string> {
   return result;
 }
 
+/** The `link_id`s a delete takes with it — conditions naming one of these
+ *  can no longer resolve. Walks only the removed subtrees. */
+function collectSubtreeLinkIds(
+  questions: Question[],
+  ids: string[],
+): Set<string> {
+  const result = new Set<string>();
+  const walk = (question: Question) => {
+    result.add(question.link_id);
+    for (const child of question.questions ?? []) walk(child);
+  };
+  for (const id of ids) {
+    const question = findQuestion(questions, id);
+    if (question) walk(question);
+  }
+  return result;
+}
+
+/**
+ * Drops the visibility conditions naming a removed `link_id`. Without this a
+ * dangling condition survives the save (`saveValidation` only rejects targets
+ * it can type-check) and every evaluator resolves the missing response to
+ * `false`, hiding the dependent question forever with nothing on screen to
+ * explain it. A question left with no conditions becomes unconditionally
+ * visible, which is the recoverable end of that trade.
+ *
+ * Returns the same reference when nothing matched, so the surrounding
+ * `mapTree` keeps identity for untouched questions.
+ */
+function dropConditionsTargeting(
+  question: Question,
+  removedLinkIds: Set<string>,
+): Question {
+  if (!question.enable_when?.length) return question;
+  const enable_when = question.enable_when.filter(
+    (condition) => !removedLinkIds.has(condition.question),
+  );
+  return enable_when.length === question.enable_when.length
+    ? question
+    : { ...question, enable_when };
+}
+
 /** Immutably map every questions array in the tree (root included). */
 export function mapTree(
   questions: Question[],
@@ -298,8 +340,11 @@ export function builderReducer(
     case "removeQuestions": {
       const ids = new Set(action.ids);
       const removedIds = collectSubtreeIds(state.questions, action.ids);
+      const removedLinkIds = collectSubtreeLinkIds(state.questions, action.ids);
       const questions = mapTree(state.questions, (list) =>
-        list.filter((q) => !ids.has(q.id)),
+        list
+          .filter((q) => !ids.has(q.id))
+          .map((q) => dropConditionsTargeting(q, removedLinkIds)),
       );
       return {
         questions,


### PR DESCRIPTION
Enhances the logic and testing for removing questions in the questionnaire builder, specifically ensuring that any conditions referencing deleted questions or their descendants are properly cleaned up. This prevents hidden or inaccessible questions due to dangling conditions, and maintains tree identity for unaffected questions.

Entire-Checkpoint: 5596d1d0bf73

## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
