### PR TITLE
[ENG-945] 🐛 Cleans up effect timers and replaces form.watch with useWatch

### DIFF
--- a/src/components/Tokens/CreateTokenForm.tsx
+++ b/src/components/Tokens/CreateTokenForm.tsx
@@ -112,17 +112,16 @@ export default function CreateTokenForm({
 
   // Set default category when categories of resource type are loaded
   useEffect(() => {
-    form.setValue("categoryId", "");
+    const options = categories?.filter(
+      (category) => category.resource_type === selectedResource.resource_type,
+    );
 
-    if (categories?.length && !form.watch("categoryId")) {
-      const options = categories.filter(
-        (category) => category.resource_type === selectedResource.resource_type,
-      );
-      form.setValue(
-        "categoryId",
-        options.find((category) => category.default)?.id ?? options[0].id,
-      );
-    }
+    form.setValue(
+      "categoryId",
+      options?.find((category) => category.default)?.id ??
+        options?.[0]?.id ??
+        "",
+    );
   }, [categories, form, selectedResource.resource_type]);
 
   const { mutate: createToken, isPending } = useMutation({

--- a/src/components/ui/multi-filter/tagFilter.tsx
+++ b/src/components/ui/multi-filter/tagFilter.tsx
@@ -421,13 +421,17 @@ function GroupSubmenu({
   });
 
   useEffect(() => {
-    if (!open) {
-      setTimeout(() => {
-        onSubMenuOpen(false);
-      }, 100);
-    } else {
+    if (open) {
       onSubMenuOpen(true);
+      return;
     }
+
+    // Clear the timer if the menu opens again or the component unmounts.
+    const timeoutId = setTimeout(() => {
+      onSubMenuOpen(false);
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
   }, [open, onSubMenuOpen]);
 
   const hasActiveChildren = (children?.results?.length ?? 0) > 0;

--- a/src/pages/Facility/settings/locations/LocationForm.tsx
+++ b/src/pages/Facility/settings/locations/LocationForm.tsx
@@ -1,8 +1,8 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Info, RotateCcw } from "lucide-react";
-import { useEffect } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useCallback, useEffect } from "react";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import * as z from "zod";
@@ -122,25 +122,34 @@ export default function LocationForm({
     name: "bedNames",
   });
 
-  const resetToDefaultNames = () => {
-    if (form.watch("name") && form.watch("numberOfBeds")) {
+  const formType = useWatch({ control: form.control, name: "form" });
+  const bulkCreationEnabled = useWatch({
+    control: form.control,
+    name: "enableBulkCreation",
+  });
+  const numberOfBeds = useWatch({
+    control: form.control,
+    name: "numberOfBeds",
+  });
+  const locationName = useWatch({ control: form.control, name: "name" });
+  const customizeNames = useWatch({
+    control: form.control,
+    name: "customizeNames",
+  });
+
+  const resetToDefaultNames = useCallback(() => {
+    if (locationName && numberOfBeds) {
       const defaultNames = Array.from(
-        { length: Number.parseInt(form.watch("numberOfBeds") ?? "0") },
+        { length: Number.parseInt(numberOfBeds ?? "0") },
         (_, index) => ({
-          name: `${form.watch("name")} ${index + 1}`,
+          name: `${locationName} ${index + 1}`,
         }),
       );
       replaceBedFields(defaultNames);
     }
-  };
+  }, [locationName, numberOfBeds, replaceBedFields]);
 
   useEffect(() => {
-    const formType = form.watch("form");
-    const bulkCreationEnabled = form.watch("enableBulkCreation");
-    const numberOfBeds = form.watch("numberOfBeds");
-    const locationName = form.watch("name");
-    const customizeNames = form.watch("customizeNames");
-
     if (
       formType === "bd" &&
       bulkCreationEnabled &&
@@ -164,12 +173,15 @@ export default function LocationForm({
       }
     }
   }, [
-    form.watch("form"),
-    form.watch("enableBulkCreation"),
-    form.watch("numberOfBeds"),
-    form.watch("name"),
-    form.watch("customizeNames"),
+    formType,
+    bulkCreationEnabled,
+    numberOfBeds,
+    locationName,
+    customizeNames,
     bedFields.length,
+    form,
+    replaceBedFields,
+    resetToDefaultNames,
   ]);
 
   useEffect(() => {

--- a/src/pages/Facility/settings/locations/LocationMap.tsx
+++ b/src/pages/Facility/settings/locations/LocationMap.tsx
@@ -417,7 +417,7 @@ function LocationMapContent({
       });
 
       // Only fit view when there's an actual search
-      setTimeout(() => {
+      const fitViewTimeoutId = setTimeout(() => {
         fitView({
           padding: 0.2,
           minZoom: 0.2,
@@ -425,6 +425,9 @@ function LocationMapContent({
           duration: 800,
         });
       }, 100);
+
+      // Cancel the pending fit if the search changes or the component unmounts.
+      return () => clearTimeout(fitViewTimeoutId);
     }
   }, [locations, fitView, rootLocations, searchQuery]);
 
@@ -432,7 +435,7 @@ function LocationMapContent({
     if (searchQuery === "") {
       setExpandedNodes([]);
       // Fit view when collapsing all nodes
-      setTimeout(() => {
+      const fitViewTimeoutId = setTimeout(() => {
         fitView({
           padding: 0.2,
           minZoom: 0.2,
@@ -440,6 +443,9 @@ function LocationMapContent({
           duration: 800,
         });
       }, 100);
+
+      // Cancel the pending fit if the search changes or the component unmounts.
+      return () => clearTimeout(fitViewTimeoutId);
     }
   }, [searchQuery, fitView]);
 

--- a/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
+++ b/src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx
@@ -329,7 +329,7 @@ function ObservationDefinitionFormContent({
     } else {
       form.setValue(
         "component",
-        form.watch("component")?.map((c) => ({
+        form.getValues("component")?.map((c) => ({
           ...c,
           qualified_ranges: [],
         })),

--- a/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx
@@ -1,8 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
+import { TFunction } from "i18next";
 import { useQueryParams } from "raviger";
-import { useForm } from "react-hook-form";
+import { Control, useForm, useWatch } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import * as z from "zod";
@@ -55,36 +56,8 @@ import {
 } from "@/types/scheduling/schedule";
 import scheduleApis from "@/types/scheduling/scheduleApi";
 
-interface Props {
-  facilityId: string;
-  resourceType: SchedulableResourceType;
-  resourceId: string;
-  trigger?: React.ReactNode;
-}
-
-type QueryParams = {
-  sheet?: "create_template" | null;
-};
-
-export default function CreateScheduleTemplateSheet({
-  facilityId,
-  resourceType,
-  resourceId,
-  trigger,
-}: Props) {
-  const { t } = useTranslation();
-  const queryClient = useQueryClient();
-
-  // Voluntarily masking the setQParams function to merge with other query params if any (since path is not unique within the user availability tab)
-  const [qParams, _setQParams] = useQueryParams<QueryParams>();
-  const setQParams = (p: QueryParams) => _setQParams(p, { overwrite: false });
-
-  const weekdayFormat = useBreakpoints({
-    default: "alphabet",
-    md: "short",
-  } as const);
-
-  const formSchema = z
+const buildTemplateFormSchema = (t: TFunction) =>
+  z
     .object({
       name: z.string().trim().min(1, t("field_required")),
       valid_from: z
@@ -189,6 +162,101 @@ export default function CreateScheduleTemplateSheet({
       },
     );
 
+type TemplateFormSchema = ReturnType<typeof buildTemplateFormSchema>;
+
+type TemplateFormControl = Control<
+  z.input<TemplateFormSchema>,
+  unknown,
+  z.output<TemplateFormSchema>
+>;
+
+interface Props {
+  facilityId: string;
+  resourceType: SchedulableResourceType;
+  resourceId: string;
+  trigger?: React.ReactNode;
+}
+
+type QueryParams = {
+  sheet?: "create_template" | null;
+};
+
+/**
+ * Shows the slot allocation summary for one availability row.
+ *
+ * Each row keeps its own subscription. `useWatch` releases the subscription
+ * when the row unmounts, so a removed row leaves no live subscription.
+ */
+function TimeAllocationCallout({
+  control,
+  index,
+}: {
+  control: TemplateFormControl;
+  index: number;
+}) {
+  const startTime = useWatch({
+    control,
+    name: `availabilities.${index}.start_time`,
+  });
+  const endTime = useWatch({
+    control,
+    name: `availabilities.${index}.end_time`,
+  });
+  const slotSizeInMinutes = useWatch({
+    control,
+    name: `availabilities.${index}.slot_size_in_minutes`,
+  });
+  const tokensPerSlot = useWatch({
+    control,
+    name: `availabilities.${index}.tokens_per_slot`,
+  });
+
+  if (!startTime || !endTime || !slotSizeInMinutes || !tokensPerSlot) {
+    return null;
+  }
+
+  const slotsPerSession = getSlotsPerSession(
+    startTime,
+    endTime,
+    slotSizeInMinutes,
+  );
+  const tokenDuration = getTokenDuration(slotSizeInMinutes, tokensPerSlot);
+
+  if (!slotsPerSession || !tokenDuration) return null;
+
+  return (
+    <Callout variant="alert" badge="Info">
+      <Trans
+        i18nKey="schedule_slots_allocation_callout"
+        values={{
+          slots: Math.floor(slotsPerSession),
+          token_duration: tokenDuration.toFixed(1).replace(".0", ""),
+        }}
+      />
+    </Callout>
+  );
+}
+
+export default function CreateScheduleTemplateSheet({
+  facilityId,
+  resourceType,
+  resourceId,
+  trigger,
+}: Props) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  // Voluntarily masking the setQParams function to merge with other query params if any (since path is not unique within the user availability tab)
+  const [qParams, _setQParams] = useQueryParams<QueryParams>();
+  const setQParams = (p: QueryParams) => _setQParams(p, { overwrite: false });
+
+  const weekdayFormat = useBreakpoints({
+    default: "alphabet",
+    md: "short",
+  } as const);
+
+  const formSchema = buildTemplateFormSchema(t);
+
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -253,46 +321,12 @@ export default function CreateScheduleTemplateSheet({
     });
   }
 
-  const timeAllocationCallout = (index: number) => {
-    const startTime = form.watch(`availabilities.${index}.start_time`);
-    const endTime = form.watch(`availabilities.${index}.end_time`);
-    const slotSizeInMinutes = form.watch(
-      `availabilities.${index}.slot_size_in_minutes`,
-    );
-    const tokensPerSlot = form.watch(`availabilities.${index}.tokens_per_slot`);
-
-    if (!startTime || !endTime || !slotSizeInMinutes || !tokensPerSlot) {
-      return null;
-    }
-
-    const slotsPerSession = getSlotsPerSession(
-      startTime,
-      endTime,
-      slotSizeInMinutes,
-    );
-    const tokenDuration = getTokenDuration(slotSizeInMinutes, tokensPerSlot);
-
-    if (!slotsPerSession || !tokenDuration) return null;
-
-    return (
-      <Callout variant="alert" badge="Info">
-        <Trans
-          i18nKey="schedule_slots_allocation_callout"
-          values={{
-            slots: Math.floor(slotsPerSession),
-            token_duration: tokenDuration.toFixed(1).replace(".0", ""),
-          }}
-        />
-      </Callout>
-    );
-  };
-
   const updateSlotDuration = (index: number) => {
-    const isAutoFill = form.watch(`availabilities.${index}.is_auto_fill`);
+    const isAutoFill = form.getValues(`availabilities.${index}.is_auto_fill`);
     if (isAutoFill) {
-      const start = form.watch(`availabilities.${index}.start_time`);
-      const end = form.watch(`availabilities.${index}.end_time`);
-      const numOfSlots = form.watch(`availabilities.${index}.num_of_slots`);
+      const start = form.getValues(`availabilities.${index}.start_time`);
+      const end = form.getValues(`availabilities.${index}.end_time`);
+      const numOfSlots = form.getValues(`availabilities.${index}.num_of_slots`);
       if (!start || !end) return;
       const duration = calculateSlotDuration(start, end, numOfSlots);
       form.setValue(`availabilities.${index}.slot_size_in_minutes`, duration);
@@ -720,7 +754,10 @@ export default function CreateScheduleTemplateSheet({
                             />
                           </div>
                           <div className="col-span-2 mb-2">
-                            {timeAllocationCallout(index)}
+                            <TimeAllocationCallout
+                              control={form.control}
+                              index={index}
+                            />
                           </div>
                         </>
                       )}

--- a/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
+++ b/src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { SaveIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import * as z from "zod";
@@ -602,6 +602,17 @@ const NewAvailabilityCard = ({
     },
   });
 
+  const startTime = useWatch({ control: form.control, name: "start_time" });
+  const endTime = useWatch({ control: form.control, name: "end_time" });
+  const slotSizeInMinutes = useWatch({
+    control: form.control,
+    name: "slot_size_in_minutes",
+  });
+  const tokensPerSlot = useWatch({
+    control: form.control,
+    name: "tokens_per_slot",
+  });
+
   const { mutate: createAvailability, isPending } = useMutation({
     mutationFn: mutate(scheduleApis.templates.availabilities.create, {
       pathParams: { facilityId, scheduleId },
@@ -617,11 +628,6 @@ const NewAvailabilityCard = ({
   });
 
   const timeAllocationCallout = () => {
-    const startTime = form.watch("start_time");
-    const endTime = form.watch("end_time");
-    const slotSizeInMinutes = form.watch("slot_size_in_minutes");
-    const tokensPerSlot = form.watch("tokens_per_slot");
-
     if (!startTime || !endTime || !slotSizeInMinutes || !tokensPerSlot) {
       return null;
     }
@@ -687,11 +693,11 @@ const NewAvailabilityCard = ({
     );
   }
   const updateSlotDuration = () => {
-    const isAutoFill = form.watch("is_auto_fill");
+    const isAutoFill = form.getValues("is_auto_fill");
     if (isAutoFill) {
-      const start = form.watch("start_time");
-      const end = form.watch("end_time");
-      const numOfSlots = form.watch("num_of_slots");
+      const start = form.getValues("start_time");
+      const end = form.getValues("end_time");
+      const numOfSlots = form.getValues("num_of_slots");
       if (!start || !end) return;
       const duration = calculateSlotDuration(start, end, numOfSlots);
       form.setValue("slot_size_in_minutes", duration);


### PR DESCRIPTION
ENG-945

## What this pull request does

This pull request corrects all findings of the React Doctor rule `react-doctor/effect-needs-cleanup`. The rule has severity **error**, category **Bugs**, priority **P1**.

The findings have two different causes. This pull request corrects both.

---

## Cause A — an effect starts a timer but does not stop it

An effect starts a timer with `setTimeout`. The effect does not keep the timer id. The effect has no cleanup function.

React can remove the component before the timer runs. The timer still runs. It then calls a callback on a component that is gone. This is a memory leak. It can also cause a state update on a removed component.

**The fix:** keep the timer id in a variable. Return a cleanup function. The cleanup function calls `clearTimeout`.

```tsx
// Before
useEffect(() => {
  if (!open) {
    setTimeout(() => {
      onSubMenuOpen(false);
    }, 100);
  } else {
    onSubMenuOpen(true);
  }
}, [open, onSubMenuOpen]);

// After
useEffect(() => {
  if (open) {
    onSubMenuOpen(true);
    return;
  }

  const timeoutId = setTimeout(() => {
    onSubMenuOpen(false);
  }, 100);

  return () => clearTimeout(timeoutId);
}, [open, onSubMenuOpen]);
```

Files with cause A:

| File | Change |
| --- | --- |
| `src/components/ui/multi-filter/tagFilter.tsx` | 1 timer. The open branch now returns early. |
| `src/pages/Facility/settings/locations/LocationMap.tsx` | 2 timers that call `fitView`. |

---

## Cause B — the code calls `form.watch(...)` in an effect or in a helper

The detector sees `.watch` as a subscription. In react-hook-form, `form.watch("name")` with a string argument only reads a value. It does not give a handle to release. So there is nothing to clean up.

But the code is still wrong. The react-hook-form documentation says: do not call `watch()` in an effect. Do not call `watch()` in a helper that runs during render. The dependency array of the effect does not track the value. So the effect can run with an old value.

**The fix depends on when the code runs.**

1. **Code that runs during render** now uses the `useWatch` hook at the top level of a component. `useWatch` subscribes in the correct way. It renders the component again when the value changes. It cleans itself up when React removes the component. The values then go into the dependency array of the effect.

2. **Code that runs only after a user action** now uses `form.getValues(...)`. A handler must read the value at the moment of the action. A handler must not subscribe.

```tsx
// Before
useEffect(() => {
  const name = form.watch("name");
  const beds = form.watch("numberOfBeds");
  ...
}, [/* the effect does not track name and beds */]);

// After
const name = useWatch({ control: form.control, name: "name" });
const beds = useWatch({ control: form.control, name: "numberOfBeds" });

useEffect(() => {
  ...
}, [name, beds]);
```

### The decision at each site

| File | Site | Decision | Reason |
| --- | --- | --- | --- |
| `src/components/Tokens/CreateTokenForm.tsx` | effect that sets the default category | Removed the read | The effect first calls `setValue("categoryId", "")`. The guard `!form.watch("categoryId")` is then always true. The read is dead code. A `useWatch` here would make a loop, because the same effect writes `categoryId`. |
| `src/pages/Facility/settings/locations/LocationForm.tsx` | 2 sites in `resetToDefaultNames` and its effect | `useWatch` | The effect runs during the render cycle. A `useCallback` now wraps `resetToDefaultNames`, because both an effect and a click handler call it. |
| `src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx` | `handleClearObservationInterpretation` | `form.getValues` | Only the `onClick` of an `AlertDialogAction` calls this function. |
| `src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx` | `timeAllocationCallout(index)` | New child component with `useWatch` | The helper runs during render inside a loop over a field array. A hook must not go in a loop. |
| `src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx` | `updateSlotDuration(index)` | `form.getValues` | Only `onChange` and `onCheckedChange` handlers call this function. |
| `src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx` | `timeAllocationCallout()` | `useWatch` at the top level | The helper runs during render. There is no loop here, so no child component is necessary. |
| `src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx` | `updateSlotDuration()` | `form.getValues` | Only event handlers call this function. |

### Note on `CreateScheduleTemplateSheet.tsx`

This file needed more work than the others.

- The zod schema moved to a factory function at module scope: `buildTemplateFormSchema(t)`. This makes it possible to name the form type outside the component.
- A new child component `TimeAllocationCallout` holds the 4 `useWatch` calls. Each row of the field array now owns its own subscription.
- `useForm` with `zodResolver` gives `Control<TInput, unknown, TOutput>`. The prop type is `Control<z.input<S>, unknown, z.output<S>>`.

---

## Files changed

- `src/components/Tokens/CreateTokenForm.tsx`
- `src/components/ui/multi-filter/tagFilter.tsx`
- `src/pages/Facility/settings/locations/LocationForm.tsx`
- `src/pages/Facility/settings/locations/LocationMap.tsx`
- `src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx`
- `src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx`
- `src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx`

---

## React Doctor output

### Before — 11 findings

```
✖ Effect subscription or timer never cleaned up ×11
  react-doctor/effect-needs-cleanup
  src/components/Tokens/CreateTokenForm.tsx:114
  src/components/ui/multi-filter/tagFilter.tsx:423
  src/pages/Facility/settings/locations/LocationForm.tsx:126
  src/pages/Facility/settings/locations/LocationForm.tsx:137
  src/pages/Facility/settings/locations/LocationMap.tsx:377
  src/pages/Facility/settings/locations/LocationMap.tsx:431
  src/pages/Facility/settings/observationDefinition/ObservationDefinitionForm.tsx:332
  src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx:257
  src/pages/Scheduling/components/CreateScheduleTemplateSheet.tsx:291
  src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx:620
  src/pages/Scheduling/components/EditScheduleTemplateSheet.tsx:690
```

### After — 0 findings

The rule `react-doctor/effect-needs-cleanup` does not appear in the report.

### Totals

| Metric | Before | After |
| --- | --- | --- |
| `effect-needs-cleanup` findings | 11 | **0** |
| Score | 43 / 100 | **46 / 100** |
| Bugs errors | 17 | **6** |
| Bugs warnings | 510 | **503** |

A full comparison of every rule shows that no rule got worse. Two other rules improved:

- `react-doctor/exhaustive-deps`: 72 → 66
- `react-doctor/no-adjust-state-on-prop-change`: 97 → 96

The original report listed 12 findings. One of them named `src/pages/Facility/services/pharmacy/hooks/useMedicationBill.ts`. That file does not exist on `develop`. The current scan finds 11 items.

---

## Checks

| Check | Result |
| --- | --- |
| `tsc --noEmit` | No new errors. One error for `@/supportedBrowsers` also exists on a clean tree. |
| Prettier and ESLint | 0 errors. Warnings in the changed files went from 15 to 9. |
| `react-doctor/rules-of-hooks` | No new findings. |
| `react-doctor/exhaustive-deps` | Improved. |
| Playwright | 54 targeted tests pass with 1 worker. |

The Playwright run covers `locationCreation.spec.ts`, `userScheduleCreation.spec.ts`, `observationDefinition.spec.ts`, `tokenCategory.spec.ts`, tags and queues. Two tests give direct proof:

- "preserves a customized bed name when the bed count changes" covers the `LocationForm` change.
- "should create and verify a weekday schedule template" covers the `CreateScheduleTemplateSheet` change.

### One check I could not run

`CreateTokenForm` has no end-to-end test. The "Generate Token" quick action needs the flag `REACT_ENABLE_TOKEN_GENERATION_IN_PATIENT_HOME` and a facility token permission. The local fixture user does not have that permission, so the button does not appear. I verified the change by reading the code instead. The new code gives the same result as the old code. It also removes a possible crash, because the old code read `options[0].id` without a check for an empty list.

### A note on flaky tests

`observationDefinition.spec.ts` fails at random with 4 workers. The failing test changes on each run. I proved that this also happens without my change: I put my change aside, built the app again, and ran the tests 3 times. One of those runs failed. With 1 worker the file passes 19 of 19 tests, both with and without my change. The cause is a race on the shared local database. It is not a regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category selection when creating tokens, including safer handling when no compatible category is available.
  * Improved submenu open and close behavior to prevent flickering.
  * Ensured location map adjustments are canceled cleanly when searches or resets change.
  * Improved observation interpretation clearing to reliably reset qualified ranges.

* **Improvements**
  * Improved location bed-name synchronization.
  * Improved schedule template forms and slot allocation updates for more reliable, responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->