### PR TITLE
Add dropdown arrow to frequency autocomplete

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -1,4 +1,5 @@
 import { CaretSortIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { ChevronDown } from "lucide-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -280,14 +281,18 @@ export default function Autocomplete({
             ref={ref}
             data-shortcut-id={shortcutId}
           >
-            <span
-              className={cn(
-                inputValue && "truncate",
-                !selectedOption && "text-gray-500",
-              )}
-            >
-              {displayText}
-            </span>
+            <div className="flex items-center justify-between w-full">
+              <span
+                className={cn(
+                  inputValue && "truncate",
+                  !selectedOption && "text-gray-500",
+                )}
+              >
+                {displayText}
+              </span>
+
+              <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
+            </div>
           </Button>
         </PopoverTrigger>
         <PopoverContent


### PR DESCRIPTION
## Changes
- Added ChevronDown icon to frequency autocomplete dropdown
- Improved dropdown visibility
- Maintained existing autocomplete functionality

## Testing
- Verified dropdown renders correctly
- No existing functionality affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the desktop autocomplete trigger to display its label alongside a downward chevron icon.
  * Improved the trigger’s visual alignment without changing mobile behavior or autocomplete functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->