### PR TITLE
fix: handle missing appointment success data

### DIFF
--- a/src/pages/PublicAppointments/Success.tsx
+++ b/src/pages/PublicAppointments/Success.tsx
@@ -38,7 +38,9 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
 
   useEffect(() => {
     if (error) {
-      toast.error(t("appointment_not_found"));
+      toast.error(t("page_load_error"), {
+        id: "appointment-success-load-error",
+      });
     }
   }, [error, t]);
 
@@ -50,10 +52,31 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
     return <Loading />;
   }
 
-  if (error || !appointmentData) {
+  if (error) {
     return (
       <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 p-12 text-center">
-        <div className="inline-flex size-16 items-center justify-center rounded-full bg-red-100">
+        <div
+          aria-hidden="true"
+          className="inline-flex size-16 items-center justify-center rounded-full bg-red-100"
+        >
+          <CareIcon icon="l-exclamation-circle" className="size-8 text-red-600" />
+        </div>
+        <h1 className="text-xl font-medium text-gray-900">
+          {t("page_load_error")}
+        </h1>
+        <p className="text-sm text-gray-600">{t("could_not_load_page")}</p>
+        <Button onClick={() => navigate("/patient/home")}>{t("home")}</Button>
+      </div>
+    );
+  }
+
+  if (!appointmentData) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 p-12 text-center">
+        <div
+          aria-hidden="true"
+          className="inline-flex size-16 items-center justify-center rounded-full bg-red-100"
+        >
           <CareIcon icon="l-exclamation-circle" className="size-8 text-red-600" />
         </div>
         <h1 className="text-xl font-medium text-gray-900">

--- a/src/pages/PublicAppointments/Success.tsx
+++ b/src/pages/PublicAppointments/Success.tsx
@@ -1,11 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
+import { navigate } from "raviger";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import CareIcon from "@/CAREUI/icons/CareIcon";
 
 import Loading from "@/components/Common/Loading";
+import { Button } from "@/components/ui/button";
 
 import { usePatientContext } from "@/hooks/usePatientUser";
 
@@ -33,16 +36,32 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
     enabled: !!tokenData.token,
   });
 
-  if (error) {
-    toast.error(t("appointment_not_found"));
-  }
+  useEffect(() => {
+    if (error) {
+      toast.error(t("appointment_not_found"));
+    }
+  }, [error, t]);
 
   const appointmentData = data?.results.find(
     (appointment) => appointment.id === appointmentId,
   );
 
-  if (isLoading || !appointmentData) {
+  if (isLoading) {
     return <Loading />;
+  }
+
+  if (error || !appointmentData) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 p-12 text-center">
+        <div className="inline-flex size-16 items-center justify-center rounded-full bg-red-100">
+          <CareIcon icon="l-exclamation-circle" className="size-8 text-red-600" />
+        </div>
+        <h1 className="text-xl font-medium text-gray-900">
+          {t("appointment_not_found")}
+        </h1>
+        <Button onClick={() => navigate("/patient/home")}>{t("home")}</Button>
+      </div>
+    );
   }
 
   const appointmentTime = appointmentData.token_slot.start_datetime;
@@ -73,7 +92,7 @@ export function AppointmentSuccess(props: { appointmentId: string }) {
           <h2 className="text-sm font-medium text-gray-500 mb-1">
             {t("patient")}:
           </h2>
-          <p className="text-lg font-medium">{appointmentData?.patient.name}</p>
+          <p className="text-lg font-medium">{appointmentData.patient.name}</p>
         </div>
 
         <div>


### PR DESCRIPTION
## Proposed Changes

Fixes #15962

- move the appointment error toast out of render and use a stable toast id
- keep loading, request-error, and missing-appointment states separate
- show an explicit recoverable error state instead of an endless spinner
- reuse existing i18n strings and add a route back to patient home
- hide the decorative error icon from assistive technology

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes
