### PR TITLE
fix: align user profile section labels 

### DIFF
--- a/src/components/Common/UserColumns.tsx
+++ b/src/components/Common/UserColumns.tsx
@@ -19,10 +19,10 @@ export default function UserColumns({
 }) {
   return (
     <section
-      className="flex flex-col gap-5 sm:flex-row sm:items-center"
+      className="flex flex-col gap-5 sm:flex-row"
       aria-labelledby="section-heading"
     >
-      <div className="sm:w-1/4">
+      <div className="sm:w-1/4 sm:pt-10">
         <div className="my-1 text-sm leading-5">
           <p className="mb-2 font-semibold">{heading}</p>
           <p className="text-secondary-600">{note}</p>

--- a/src/components/Common/UserColumns.tsx
+++ b/src/components/Common/UserColumns.tsx
@@ -19,7 +19,7 @@ export default function UserColumns({
 }) {
   return (
     <section
-      className="flex flex-col gap-5 sm:flex-row"
+      className="flex flex-col gap-5 sm:flex-row sm:items-center"
       aria-labelledby="section-heading"
     >
       <div className="sm:w-1/4">


### PR DESCRIPTION
## Proposed Changes

Fixes #16599 
- Added `sm:pt-10` to the label wrapper's className in `UserColumns.tsx`, matching the vertical offset present on the card's heading side (CardHeader padding + a decorative bar above the heading text).
- This aligns the label text with its card's heading text on the same line, rather than relying on `items-center`/`items-start`, which only matched box heights, not actual text baselines.
- Only applies at the `sm:` breakpoint and above, so the mobile stacked layout (`flex-col`) is unaffected.

**Before:**
 
<img width="1600" height="871" alt="WhatsApp Image 2026-08-20 at 1 13 04 AM" src="https://github.com/user-attachments/assets/287ff388-1580-46bf-82df-c17915bc3fe2" />


**After:**
 
<img width="1919" height="762" alt="image" src="https://github.com/user-attachments/assets/2a92cd24-8960-43e5-905b-ccdb0eafef96" />



Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout alignment so items are vertically centered on small screens and larger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->