### PR TITLE
🧪 Align new Playwright specs with the CARE playwright skill

### DIFF
--- a/tests/facility/billing/invoiceCreation.spec.ts
+++ b/tests/facility/billing/invoiceCreation.spec.ts
@@ -8,7 +8,7 @@ test.describe("Invoice Creation", () => {
   let facilityId: string;
   let accountId: string;
 
-  test.beforeEach(async () => {
+  test.beforeEach(() => {
     facilityId = getFacilityId();
     accountId = getAccountId();
   });

--- a/tests/facility/patient/encounter/consents/encounterConsents.spec.ts
+++ b/tests/facility/patient/encounter/consents/encounterConsents.spec.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "@playwright/test";
-import {
-  clickTabOrMenuItem,
-  openFirstInProgressEncounter,
-} from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
+import { clickTabOrMenuItem, openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
@@ -13,11 +9,8 @@ test.describe("Encounter Consents Tab", () => {
   // single worker instead of in parallel.
   test.describe.configure({ mode: "serial" });
 
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
     await clickTabOrMenuItem(page, "Consents");
     await expect(page).toHaveURL(/\/consents$/);
   });

--- a/tests/facility/patient/encounter/devices/encounterDevices.spec.ts
+++ b/tests/facility/patient/encounter/devices/encounterDevices.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from "@playwright/test";
 import {
   clickTabOrMenuItem,
-  openFirstInProgressEncounter,
+  openFixtureEncounter,
   selectFromCommand,
 } from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
@@ -13,11 +12,8 @@ test.describe("Encounter Devices Tab", () => {
   // tests serially in one worker for deterministic ordering.
   test.describe.configure({ mode: "serial" });
 
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
     await clickTabOrMenuItem(page, "Devices");
     await expect(page).toHaveURL(/\/devices$/);
   });

--- a/tests/facility/patient/encounter/diagnosticReports/encounterDiagnosticReports.spec.ts
+++ b/tests/facility/patient/encounter/diagnosticReports/encounterDiagnosticReports.spec.ts
@@ -1,15 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { openFirstInProgressEncounter } from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
+import { openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
 test.describe("Encounter Diagnostic Reports Tab", () => {
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
   });
 
   test("should display the diagnostic reports tab with its empty state", async ({

--- a/tests/facility/patient/encounter/encounterCompletion.spec.ts
+++ b/tests/facility/patient/encounter/encounterCompletion.spec.ts
@@ -1,15 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { openFirstInProgressEncounter } from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
+import { openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
 test.describe("Encounter Completion", () => {
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
   });
 
   test("should prompt for confirmation when marking an encounter as completed", async ({

--- a/tests/facility/patient/encounter/encounterUpdate.spec.ts
+++ b/tests/facility/patient/encounter/encounterUpdate.spec.ts
@@ -1,18 +1,14 @@
-import { expect, test } from "@playwright/test";
-import { openFirstInProgressEncounter } from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
+import { expect, test, type Page } from "@playwright/test";
+import { openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
 test.describe("Encounter Update", () => {
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
   });
 
-  async function openUpdateForm(page: import("@playwright/test").Page) {
+  async function openUpdateForm(page: Page) {
     await page.getByRole("link", { name: "Update Encounter" }).first().click();
     await page.waitForURL(/\/questionnaire\/encounter/);
     await expect(page.getByText("Encounter Status")).toBeVisible();

--- a/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
+++ b/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
@@ -41,7 +41,7 @@ test.describe("Encounter Observations Tab", () => {
     await combobox.scrollIntoViewIfNeeded();
     await combobox.click();
 
-    const search = page.locator('[data-slot="command-input"]');
+    const search = page.getByPlaceholder(/Add (another )?Symptom/i);
     await search.waitFor({ state: "visible" });
     await search.fill("Headache");
     await page

--- a/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
+++ b/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
@@ -1,15 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { openFirstInProgressEncounter } from "tests/helper/ui";
-import { getFacilityId } from "tests/support/facilityId";
+import { expectToast, openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
 test.describe("Encounter Observations Tab", () => {
-  let facilityId: string;
-
   test.beforeEach(async ({ page }) => {
-    facilityId = getFacilityId();
-    await openFirstInProgressEncounter(page, facilityId);
+    await openFixtureEncounter(page);
   });
 
   test("should display the observations tab", async ({ page }) => {
@@ -45,7 +41,7 @@ test.describe("Encounter Observations Tab", () => {
     await combobox.scrollIntoViewIfNeeded();
     await combobox.click();
 
-    const search = page.locator("[cmdk-input]");
+    const search = page.locator('[data-slot="command-input"]');
     await search.waitFor({ state: "visible" });
     await search.fill("Headache");
     await page
@@ -54,11 +50,7 @@ test.describe("Encounter Observations Tab", () => {
       .click();
 
     await page.getByRole("button", { name: "Submit", exact: true }).click();
-    await expect(
-      page
-        .locator("li[data-sonner-toast]")
-        .getByText("Questionnaire submitted successfully"),
-    ).toBeVisible();
+    await expectToast(page, "Questionnaire submitted successfully");
   });
 
   test("should navigate between encounter tabs without errors", async ({

--- a/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
+++ b/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
@@ -35,7 +35,9 @@ test.describe("Healthcare Service Create & Edit", () => {
     });
 
     await test.step("Fill service name", async () => {
-      await page.getByRole("textbox", { name: /name/i }).fill(serviceName);
+      await page
+        .getByRole("textbox", { name: "Name", exact: true })
+        .fill(serviceName);
     });
 
     await test.step("Select a location", async () => {
@@ -77,7 +79,9 @@ test.describe("Healthcare Service Create & Edit", () => {
         .click();
       await page.waitForURL(/\/healthcare_services\/new/);
 
-      await page.getByRole("textbox", { name: /name/i }).fill(originalName);
+      await page
+        .getByRole("textbox", { name: "Name", exact: true })
+        .fill(originalName);
 
       // Select a location
       await selectFirstLocation(page);
@@ -102,8 +106,10 @@ test.describe("Healthcare Service Create & Edit", () => {
       await page.waitForURL(/\/edit$/);
 
       // Clear and update the name
-      await page.getByRole("textbox", { name: /name/i }).clear();
-      await page.getByRole("textbox", { name: /name/i }).fill(updatedName);
+      await page.getByRole("textbox", { name: "Name", exact: true }).clear();
+      await page
+        .getByRole("textbox", { name: "Name", exact: true })
+        .fill(updatedName);
 
       await page.getByRole("button", { name: "Save" }).click();
       await expect(
@@ -131,7 +137,7 @@ test.describe("Healthcare Service Create & Edit", () => {
     // Filling the required name and selecting a location makes the form valid,
     // which must enable the create action.
     await page
-      .getByRole("textbox", { name: /name/i })
+      .getByRole("textbox", { name: "Name", exact: true })
       .fill(faker.commerce.productName());
     await selectFirstLocation(page);
 

--- a/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
+++ b/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
@@ -123,27 +123,23 @@ test.describe("Healthcare Service Create & Edit", () => {
     });
   });
 
-  test("should enable the create button only once the form is valid", async ({
+  test("should enable the create button once the form is edited", async ({
     page,
   }) => {
     await page.getByRole("button", { name: /add healthcare service/i }).click();
     await page.waitForURL(/\/healthcare_services\/new/);
 
-    // Name (and a location) are required, so the create action stays disabled
-    // on an empty form.
+    // The create button is gated on form dirtiness — disabled until a field
+    // changes, then enabled. (Field-level validation surfaces on submit.)
     const createButton = page.getByRole("button", {
       name: "Create",
       exact: true,
     });
     await expect(createButton).toBeDisabled();
 
-    // Filling the required name and selecting a location makes the form valid,
-    // which must enable the create action. The form is intentionally never
-    // submitted — this asserts validation only, so nothing is persisted.
     await page
       .getByRole("textbox", { name: "Name", exact: true })
       .fill(faker.commerce.productName());
-    await selectFirstLocation(page);
 
     await expect(createButton).toBeEnabled();
   });

--- a/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
+++ b/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
@@ -135,7 +135,8 @@ test.describe("Healthcare Service Create & Edit", () => {
     await expect(createButton).toBeDisabled();
 
     // Filling the required name and selecting a location makes the form valid,
-    // which must enable the create action.
+    // which must enable the create action. The form is intentionally never
+    // submitted — this asserts validation only, so nothing is persisted.
     await page
       .getByRole("textbox", { name: "Name", exact: true })
       .fill(faker.commerce.productName());

--- a/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
+++ b/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
@@ -45,7 +45,7 @@ test.describe("Healthcare Service Create & Edit", () => {
     });
 
     await test.step("Submit the form", async () => {
-      await page.getByRole("button", { name: /create/i }).click();
+      await page.getByRole("button", { name: "Create", exact: true }).click();
 
       await expect(
         page.getByText(/healthcare service created successfully/i),
@@ -86,7 +86,7 @@ test.describe("Healthcare Service Create & Edit", () => {
       // Select a location
       await selectFirstLocation(page);
 
-      await page.getByRole("button", { name: /create/i }).click();
+      await page.getByRole("button", { name: "Create", exact: true }).click();
       await expect(
         page.getByText(/healthcare service created successfully/i),
       ).toBeVisible({ timeout: 10000 });
@@ -131,7 +131,10 @@ test.describe("Healthcare Service Create & Edit", () => {
 
     // Name (and a location) are required, so the create action stays disabled
     // on an empty form.
-    const createButton = page.getByRole("button", { name: /create/i });
+    const createButton = page.getByRole("button", {
+      name: "Create",
+      exact: true,
+    });
     await expect(createButton).toBeDisabled();
 
     // Filling the required name and selecting a location makes the form valid,

--- a/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
+++ b/tests/facility/settings/services/healthcareServiceCreateEdit.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { selectFromLocationMultiSelect } from "tests/helper/ui";
 import { getFacilityId } from "tests/support/facilityId";
 
@@ -7,7 +7,7 @@ test.use({ storageState: "tests/.auth/user.json" });
 
 // Selecting the first available location is repeated across the create and edit
 // flows, so keep it in one place.
-async function selectFirstLocation(page: import("@playwright/test").Page) {
+async function selectFirstLocation(page: Page) {
   const locationTrigger = page
     .getByRole("combobox")
     .filter({ hasText: /select locations/i })
@@ -117,7 +117,7 @@ test.describe("Healthcare Service Create & Edit", () => {
     });
   });
 
-  test("should keep the create button disabled until the form is valid", async ({
+  test("should enable the create button only once the form is valid", async ({
     page,
   }) => {
     await page.getByRole("button", { name: /add healthcare service/i }).click();
@@ -125,6 +125,16 @@ test.describe("Healthcare Service Create & Edit", () => {
 
     // Name (and a location) are required, so the create action stays disabled
     // on an empty form.
-    await expect(page.getByRole("button", { name: /create/i })).toBeDisabled();
+    const createButton = page.getByRole("button", { name: /create/i });
+    await expect(createButton).toBeDisabled();
+
+    // Filling the required name and selecting a location makes the form valid,
+    // which must enable the create action.
+    await page
+      .getByRole("textbox", { name: /name/i })
+      .fill(faker.commerce.productName());
+    await selectFirstLocation(page);
+
+    await expect(createButton).toBeEnabled();
   });
 });

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -698,8 +698,9 @@ export async function clickTabOrMenuItem(
 }
 
 /**
- * Opens the deterministic fixture encounter's Overview tab, using the facility,
- * patient, and encounter IDs saved during setup (`tests/setup/patient.setup.ts`).
+ * Opens the deterministic fixture encounter's Overview tab (served at the
+ * `/updates` route), using the facility, patient, and encounter IDs saved during
+ * setup (`tests/setup/patient.setup.ts`).
  *
  * Prefer this over selecting an encounter from a UI list: picking a row from a
  * filtered listing flakes when fixture data changes (skill Critical Rule #2 —

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -698,14 +698,14 @@ export async function clickTabOrMenuItem(
 }
 
 /**
- * Opens the deterministic fixture encounter's Overview tab (served at the
- * `/updates` route), using the facility, patient, and encounter IDs saved during
- * setup (`tests/setup/patient.setup.ts`).
+ * Opens the fixture encounter's Overview tab (served at the `/updates` route),
+ * using the facility, patient, and encounter IDs saved during setup
+ * (`tests/setup/patient.setup.ts`).
  *
- * Prefer this over selecting an encounter from a UI list: picking a row from a
- * filtered listing flakes when fixture data changes (skill Critical Rule #2 —
- * never pick a random row from a UI list). The saved encounter is a writable
- * (planned / in-progress) encounter, so questionnaires and actions are available.
+ * The encounter is selected once during setup — pinned to a writable
+ * planned/in-progress encounter via its `status` filter — and reused here,
+ * instead of each spec re-querying a filtered listing. One selection point,
+ * consistent across specs, matching the `encounterShortcuts.spec.ts` convention.
  *
  * @param page - Playwright page instance
  */

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -1,5 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
-import { format, subDays } from "date-fns";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
 
 export async function selectFromLocationMultiSelect(
   page: Page,
@@ -696,33 +698,23 @@ export async function clickTabOrMenuItem(
 }
 
 /**
- * Opens the first in-progress encounter for a facility from the encounter
- * listing and waits until its detail page (Overview tab) is ready.
+ * Opens the deterministic fixture encounter's Overview tab, using the facility,
+ * patient, and encounter IDs saved during setup (`tests/setup/patient.setup.ts`).
  *
- * Centralises the fixture-selection query used across the encounter specs so
- * the date window / status filter lives in one place.
+ * Prefer this over selecting an encounter from a UI list: picking a row from a
+ * filtered listing flakes when fixture data changes (skill Critical Rule #2 —
+ * never pick a random row from a UI list). The saved encounter is a writable
+ * (planned / in-progress) encounter, so questionnaires and actions are available.
  *
  * @param page - Playwright page instance
- * @param facilityId - Facility whose encounters to list
  */
-export async function openFirstInProgressEncounter(
-  page: Page,
-  facilityId: string,
-): Promise<void> {
-  const createdDateAfter = format(subDays(new Date(), 90), "yyyy-MM-dd");
-  const createdDateBefore = format(new Date(), "yyyy-MM-dd");
+export async function openFixtureEncounter(page: Page): Promise<void> {
+  const facilityId = getFacilityId();
+  const patientId = getPatientId();
+  const encounterId = getEncounterId();
 
   await page.goto(
-    `/facility/${facilityId}/encounters/patients/all?created_date_after=${createdDateAfter}&created_date_before=${createdDateBefore}&status=in_progress`,
+    `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
   );
-  const firstEncounter = page
-    .getByRole("link", { name: "View Encounter" })
-    .first();
-  await expect(
-    firstEncounter,
-    `No in-progress encounter found for facility ${facilityId} — the shared fixture may be missing.`,
-  ).toBeVisible();
-  await firstEncounter.click();
-  await page.waitForURL(/\/facility\/[^/]+\/patient\/[^/]+\/encounter\/[^/]+/);
   await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible();
 }

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -716,8 +716,12 @@ export async function openFixtureEncounter(page: Page): Promise<void> {
   await page.goto(
     `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
   );
+  await page.waitForURL(new RegExp(`/encounter/${encounterId}/updates$`));
+  // Assert encounter-specific content (not just the tab shell) so a stale or
+  // deleted fixture id fails here with a clear reason instead of a blank page.
   await expect(
-    page.getByRole("tab", { name: "Overview" }),
+    page.getByRole("button", { name: /encounter actions/i }).first(),
     `Fixture encounter ${encounterId} did not load — the saved encounterMeta.json id may be stale or deleted; re-run the patient setup.`,
   ).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible();
 }

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -716,5 +716,8 @@ export async function openFixtureEncounter(page: Page): Promise<void> {
   await page.goto(
     `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
   );
-  await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible();
+  await expect(
+    page.getByRole("tab", { name: "Overview" }),
+    `Fixture encounter ${encounterId} did not load — the saved encounterMeta.json id may be stale or deleted; re-run the patient setup.`,
+  ).toBeVisible();
 }

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -717,12 +717,11 @@ export async function openFixtureEncounter(page: Page): Promise<void> {
   await page.goto(
     `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
   );
-  await page.waitForURL(new RegExp(`/encounter/${encounterId}/updates$`));
-  // Assert encounter-specific content (not just the tab shell) so a stale or
+  // `Encounter Actions` only renders once the encounter itself resolves
+  // (`EncounterShow.tsx`), so this doubles as the readiness gate — a stale or
   // deleted fixture id fails here with a clear reason instead of a blank page.
   await expect(
     page.getByRole("button", { name: /encounter actions/i }).first(),
     `Fixture encounter ${encounterId} did not load — the saved encounterMeta.json id may be stale or deleted; re-run the patient setup.`,
   ).toBeVisible();
-  await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible();
 }

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -702,10 +702,10 @@ export async function clickTabOrMenuItem(
  * using the facility, patient, and encounter IDs saved during setup
  * (`tests/setup/patient.setup.ts`).
  *
- * The encounter is selected once during setup — pinned to a writable
- * planned/in-progress encounter via its `status` filter — and reused here,
- * instead of each spec re-querying a filtered listing. One selection point,
- * consistent across specs, matching the `encounterShortcuts.spec.ts` convention.
+ * The encounter is selected once during setup (which targets a writable
+ * planned/in-progress encounter) and reused here, instead of each spec
+ * re-querying a filtered listing. One selection point, consistent across specs,
+ * matching the `encounterShortcuts.spec.ts` convention.
  *
  * @param page - Playwright page instance
  */


### PR DESCRIPTION
Stacked on top of #15970 (base is that PR's branch) so it can be reviewed and merged into it separately.

## Why
The specs added in #15970 are solid, but a few points diverge from the [CARE playwright skill](https://github.com/ohcnetwork/skills/tree/main/playwright). This PR brings them in line.

## Changes (skill rule in parentheses)
- **Deterministic encounter navigation (Critical Rule #2 — never pick a random row from a UI list).** Replaced `openFirstInProgressEncounter(page, facilityId)` — which scraped the first "View Encounter" link from a date-filtered listing — with `openFixtureEncounter(page)` that navigates straight to the fixture encounter via `getFacilityId/getPatientId/getEncounterId` (`.../encounter/{id}/updates`), mirroring the existing `encounterShortcuts.spec.ts` convention. Removes the arbitrary 90-day window and the `date-fns` import from `tests/helper/ui.ts`. Updated all 6 encounter specs (consents, devices, diagnosticReports, completion, update, observations).
- **No CSS-selector leaks in specs (Rules #11/#13).** In `encounterObservations.spec.ts`: `page.locator("[cmdk-input]")` → `getByPlaceholder(/Add (another )?Symptom/i)` (matching the existing `symptom.spec.ts` convention), and the raw `li[data-sonner-toast]` assertion → the `expectToast()` helper.
- **TS hygiene.** Inline `import("@playwright/test").Page` type annotations → a top-level `type { Page }` import (encounterUpdate, healthcareServiceCreateEdit).
- **Accurate form-gating assertion.** The healthcare-service create button is gated on form *dirtiness* (`!form.formState.isDirty`), not zod validity, so the test asserts exactly that — disabled on a pristine form, enabled after editing the name — and is named `should enable the create button once the form is edited`. (Field-level validation surfaces on submit.)
- `invoiceCreation` `beforeEach` de-async'd (no awaits).

The `EncounterQuestion.tsx` aria-labels from #15970 are retained (needed for the role-based combobox lookups).

## Validation
All changed specs run green locally against a fixture-loaded backend (setup + 41 test cases across the touched files passed).

