### PR TITLE
Fix: Scroll to top issue when opening drawer in iOS

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -3,10 +3,19 @@ import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils";
 
+import { isIOSDevice } from "@/Utils/utils";
+
 function Drawer({
+  repositionInputs = !isIOSDevice,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  );
 }
 
 function DrawerTrigger({


### PR DESCRIPTION
Improves the `Drawer` component by enhancing its handling of input repositioning, especially for iOS devices.

Entire-Checkpoint: cb00f35770e4

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer behavior on iOS devices by automatically adjusting input repositioning.
  * Preserved the ability to customize input repositioning when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->