### PR TITLE
[ENG-950] Skip setting `dispense_status` when creating medication requests

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -191,6 +191,7 @@ async function fetchProductAndBuildMedication(
   return {
     ...med,
     id: undefined,
+    dispense_status: undefined,
     do_not_perform: med.do_not_perform ?? false,
     dosage_instruction: med.dosage_instruction ?? [
       { as_needed_boolean: false },

--- a/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
+++ b/src/components/Questionnaire/QuestionTypes/MedicationRequestQuestion.tsx
@@ -149,6 +149,7 @@ export function buildMedicationForTemplate(
   // Remove internal objects that shouldn't be stored in templates
   delete medicationForTemplate.requested_product_internal;
   delete medicationForTemplate.id;
+  delete medicationForTemplate.dispense_status;
 
   return medicationForTemplate;
 }
@@ -646,6 +647,7 @@ export function MedicationRequestQuestion({
       ...medications,
       {
         ...medication,
+        dispense_status: undefined,
         dirty: true, // Mark new medication as dirty
         create_prescription: {
           status: PrescriptionStatus.active,
@@ -684,6 +686,7 @@ export function MedicationRequestQuestion({
 
         return {
           ...request,
+          dispense_status: undefined,
           requested_product: requested_product?.id,
           requested_product_internal: requested_product,
           requester: currentUser,
@@ -701,6 +704,7 @@ export function MedicationRequestQuestion({
           ...parseMedicationStringToRequest(currentUser, statement.medication),
           authored_on: new Date().toISOString(),
           note: statement.note,
+          dispense_status: undefined,
           requester: currentUser,
           dirty: true, // Mark as dirty since it's being added as new
           create_prescription: {
@@ -798,6 +802,7 @@ export function MedicationRequestQuestion({
       ...medications,
       {
         ...medicationToAdd,
+        dispense_status: undefined,
         create_prescription: {
           status: PrescriptionStatus.active,
           alternate_identifier: "",
@@ -835,6 +840,7 @@ export function MedicationRequestQuestion({
         ...medications,
         ...medicationsWithProductKnowledge.map((med) => ({
           ...med,
+          dispense_status: undefined,
           create_prescription: {
             status: PrescriptionStatus.active,
             alternate_identifier: "",


### PR DESCRIPTION
## Proposed Changes

- Skip setting `dispense_status` when creating medication requests

ENG-950

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Medication requests created from templates or converted from historical medication records now leave the dispense status unset until it is explicitly determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->