### PR TITLE
Fix section label alignment in user profile page

### DIFF
--- a/src/components/Common/UserColumns.tsx
+++ b/src/components/Common/UserColumns.tsx
@@ -19,7 +19,7 @@ export default function UserColumns({
 }) {
   return (
     <section
-      className="flex flex-col gap-5 sm:flex-row"
+      className="flex flex-col gap-5 sm:flex-row sm:items-center"
       aria-labelledby="section-heading"
     >
       <div className="sm:w-1/4">


### PR DESCRIPTION
## Proposed Changes

Fixes #16599

- Added `sm:items-center` to the flex container in `UserColumns.tsx`
- Prevents the section label column from stretching to match the content card height
- Improves alignment between section labels and content cards on the user profile page
- Mobile layout remains unchanged since the fix only applies at the `sm` breakpoint and above

## Testing

- Verified the fix on desktop
- Verified the fix using responsive/mobile mode
- Confirmed alignment for:
  - Personal Information
  - Contact Information
  - Location Information

Tagging: @ohcnetwork/care-fe-code-reviewers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout alignment by vertically centering items on small and larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->