### PR TITLE
fix: handle upload completion failures

### DIFF
--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -190,6 +190,7 @@ export default function useFileUpload(
     mutationFn: (fileId: string) =>
       mutate(fileApi.markUploadCompleted, {
         pathParams: { fileId },
+        silent: true,
       })(undefined),
     onSuccess: (data) => {
       queryClient.invalidateQueries({

--- a/src/hooks/useFileUpload.tsx
+++ b/src/hooks/useFileUpload.tsx
@@ -186,21 +186,20 @@ export default function useFileUpload(
     }
     return true;
   };
-  const { mutateAsync: markUploadComplete, error: markUploadCompleteError } =
-    useMutation({
-      mutationFn: (fileId: string) =>
-        mutate(fileApi.markUploadCompleted, {
-          pathParams: { fileId },
-        })(undefined),
-      onSuccess: (data) => {
-        queryClient.invalidateQueries({
-          queryKey: ["files", fileType, data.associating_id],
-        });
-        toast.success(t("file_uploaded"));
-        setError(null);
-        onUpload?.(data);
-      },
-    });
+  const { mutateAsync: markUploadComplete } = useMutation({
+    mutationFn: (fileId: string) =>
+      mutate(fileApi.markUploadCompleted, {
+        pathParams: { fileId },
+      })(undefined),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ["files", fileType, data.associating_id],
+      });
+      toast.success(t("file_uploaded"));
+      setError(null);
+      onUpload?.(data);
+    },
+  });
 
   const uploadfile = async (data: FileRead, file: File) => {
     const url = data.signed_url;
@@ -216,13 +215,14 @@ export default function useFileUpload(
         async (xhr: XMLHttpRequest) => {
           if (xhr.status >= 200 && xhr.status < 300) {
             setProgress(null);
-            await markUploadComplete(data.id);
-            if (markUploadCompleteError) {
+            try {
+              await markUploadComplete(data.id);
+              resolve();
+            } catch {
               toast.error(t("file_error__mark_complete_failed"));
+              setProgress(null);
               reject();
-              return;
             }
-            resolve();
           } else {
             toast.error(
               t("file_error__dynamic", { statusText: xhr.statusText }),


### PR DESCRIPTION
## Proposed Changes

Fixes #15947

- handle `markUploadComplete` failures with `try/catch`
- reject the upload when the completion request fails
- suppress the duplicate global HTTP error toast for this handled failure
- keep the existing success path and upload-complete feedback

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
