### PR TITLE
[ENG-953] 🧪 Add Playwright tests for medication request dispense status

### DIFF
--- a/tests/facility/patient/encounter/structuredQuestions/medicationRequestApi.ts
+++ b/tests/facility/patient/encounter/structuredQuestions/medicationRequestApi.ts
@@ -1,0 +1,223 @@
+import { getApiHeaders, getApiUrl } from "tests/helper/utils";
+
+/**
+ * API helpers that seed and read medication requests and response templates.
+ *
+ * The UI cannot set `dispense_status`. Only the pharmacy dispense flow sets it.
+ * These helpers seed that state directly, so a test can show that a new
+ * medication request does not copy the `dispense_status` of its source record.
+ */
+
+export interface MedicationCode {
+  system: string;
+  code: string;
+  display: string;
+}
+
+export interface MedicationRequestRecord {
+  id: string;
+  medication: MedicationCode | null;
+  dispense_status: string | null;
+  authored_on: string;
+}
+
+async function callApi<T>(
+  path: string,
+  init: { method: string; body?: unknown } = { method: "GET" },
+): Promise<T> {
+  const response = await fetch(`${getApiUrl()}${path}`, {
+    method: init.method,
+    headers: getApiHeaders(),
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${init.method} ${path} failed with ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  return response.status === 204 ? (undefined as T) : await response.json();
+}
+
+/** Returns the medication code that the given display name refers to. */
+export async function findMedicationCode(
+  display: string,
+): Promise<MedicationCode> {
+  const { results } = await callApi<{ results: MedicationCode[] }>(
+    "/api/v1/valueset/system-medication/expand/",
+    { method: "POST", body: { search: `${display} clinical drug`, count: 20 } },
+  );
+
+  const match = results.find((result) => result.display === display);
+  if (!match) {
+    throw new Error(`Medication "${display}" is not in the valueset`);
+  }
+
+  return { system: match.system, code: match.code, display: match.display };
+}
+
+/** Returns the id of the logged in user. */
+export async function getCurrentUserId(): Promise<string> {
+  const user = await callApi<{ id: string }>("/api/v1/users/getcurrentuser/");
+  return user.id;
+}
+
+/** Builds a valid medication request body for the given code. */
+export function buildMedicationRequestBody(
+  medication: MedicationCode,
+  encounterId: string,
+  requesterId: string,
+  dispenseStatus?: string,
+) {
+  return {
+    status: "active",
+    intent: "order",
+    category: "inpatient",
+    priority: "routine",
+    do_not_perform: false,
+    medication,
+    dosage_instruction: [
+      {
+        as_needed_boolean: false,
+        dose_and_rate: {
+          type: "ordered",
+          dose_quantity: {
+            value: 1,
+            unit: {
+              system: "http://unitsofmeasure.org",
+              code: "{tbl}",
+              display: "tablets",
+            },
+          },
+        },
+        timing: {
+          repeat: {
+            frequency: 2,
+            period: 1,
+            period_unit: "d",
+            bounds_duration: { value: 3, unit: "d" },
+          },
+          code: {
+            system: "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation",
+            code: "BID",
+            display: "BID",
+          },
+        },
+      },
+    ],
+    authored_on: new Date().toISOString(),
+    encounter: encounterId,
+    requester: requesterId,
+    ...(dispenseStatus ? { dispense_status: dispenseStatus } : {}),
+  };
+}
+
+/**
+ * Creates a medication request that the pharmacy has already dispensed.
+ * Returns the id of the new record.
+ */
+export async function seedDispensedMedicationRequest(
+  patientId: string,
+  encounterId: string,
+  medication: MedicationCode,
+): Promise<string> {
+  const requesterId = await getCurrentUserId();
+  const created = await callApi<MedicationRequestRecord>(
+    `/api/v1/patient/${patientId}/medication/request/`,
+    {
+      method: "POST",
+      body: buildMedicationRequestBody(
+        medication,
+        encounterId,
+        requesterId,
+        "complete",
+      ),
+    },
+  );
+
+  if (created.dispense_status !== "complete") {
+    throw new Error("The seeded medication request is not dispensed");
+  }
+
+  return created.id;
+}
+
+/** Returns every medication request of the encounter that uses the code. */
+export async function listMedicationRequests(
+  patientId: string,
+  encounterId: string,
+  medicationCode: string,
+): Promise<MedicationRequestRecord[]> {
+  const { results } = await callApi<{ results: MedicationRequestRecord[] }>(
+    `/api/v1/patient/${patientId}/medication/request/?encounter=${encounterId}&limit=100`,
+  );
+
+  return results.filter((result) => result.medication?.code === medicationCode);
+}
+
+/**
+ * Creates a response template that holds one dispensed medication.
+ * Returns the id of the new template.
+ */
+export async function seedTemplateWithDispensedMedication(
+  facilityId: string,
+  name: string,
+  medication: MedicationCode,
+  encounterId: string,
+): Promise<string> {
+  const requesterId = await getCurrentUserId();
+  const {
+    encounter: _encounter,
+    requester: _requester,
+    ...medicationRequest
+  } = buildMedicationRequestBody(
+    medication,
+    encounterId,
+    requesterId,
+    "complete",
+  );
+
+  const template = await callApi<{ id: string }>(
+    "/api/v1/questionnaire_response_template/",
+    {
+      method: "POST",
+      body: {
+        name,
+        description: "",
+        facility: facilityId,
+        template_data: {
+          medication_request: [medicationRequest],
+          service_request: [],
+        },
+        users: ["admin"],
+        facility_organizations: [],
+      },
+    },
+  );
+
+  return template.id;
+}
+
+/** Returns the medications that the template holds. */
+export async function getTemplateMedications(
+  templateId: string,
+): Promise<Record<string, unknown>[]> {
+  const template = await callApi<{
+    template_data?: { medication_request?: Record<string, unknown>[] };
+  }>(`/api/v1/questionnaire_response_template/${templateId}/`);
+
+  return template.template_data?.medication_request ?? [];
+}
+
+/** Returns the id of the template with the given name, or null. */
+export async function findTemplateIdByName(
+  facilityId: string,
+  name: string,
+): Promise<string | null> {
+  const { results } = await callApi<{ results: { id: string }[] }>(
+    `/api/v1/questionnaire_response_template/?facility=${facilityId}&name=${encodeURIComponent(name)}&limit=20`,
+  );
+
+  return results[0]?.id ?? null;
+}

--- a/tests/facility/patient/encounter/structuredQuestions/medicationRequestDispenseStatus.spec.ts
+++ b/tests/facility/patient/encounter/structuredQuestions/medicationRequestDispenseStatus.spec.ts
@@ -1,0 +1,319 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  findMedicationCode,
+  findTemplateIdByName,
+  getTemplateMedications,
+  listMedicationRequests,
+  seedDispensedMedicationRequest,
+  seedTemplateWithDispensedMedication,
+  type MedicationCode,
+} from "tests/facility/patient/encounter/structuredQuestions/medicationRequestApi";
+import { expectToast } from "tests/helper/ui";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+/**
+ * `dispense_status` belongs to the pharmacy. Only a dispense action sets it.
+ * A new medication request must always start with an empty `dispense_status`,
+ * even when the user copies it from a record that the pharmacy dispensed.
+ *
+ * Each test uses its own medication, so the tests can run in parallel against
+ * the same patient and encounter.
+ */
+
+/** One medication per add path, to keep the assertions independent. */
+const MEDICATIONS = {
+  history: "Senna 15 mg oral tablet",
+  templateMedication: "Zinc 50 mg oral capsule",
+  templateApply: "Doxepin 3 mg oral tablet",
+  saveTemplate: "Mesna 400 mg oral tablet",
+} as const;
+
+async function openMedicationQuestionnaire(
+  page: Page,
+  facilityId: string,
+  patientId: string,
+  encounterId: string,
+) {
+  await page.goto(
+    `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/questionnaire/medication_request`,
+  );
+  await page.waitForLoadState("networkidle");
+}
+
+/** Adds a past prescription through the "Medication History" sheet. */
+async function addFromMedicationHistory(page: Page, medicationName: string) {
+  await page.getByRole("button", { name: "Medication History" }).click();
+
+  const sheet = page.getByRole("dialog", { name: "Medication History" });
+  await sheet.waitFor({ state: "visible" });
+  await sheet.getByRole("tab", { name: "Past Prescriptions" }).click();
+
+  const row = sheet.locator("tbody tr").filter({ hasText: medicationName });
+  await expect(row.first()).toBeVisible();
+  await row.first().getByRole("checkbox").check();
+
+  await sheet.getByRole("button", { name: "Add Selected" }).click();
+  await sheet.waitFor({ state: "hidden" });
+}
+
+/** Opens the response templates sheet and expands the given template. */
+async function openTemplate(page: Page, templateName: string) {
+  await page.getByRole("button", { name: "Templates" }).click();
+
+  const sheet = page.getByRole("dialog", { name: "Response Templates" });
+  await sheet.waitFor({ state: "visible" });
+  await sheet.getByPlaceholder("Search templates").fill(templateName);
+  await expect(sheet.getByText(templateName, { exact: true })).toBeVisible();
+
+  return sheet;
+}
+
+async function submitQuestionnaire(page: Page) {
+  await page.getByRole("button", { name: "Submit", exact: true }).click();
+  await expectToast(page, /questionnaire submitted successfully/i);
+}
+
+/**
+ * Asserts that the encounter holds a medication request for the code that the
+ * questionnaire created, and that its `dispense_status` is empty.
+ * `knownIds` holds the records that existed before the questionnaire ran.
+ */
+async function expectNewRequestWithoutDispenseStatus(
+  patientId: string,
+  encounterId: string,
+  medication: MedicationCode,
+  knownIds: Set<string>,
+) {
+  const newRequests = async () => {
+    const requests = await listMedicationRequests(
+      patientId,
+      encounterId,
+      medication.code,
+    );
+    return requests.filter((request) => !knownIds.has(request.id));
+  };
+
+  await expect
+    .poll(async () => (await newRequests()).length, {
+      message: "The questionnaire did not create a medication request",
+    })
+    .toBeGreaterThan(0);
+
+  for (const request of await newRequests()) {
+    expect(
+      request.dispense_status,
+      "A new medication request must not copy the dispense status",
+    ).toBeFalsy();
+  }
+}
+
+/** Returns the ids of the medication requests that already exist. */
+async function existingRequestIds(
+  patientId: string,
+  encounterId: string,
+  medication: MedicationCode,
+): Promise<Set<string>> {
+  const requests = await listMedicationRequests(
+    patientId,
+    encounterId,
+    medication.code,
+  );
+  return new Set(requests.map((request) => request.id));
+}
+
+test.describe("Medication Request dispense status", () => {
+  let facilityId: string;
+  let patientId: string;
+  let encounterId: string;
+
+  test.beforeEach(() => {
+    facilityId = getFacilityId();
+    patientId = getPatientId();
+    encounterId = getEncounterId();
+  });
+
+  test("does not copy the dispense status of a past prescription", async ({
+    page,
+  }) => {
+    const medication = await findMedicationCode(MEDICATIONS.history);
+    let knownIds = new Set<string>();
+
+    await test.step("Seed a dispensed prescription", async () => {
+      await seedDispensedMedicationRequest(patientId, encounterId, medication);
+      knownIds = await existingRequestIds(patientId, encounterId, medication);
+    });
+
+    await test.step("Add the prescription again from the history", async () => {
+      await openMedicationQuestionnaire(
+        page,
+        facilityId,
+        patientId,
+        encounterId,
+      );
+      await addFromMedicationHistory(page, medication.display);
+      await submitQuestionnaire(page);
+    });
+
+    await test.step("Verify the new request has no dispense status", async () => {
+      await expectNewRequestWithoutDispenseStatus(
+        patientId,
+        encounterId,
+        medication,
+        knownIds,
+      );
+    });
+  });
+
+  test("does not copy the dispense status of a single template medication", async ({
+    page,
+  }) => {
+    const medication = await findMedicationCode(MEDICATIONS.templateMedication);
+    const templateName = `PW Dispensed Medication ${Date.now()}`;
+    let knownIds = new Set<string>();
+
+    await test.step("Seed a template that holds a dispensed medication", async () => {
+      await seedTemplateWithDispensedMedication(
+        facilityId,
+        templateName,
+        medication,
+        encounterId,
+      );
+      knownIds = await existingRequestIds(patientId, encounterId, medication);
+    });
+
+    await test.step("Add the template medication to the questionnaire", async () => {
+      await openMedicationQuestionnaire(
+        page,
+        facilityId,
+        patientId,
+        encounterId,
+      );
+
+      const sheet = await openTemplate(page, templateName);
+      await sheet.getByText(templateName, { exact: true }).click();
+      await sheet
+        .getByRole("button")
+        .filter({ hasText: medication.display })
+        .click();
+      await expectToast(page, /medication added/i);
+
+      await page.keyboard.press("Escape");
+      await sheet.waitFor({ state: "hidden" });
+      await submitQuestionnaire(page);
+    });
+
+    await test.step("Verify the new request has no dispense status", async () => {
+      await expectNewRequestWithoutDispenseStatus(
+        patientId,
+        encounterId,
+        medication,
+        knownIds,
+      );
+    });
+  });
+
+  test("does not copy the dispense status when a template is applied", async ({
+    page,
+  }) => {
+    const medication = await findMedicationCode(MEDICATIONS.templateApply);
+    const templateName = `PW Dispensed Template ${Date.now()}`;
+    let knownIds = new Set<string>();
+
+    await test.step("Seed a template that holds a dispensed medication", async () => {
+      await seedTemplateWithDispensedMedication(
+        facilityId,
+        templateName,
+        medication,
+        encounterId,
+      );
+      knownIds = await existingRequestIds(patientId, encounterId, medication);
+    });
+
+    await test.step("Apply the template to the questionnaire", async () => {
+      await openMedicationQuestionnaire(
+        page,
+        facilityId,
+        patientId,
+        encounterId,
+      );
+
+      const sheet = await openTemplate(page, templateName);
+      await sheet.getByRole("button", { name: "Apply", exact: true }).click();
+      await expectToast(page, /applied 1 medication/i);
+
+      await page.keyboard.press("Escape");
+      await sheet.waitFor({ state: "hidden" });
+      await submitQuestionnaire(page);
+    });
+
+    await test.step("Verify the new request has no dispense status", async () => {
+      await expectNewRequestWithoutDispenseStatus(
+        patientId,
+        encounterId,
+        medication,
+        knownIds,
+      );
+    });
+  });
+
+  test("does not store the dispense status in a new template", async ({
+    page,
+  }) => {
+    const medication = await findMedicationCode(MEDICATIONS.saveTemplate);
+    const templateName = `PW Saved Medication ${Date.now()}`;
+
+    await test.step("Seed a dispensed prescription", async () => {
+      await seedDispensedMedicationRequest(patientId, encounterId, medication);
+    });
+
+    await test.step("Save the medication into a new template", async () => {
+      await openMedicationQuestionnaire(
+        page,
+        facilityId,
+        patientId,
+        encounterId,
+      );
+      await addFromMedicationHistory(page, medication.display);
+
+      const row = page
+        .locator('[id^="question-"]')
+        .getByRole("button", { name: "Medication actions" })
+        .first();
+      await row.click();
+      await page.getByRole("menuitem", { name: "Add to template" }).click();
+
+      const dialog = page.getByRole("dialog", { name: "Add to template" });
+      await dialog.waitFor({ state: "visible" });
+      await dialog
+        .getByRole("button", { name: /Create New Template/i })
+        .click();
+
+      // The dialog title changes once the create form opens, so the locator
+      // above no longer matches. Target the name field by its stable id.
+      await page.locator("#new-template-name").fill(templateName);
+      await page
+        .getByRole("button", { name: "Create Template", exact: true })
+        .click();
+      await expectToast(page, /created with medication/i);
+    });
+
+    await test.step("Verify the template holds no dispense status", async () => {
+      const templateId = await findTemplateIdByName(facilityId, templateName);
+      expect(templateId, "The template was not created").not.toBeNull();
+
+      const medications = await getTemplateMedications(templateId!);
+      expect(medications.length).toBeGreaterThan(0);
+
+      for (const stored of medications) {
+        expect(
+          stored.dispense_status,
+          "A template must not store the dispense status",
+        ).toBeFalsy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
ENG-953

## Proposed Changes

A new medication request must always start with an empty `dispense_status`. Only the pharmacy sets that field.

The medication request questionnaire copies `dispense_status` when the user adds a medication from an existing record. #16729 fixes this. This pull request adds the Playwright tests for the same bug.

> [!IMPORTANT]
> These tests **fail on `develop`**. They **pass** with the fix in #16729. Merge #16729 first.

### Covered add paths

The questionnaire has 7 ways to add a medication. Only 4 can copy `dispense_status`. Each test covers one path:

| Test | Path | Handler |
| --- | --- | --- |
| does not copy the dispense status of a past prescription | "Medication History" sheet → Past Prescriptions tab | `handleAddHistoricalMedications` |
| does not copy the dispense status of a single template medication | Templates sheet → one medication | `handleAddSingleMedication` |
| does not copy the dispense status when a template is applied | Templates sheet → Apply | `handleApplyTemplate` |
| does not store the dispense status in a new template | Medication actions → Add to template | `buildMedicationForTemplate` |

The other 3 paths build a fresh record, so they cannot copy the field:

- Add Medication → Medication tab (valueset search)
- Add Medication → Product tab (product knowledge)
- Medication History → Medication Statements tab (the code parses a string)

### Test method

1. Seed a dispensed medication request, or a template that holds one, through the API. The user interface cannot set `dispense_status`.
2. Drive the add path through the real user interface.
3. Submit the questionnaire.
4. Read the new records back through the API and check that `dispense_status` is empty.

Each test uses a different medication and compares the record ids before and after the flow. The tests are safe to run in parallel.

### Files

- `tests/facility/patient/encounter/structuredQuestions/medicationRequestApi.ts` — API helpers to seed and read the data.
- `tests/facility/patient/encounter/structuredQuestions/medicationRequestDispenseStatus.spec.ts` — the 4 tests.

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting & Formatting
- [ ] Deploy actions passing

Related to #16729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medication selections added from history or templates no longer retain the original dispense status.
  * Saving medications to a new template prevents dispense-status data from being carried over.

* **Tests**
  * Added automated coverage for medication history, template application, and template creation workflows.
  * Added validation to confirm medication responses are saved without unintended dispense-status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->