### PR TITLE
fix: allow clicking medication frequency dropdown caret

### DIFF
--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -254,7 +254,7 @@ export default function Autocomplete({
             <span className="sr-only">{t("clear")}</span>
           </Button>
         ) : (
-          <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+          <CaretSortIcon className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
         )}
       </div>
     );
@@ -315,14 +315,14 @@ export default function Autocomplete({
       ) : (
         <>
           {shortcutId ? (
-            <div className="absolute right-3 top-1/2 -translate-y-1/2 ">
+            <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 ">
               <div className="flex items-center justify-center gap-1">
                 <ShortcutBadge actionId={shortcutId} />
                 <CaretSortIcon className="size-3 shrink-0 opacity-50" />
               </div>
             </div>
           ) : (
-            <CaretSortIcon className="absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
+            <CaretSortIcon className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 ml-2 size-4 shrink-0 opacity-50" />
           )}
         </>
       )}


### PR DESCRIPTION
## Proposed Changes

Fixes #issue_number
- Change 1
- Change 2
- Additional context if needed

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete interactions by ensuring caret and shortcut overlay elements don’t block clicks or other pointer actions on the control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->