### PR TITLE
[QA-312] Migrate off waitForTimeout & force:true; enforce as errors 

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -11,9 +11,7 @@ on:
   push:
     branches: [main, develop, production, playwright-actions]
   pull_request:
-    # TEMP(QA-312): "issues/**" added so Playwright runs on the stacked PRs.
-    # Revert to [develop, production] before merging.
-    branches: [develop, production, "issues/**"]
+    branches: [develop, production]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -11,7 +11,9 @@ on:
   push:
     branches: [main, develop, production, playwright-actions]
   pull_request:
-    branches: [develop, production]
+    # TEMP(QA-312): "issues/**" added so Playwright runs on the stacked PRs.
+    # Revert to [develop, production] before merging.
+    branches: [develop, production, "issues/**"]
   workflow_dispatch:
 
 concurrency:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -237,15 +237,40 @@ const config = [
       },
     },
     rules: {
-      ...playwright.configs["flat/recommended"].rules,
-      // Forward gates (no existing usages): promote to error so CI actually
-      // rejects new usages (these are only `warn` in flat/recommended).
-      "playwright/no-wait-for-selector": "error",
+      // Explicit allow-list of the Playwright rules we enforce, all as errors.
+      "playwright/consistent-spacing-between-blocks": "error",
+      "playwright/max-nested-describe": "error",
+      "playwright/missing-playwright-await": "error",
+      "playwright/no-duplicate-hooks": "error",
+      "playwright/no-duplicate-slow": "error",
       "playwright/no-element-handle": "error",
       "playwright/no-eval": "error",
+      "playwright/no-focused-test": "error",
+      "playwright/no-force-option": "error",
+      "playwright/no-nested-step": "error",
+      "playwright/no-networkidle": "error",
       "playwright/no-page-pause": "error",
-      // Forward gate (no existing usages): disallow test-id selectors in favour
-      // of role/label/text locators.
+      "playwright/no-standalone-expect": "error",
+      "playwright/no-unnecessary-assertions": "error",
+      "playwright/no-unsafe-references": "error",
+      "playwright/no-unused-locators": "error",
+      "playwright/no-useless-await": "error",
+      "playwright/no-useless-not": "error",
+      "playwright/no-wait-for-navigation": "error",
+      "playwright/no-wait-for-selector": "error",
+      "playwright/no-wait-for-timeout": "error",
+      "playwright/prefer-hooks-in-order": "error",
+      "playwright/prefer-hooks-on-top": "error",
+      "playwright/prefer-locator": "error",
+      "playwright/prefer-to-have-count": "error",
+      "playwright/prefer-to-have-length": "error",
+      "playwright/prefer-web-first-assertions": "error",
+      "playwright/valid-describe-callback": "error",
+      "playwright/valid-expect": "error",
+      "playwright/valid-expect-in-promise": "error",
+      "playwright/valid-test-tags": "error",
+      "playwright/valid-title": "error",
+      // Disallow test-id selectors in favour of role/label/text locators.
       "playwright/no-restricted-locators": [
         "error",
         [
@@ -256,24 +281,6 @@ const config = [
           },
         ],
       ],
-      // Anti-flakiness rules with existing usages: baselined as warn here,
-      // migrated then flipped to error in follow-up PRs (QA-39 stack).
-      "playwright/no-networkidle": "warn",
-      "playwright/no-nth-methods": "warn",
-      "playwright/no-wait-for-timeout": "error",
-      "playwright/no-force-option": "error",
-      // General correctness/style rules with existing violations: baselined as
-      // warn so CI stays green; clean up incrementally.
-      "playwright/expect-expect": "warn",
-      "playwright/no-useless-not": "warn",
-      "playwright/no-conditional-in-test": "warn",
-      "playwright/no-conditional-expect": "warn",
-      "playwright/prefer-to-have-count": "warn",
-      "playwright/no-useless-await": "warn",
-      "playwright/no-unused-locators": "warn",
-      "playwright/prefer-web-first-assertions": "warn",
-      "playwright/no-skipped-test": "warn",
-      "playwright/consistent-spacing-between-blocks": "warn",
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -260,8 +260,8 @@ const config = [
       // migrated then flipped to error in follow-up PRs (QA-39 stack).
       "playwright/no-networkidle": "warn",
       "playwright/no-nth-methods": "warn",
-      "playwright/no-wait-for-timeout": "warn",
-      "playwright/no-force-option": "warn",
+      "playwright/no-wait-for-timeout": "error",
+      "playwright/no-force-option": "error",
       // General correctness/style rules with existing violations: baselined as
       // warn so CI stays green; clean up incrementally.
       "playwright/expect-expect": "warn",

--- a/tests/PLAYWRIGHT_GUIDE.md
+++ b/tests/PLAYWRIGHT_GUIDE.md
@@ -476,7 +476,7 @@ Name files as: `featureName.spec.ts` or `featureAction.spec.ts` (e.g., `location
 4. **Not awaiting helpers** — All helper functions are async, must use `await`
 5. **Forgetting `test.use({ storageState })`** — Tests will fail with auth errors
 6. **Not using `test.step()`** — Makes test reports hard to read
-7. **Using custom timeouts / manual waits** — Avoid hardcoded `{ timeout: 15000 }` (Playwright guidance; not lint-enforced), and avoid `page.waitForTimeout()` and `page.waitForLoadState("networkidle")` (flagged by the Playwright ESLint rules — currently warnings, being migrated toward errors). Instead use web-first assertions like `expect(locator).toBeVisible()` to wait for page readiness. Rely on global timeouts from `playwright.config.ts`.
+7. **Using custom timeouts / manual waits** — Avoid hardcoded `{ timeout: 15000 }` (Playwright guidance; not lint-enforced), `page.waitForTimeout()` (enforced as an error), and `page.waitForLoadState("networkidle")` (currently a warning, being migrated to an error). Instead use web-first assertions like `expect(locator).toBeVisible()` to wait for page readiness. Rely on global timeouts from `playwright.config.ts`.
 8. **Non-camelCase directory names** — Use camelCase for test directories (e.g., `enableWhen/`, `patientDetails/`), not kebab-case or snake_case.
 
 ## Available Constants

--- a/tests/PLAYWRIGHT_GUIDE.md
+++ b/tests/PLAYWRIGHT_GUIDE.md
@@ -476,7 +476,7 @@ Name files as: `featureName.spec.ts` or `featureAction.spec.ts` (e.g., `location
 4. **Not awaiting helpers** — All helper functions are async, must use `await`
 5. **Forgetting `test.use({ storageState })`** — Tests will fail with auth errors
 6. **Not using `test.step()`** — Makes test reports hard to read
-7. **Using custom timeouts / manual waits** — Avoid hardcoded `{ timeout: 15000 }` (Playwright guidance; not lint-enforced), `page.waitForTimeout()` (enforced as an error), and `page.waitForLoadState("networkidle")` (currently a warning, being migrated to an error). Instead use web-first assertions like `expect(locator).toBeVisible()` to wait for page readiness. Rely on global timeouts from `playwright.config.ts`.
+7. **Using custom timeouts / manual waits** — Avoid hardcoded `{ timeout: 15000 }` (Playwright guidance; not lint-enforced), `page.waitForTimeout()`, and `page.waitForLoadState("networkidle")` (both enforced as errors). Instead use web-first assertions like `expect(locator).toBeVisible()` to wait for page readiness. Rely on global timeouts from `playwright.config.ts`.
 8. **Non-camelCase directory names** — Use camelCase for test directories (e.g., `enableWhen/`, `patientDetails/`), not kebab-case or snake_case.
 
 ## Available Constants

--- a/tests/admin/organizations/governanceSuppliersRolesVerify.spec.ts
+++ b/tests/admin/organizations/governanceSuppliersRolesVerify.spec.ts
@@ -45,9 +45,7 @@ function adminOrgDetailUrlRegex(type: OrganizationType) {
 }
 
 async function gotoOrgTypeList(page: Page, type: OrganizationType) {
-  await page.goto(`/admin/organizations/${type}`, {
-    waitUntil: "networkidle",
-  });
+  await page.goto(`/admin/organizations/${type}`);
   await expect(searchInput(page, type)).toBeVisible();
 }
 

--- a/tests/admin/valueset/valuesetCreate.spec.ts
+++ b/tests/admin/valueset/valuesetCreate.spec.ts
@@ -118,13 +118,8 @@ test.describe("ValueSet Create", () => {
     await page.getByRole("textbox", { name: "Name *" }).fill(name);
 
     const slugField = page.getByRole("textbox", { name: "Slug *" });
-    const slugValue = await slugField.inputValue();
-    expect(slugValue).toBeTruthy();
-    expect(slugValue.length).toBeGreaterThan(0);
-
     const expectedSlugValue = expectedSlug(name);
-
-    expect(slugValue).toContain(expectedSlugValue);
+    await expect(slugField).toHaveValue(new RegExp(expectedSlugValue));
   });
 
   test("verify excluded rules are not present in preview", async ({ page }) => {
@@ -166,7 +161,7 @@ test.describe("ValueSet Create", () => {
 
     await previewDialog.getByRole("combobox").click();
 
-    await expect(page.getByText(codeName)).not.toBeVisible();
+    await expect(page.getByText(codeName)).toBeHidden();
 
     // Close the preview valueset selector first and then the dialog
     await closeAnyOpenPopovers(page);

--- a/tests/auth/passwordResetOtp.spec.ts
+++ b/tests/auth/passwordResetOtp.spec.ts
@@ -99,9 +99,7 @@ test.describe("OTP password reset", () => {
     await page.getByRole("button", { name: /^reset password$/i }).click();
 
     await expectToast(page, /invalid otp/i);
-    await expect(
-      page.getByRole("textbox", { name: /username/i }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("textbox", { name: /username/i })).toBeHidden();
 
     await page.close();
   });

--- a/tests/billing/paymentSheetUrl.spec.ts
+++ b/tests/billing/paymentSheetUrl.spec.ts
@@ -53,7 +53,7 @@ test.describe("Payment Sheet URL Persistence", () => {
       // Close via the sheet's close button
       await paymentSheet.getByRole("button", { name: /close/i }).click();
 
-      await expect(paymentSheet).not.toBeVisible();
+      await expect(paymentSheet).toBeHidden();
       await expect(page).not.toHaveURL(/\/payment\//);
     });
 

--- a/tests/billing/updateAccountPermission.spec.ts
+++ b/tests/billing/updateAccountPermission.spec.ts
@@ -77,11 +77,11 @@ test.describe("Account Management Permissions", () => {
       const accountEditButton = page
         .getByRole("button", { name: /edit/i })
         .nth(0);
-      await expect(accountEditButton).not.toBeVisible();
+      await expect(accountEditButton).toBeHidden();
 
       // Verify Rebalance button is not visible
       const rebalanceButton = page.getByRole("button", { name: /rebalance/i });
-      await expect(rebalanceButton).not.toBeVisible();
+      await expect(rebalanceButton).toBeHidden();
     });
   });
 });

--- a/tests/facility/billing/accountTransfer.spec.ts
+++ b/tests/facility/billing/accountTransfer.spec.ts
@@ -291,7 +291,7 @@ test.describe("Account Transfer Payment", () => {
     for (const account of nonActiveAccounts) {
       await page.goto(`/facility/${facilityId}/billing/account/${account.id}`);
       await expect(page.getByText(account.name)).toBeVisible();
-      await expect(page.locator(moreOptionsSelector)).not.toBeVisible();
+      await expect(page.locator(moreOptionsSelector)).toBeHidden();
     }
   });
 
@@ -310,7 +310,7 @@ test.describe("Account Transfer Payment", () => {
 
     // Active target visible, non-active targets not visible
     await expect(page.getByText(targetAccount.name)).toBeVisible();
-    await expect(page.getByText(nonActiveAccounts[0].name)).not.toBeVisible();
+    await expect(page.getByText(nonActiveAccounts[0].name)).toBeHidden();
 
     await page.getByText(targetAccount.name).click();
 

--- a/tests/facility/billing/paymentReconciliation.spec.ts
+++ b/tests/facility/billing/paymentReconciliation.spec.ts
@@ -65,7 +65,7 @@ test.describe("Payment Reconciliation", () => {
       // For non-cash payments, Amount Received field should not be visible
       await expect(
         page.getByRole("textbox", { name: "Amount Received" }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     }
 
     // Fill Payment Date

--- a/tests/facility/components/backButton.spec.ts
+++ b/tests/facility/components/backButton.spec.ts
@@ -28,7 +28,7 @@ test.describe("Back button should not appear when page is opened in a new tab wi
 
     // Verify back button is NOT visible (no history)
     const backButton = newPage.getByRole("button", { name: /back/i });
-    await expect(backButton).not.toBeVisible();
+    await expect(backButton).toBeHidden();
   });
 
   test("Back button in Account Show", async ({ page, context }) => {
@@ -51,6 +51,6 @@ test.describe("Back button should not appear when page is opened in a new tab wi
 
     // Verify back button is NOT visible (no history)
     const backButton = newPage.getByRole("button", { name: /back/i });
-    await expect(backButton).not.toBeVisible();
+    await expect(backButton).toBeHidden();
   });
 });

--- a/tests/facility/patient/encounter/careTeam/linkCareTeam.spec.ts
+++ b/tests/facility/patient/encounter/careTeam/linkCareTeam.spec.ts
@@ -209,7 +209,7 @@ test.describe("Manage care team for an encounter", () => {
       await page.getByRole("button", { name: "Close" }).click();
       await expect(
         page.getByRole("dialog", { name: "Manage Care Team" }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
 
     await test.step("Verify member was not added", async () => {
@@ -218,7 +218,7 @@ test.describe("Manage care team for an encounter", () => {
       const dialog = page.getByRole("dialog", { name: "Manage Care Team" });
       await expect(
         dialog.getByText(selectedUsername, { exact: true }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
   });
 

--- a/tests/facility/patient/encounter/consent/consentCreation.spec.ts
+++ b/tests/facility/patient/encounter/consent/consentCreation.spec.ts
@@ -202,7 +202,7 @@ test.describe("Consent Creation", () => {
     await page.getByRole("button", { name: "See Details" }).first().click();
 
     // The Note heading should not be visible (it only shows when note exists)
-    await expect(page.getByRole("heading", { name: "Note" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Note" })).toBeHidden();
   });
 
   test("create consent with custom Valid From and Valid Until → dates on card and detail", async ({
@@ -313,10 +313,10 @@ test.describe("Consent Editing", () => {
     // (Scoped to the sheet: the detail page behind it still shows these.)
     await expect(
       editSheet.getByText("Consent Given On", { exact: true }),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       editSheet.getByText("Consent Decision", { exact: true }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 
   test("edit note → save → updated note on detail page", async ({ page }) => {
@@ -344,7 +344,7 @@ test.describe("Consent Editing", () => {
     // Sheet closes after save; verify updated note on the detail page
     await expect(page.getByRole("dialog")).toBeHidden();
     await expect(page.getByText(updatedNote)).toBeVisible();
-    await expect(page.getByText(originalNote)).not.toBeVisible();
+    await expect(page.getByText(originalNote)).toBeHidden();
   });
 
   // One test per status (mirrors the split category tests): each creates its

--- a/tests/facility/patient/encounter/encounter.spec.ts
+++ b/tests/facility/patient/encounter/encounter.spec.ts
@@ -84,7 +84,7 @@ test.describe("Create an Encounter", () => {
       .locator('a[href^="tel:"]')
       .first()
       .textContent();
-    const dobLabel = await page.getByText("Date of Birth");
+    const dobLabel = page.getByText("Date of Birth");
     const dobText = await dobLabel
       .locator("xpath=following-sibling::*[1]")
       .textContent();

--- a/tests/facility/patient/encounter/encounterFutureDateRestriction.spec.ts
+++ b/tests/facility/patient/encounter/encounterFutureDateRestriction.spec.ts
@@ -116,7 +116,7 @@ test.describe("Encounter Future Date Restriction", () => {
       .click();
 
     // Wait for encounter to be created and dialog to close
-    await expect(encounterDialog).not.toBeVisible();
+    await expect(encounterDialog).toBeHidden();
 
     // Verify Encounter Actions button is visible after encounter creation
     await expect(

--- a/tests/facility/patient/encounter/notes/encounterNotes.spec.ts
+++ b/tests/facility/patient/encounter/notes/encounterNotes.spec.ts
@@ -79,8 +79,8 @@ test.describe("Encounter Notes - Isolation from Patient Notes", () => {
     // Verify encounter note does NOT appear in patient notes
     await expect(
       page.getByRole("button").filter({ hasText: encounterNoteTitle }),
-    ).not.toBeVisible();
-    await expect(page.getByText(encounterNoteMessage)).not.toBeVisible();
+    ).toBeHidden();
+    await expect(page.getByText(encounterNoteMessage)).toBeHidden();
   });
 });
 
@@ -248,13 +248,13 @@ test.describe("Encounter Notes - Thread Messaging (Multi-user & Single-user)", (
     await expect(page.getByText(userAMessage3)).toBeVisible();
 
     // Verify exactly 3 messages are present by counting occurrences
-    const message1Count = await page.getByText(userAMessage1).count();
-    const message2Count = await page.getByText(userAMessage2).count();
-    const message3Count = await page.getByText(userAMessage3).count();
+    const message1Count = page.getByText(userAMessage1);
+    const message2Count = page.getByText(userAMessage2);
+    const message3Count = page.getByText(userAMessage3);
 
-    expect(message1Count).toBe(1);
-    expect(message2Count).toBe(1);
-    expect(message3Count).toBe(1);
+    await expect(message1Count).toHaveCount(1);
+    await expect(message2Count).toHaveCount(1);
+    await expect(message3Count).toHaveCount(1);
   });
 });
 
@@ -312,8 +312,8 @@ test.describe("Encounter Notes - Thread Creation", () => {
     // Verify no duplication - each thread should appear exactly once
     for (const title of threadTitles) {
       const threadButtons = page.getByRole("button").filter({ hasText: title });
-      const count = await threadButtons.count();
-      expect(count).toBe(1);
+      const count = threadButtons;
+      await expect(count).toHaveCount(1);
     }
   });
 });
@@ -361,7 +361,7 @@ test.describe("Encounter Notes - Thread Visibility & Switching", () => {
       await threadTitleInput.fill(thread.title);
 
       await page.getByRole("button", { name: /Create/i }).click();
-      await expect(page.getByRole("dialog")).not.toBeVisible();
+      await expect(page.getByRole("dialog")).toBeHidden();
 
       // Fill message input and send message
       await messageInput.fill(thread.message);
@@ -380,26 +380,26 @@ test.describe("Encounter Notes - Thread Visibility & Switching", () => {
     // Click Thread 1 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread2Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
 
     // Click Thread 2 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread2Title }).click();
     await expect(page.getByText(thread2Message)).toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread1Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
 
     // Click Thread 3 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread3Title }).click();
     await expect(page.getByText(thread3Message)).toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
+    await expect(page.getByText(thread1Message)).toBeHidden();
+    await expect(page.getByText(thread2Message)).toBeHidden();
 
     // Click back to Thread 1 to verify persistence of messages
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread2Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
   });
 
   test("should allow sending messages in different threads and confirm messages stay in respective threads", async ({
@@ -432,15 +432,15 @@ test.describe("Encounter Notes - Thread Visibility & Switching", () => {
     // Verify Thread 2 messages are visible and Thread 1 messages are not visible
     await expect(page.getByText(newThread2Message)).toBeVisible();
     await expect(page.getByText(thread2Message)).toBeVisible();
-    await expect(page.getByText(newThread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
+    await expect(page.getByText(newThread1Message)).toBeHidden();
+    await expect(page.getByText(thread1Message)).toBeHidden();
 
     // Click back to Thread 1 to verify isolation
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     // Verify Thread 1 messages are visible and Thread 2 messages are not visible
     await expect(page.getByText(newThread1Message)).toBeVisible();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(newThread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
+    await expect(page.getByText(newThread2Message)).toBeHidden();
+    await expect(page.getByText(thread2Message)).toBeHidden();
   });
 });

--- a/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
+++ b/tests/facility/patient/encounter/serviceRequests/ServiceRequestCreate.spec.ts
@@ -141,12 +141,10 @@ test.describe("Patient Service Request Tab", () => {
       .first()
       .getByRole("button", { name: "See Details" })
       .click();
-    await page.waitForLoadState("networkidle");
     await page.getByRole("button", { name: "Collect Specimen" }).click();
     await expect(
       page.getByText("QR code generated successfully"),
     ).toBeVisible();
-    await page.waitForLoadState("networkidle");
     await expect(page.getByText("Sample Identification")).toBeVisible();
     await page.getByPlaceholder("Value", { exact: true }).fill("2");
     await expect(page.getByPlaceholder("Value", { exact: true })).toHaveValue(
@@ -207,12 +205,10 @@ test("should fill result value, capture a photo and save results", async ({
     .first()
     .getByRole("button", { name: "See Details" })
     .click();
-  await page.waitForLoadState("networkidle");
 
   // Collect the specimen so a diagnostic report can be created
   await page.getByRole("button", { name: "Collect Specimen" }).click();
   await expect(page.getByText("QR code generated successfully")).toBeVisible();
-  await page.waitForLoadState("networkidle");
   await expect(page.getByText("Sample Identification")).toBeVisible();
   await page.getByPlaceholder("Value", { exact: true }).fill("2");
   await page

--- a/tests/facility/patient/encounter/structuredQuestions/diagnosis.spec.ts
+++ b/tests/facility/patient/encounter/structuredQuestions/diagnosis.spec.ts
@@ -93,8 +93,6 @@ test.describe("Diagnosis", () => {
   test("should add diagnosis with all fields and verify it appears in diagnosis history", async ({
     page,
   }) => {
-    await page.waitForLoadState("networkidle");
-
     await addDiagnosis(page);
 
     const diagnosisRow = page.getByRole("row", { name: diagnosisName });
@@ -134,8 +132,6 @@ test.describe("Diagnosis", () => {
   });
 
   test("verify duplicate diagnosis cannot be added", async ({ page }) => {
-    await page.waitForLoadState("networkidle");
-
     await page
       .getByRole("combobox")
       .filter({ hasText: /Add (another )?Diagnosis/i })
@@ -153,7 +149,6 @@ test.describe("Diagnosis", () => {
     ).toBeVisible();
 
     await page.goto(questionnaireUrl);
-    await page.waitForLoadState("networkidle");
 
     const duplicateDiagnosisName = faker.helpers.arrayElement([
       ...usedDiagnoses,

--- a/tests/facility/patient/encounter/structuredQuestions/medicationRequest.spec.ts
+++ b/tests/facility/patient/encounter/structuredQuestions/medicationRequest.spec.ts
@@ -136,8 +136,6 @@ test.describe("Medication Request Questionnaire", () => {
   test("should add medication filling all fields and verify it appears in medication history", async ({
     page,
   }) => {
-    await page.waitForLoadState("networkidle");
-
     await page
       .getByRole("combobox")
       .filter({ hasText: /Add Medication/i })
@@ -246,8 +244,6 @@ test.describe("Medication Request Questionnaire", () => {
   test("add medication with only required fields and verify it appears in medication history", async ({
     page,
   }) => {
-    await page.waitForLoadState("networkidle");
-
     await page
       .getByRole("combobox")
       .filter({ hasText: /Add Medication/i })
@@ -305,8 +301,6 @@ test.describe("Medication Request Questionnaire", () => {
   test("should show validation errors when required fields are missing", async ({
     page,
   }) => {
-    await page.waitForLoadState("networkidle");
-
     await page
       .getByRole("combobox")
       .filter({ hasText: /Add Medication/i })

--- a/tests/facility/patient/encounter/structuredQuestions/symptom.spec.ts
+++ b/tests/facility/patient/encounter/structuredQuestions/symptom.spec.ts
@@ -72,8 +72,6 @@ test.describe("Symptom Questionnaire", () => {
   });
 
   test("should add symptom with all fields", async ({ page }) => {
-    await page.waitForLoadState("networkidle");
-
     await page
       .getByRole("combobox")
       .filter({ hasText: /Add (another )?Symptom/i })
@@ -132,7 +130,6 @@ test.describe("Symptom Questionnaire", () => {
     ).toBeVisible();
 
     await page.goto(questionnaireUrl);
-    await page.waitForLoadState("networkidle");
 
     const duplicateSymptomName = faker.helpers.arrayElement([...usedSymptoms]);
 

--- a/tests/facility/patient/patientDetails/notes/patientNotes.spec.ts
+++ b/tests/facility/patient/patientDetails/notes/patientNotes.spec.ts
@@ -89,8 +89,8 @@ test.describe("Patient Notes - Isolation from Encounter Notes", () => {
     // Verify patient note does NOT appear in encounter notes
     await expect(
       page.getByRole("button").filter({ hasText: patientNoteTitle }),
-    ).not.toBeVisible();
-    await expect(page.getByText(patientNoteMessage)).not.toBeVisible();
+    ).toBeHidden();
+    await expect(page.getByText(patientNoteMessage)).toBeHidden();
   });
 });
 
@@ -212,13 +212,13 @@ test.describe("Patient Notes - Thread Messaging (Multi-user & Single-user)", () 
     await expect(page.getByText(userAMessage3)).toBeVisible();
 
     // Count each message individually to verify exactly one of each appears
-    const message1Count = await page.getByText(userAMessage1).count();
-    const message2Count = await page.getByText(userAMessage2).count();
-    const message3Count = await page.getByText(userAMessage3).count();
+    const message1Count = page.getByText(userAMessage1);
+    const message2Count = page.getByText(userAMessage2);
+    const message3Count = page.getByText(userAMessage3);
 
-    expect(message1Count).toBe(1);
-    expect(message2Count).toBe(1);
-    expect(message3Count).toBe(1);
+    await expect(message1Count).toHaveCount(1);
+    await expect(message2Count).toHaveCount(1);
+    await expect(message3Count).toHaveCount(1);
   });
 });
 
@@ -281,8 +281,8 @@ test.describe("Patient Notes - Thread Creation", () => {
     // Verify no duplication - each thread should appear exactly once
     for (const title of threadTitles) {
       const threadButtons = page.getByRole("button").filter({ hasText: title });
-      const count = await threadButtons.count();
-      expect(count).toBe(1);
+      const count = threadButtons;
+      await expect(count).toHaveCount(1);
     }
   });
 });
@@ -336,7 +336,7 @@ test.describe("Patient Notes - Thread Visibility & Switching", () => {
       await threadTitleInput.fill(thread.title);
 
       await page.getByRole("button", { name: /Create/i }).click();
-      await expect(page.getByRole("dialog")).not.toBeVisible();
+      await expect(page.getByRole("dialog")).toBeHidden();
 
       await messageInput.fill(thread.message);
 
@@ -352,26 +352,26 @@ test.describe("Patient Notes - Thread Visibility & Switching", () => {
     // Click Thread 1 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread2Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
 
     // Click Thread 2 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread2Title }).click();
     await expect(page.getByText(thread2Message)).toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread1Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
 
     // Click Thread 3 and verify only its message is visible
     await page.getByRole("button").filter({ hasText: thread3Title }).click();
     await expect(page.getByText(thread3Message)).toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
+    await expect(page.getByText(thread1Message)).toBeHidden();
+    await expect(page.getByText(thread2Message)).toBeHidden();
 
     // Click back to Thread 1 to verify persistence of messages
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread3Message)).not.toBeVisible();
+    await expect(page.getByText(thread2Message)).toBeHidden();
+    await expect(page.getByText(thread3Message)).toBeHidden();
   });
 
   test("should allow sending messages in different threads and confirm messages stay in respective threads", async ({
@@ -402,15 +402,15 @@ test.describe("Patient Notes - Thread Visibility & Switching", () => {
     // Verify Thread 2 messages are visible and Thread 1 messages are not visible
     await expect(page.getByText(newThread2Message)).toBeVisible();
     await expect(page.getByText(thread2Message)).toBeVisible();
-    await expect(page.getByText(newThread1Message)).not.toBeVisible();
-    await expect(page.getByText(thread1Message)).not.toBeVisible();
+    await expect(page.getByText(newThread1Message)).toBeHidden();
+    await expect(page.getByText(thread1Message)).toBeHidden();
 
     // Click back to Thread 1 to verify isolation
     await page.getByRole("button").filter({ hasText: thread1Title }).click();
     // Verify Thread 1 messages are visible and Thread 2 messages are not visible
     await expect(page.getByText(newThread1Message)).toBeVisible();
     await expect(page.getByText(thread1Message)).toBeVisible();
-    await expect(page.getByText(newThread2Message)).not.toBeVisible();
-    await expect(page.getByText(thread2Message)).not.toBeVisible();
+    await expect(page.getByText(newThread2Message)).toBeHidden();
+    await expect(page.getByText(thread2Message)).toBeHidden();
   });
 });

--- a/tests/facility/patient/patientHome/patientinfoHoverCard.spec.ts
+++ b/tests/facility/patient/patientHome/patientinfoHoverCard.spec.ts
@@ -21,9 +21,7 @@ test.describe("PatientInfoHoverCard Conditional Rendering", () => {
       .click();
 
     // Verify that Patient Home button is NOT visible (because its home page)
-    await expect(
-      page.getByRole("link", { name: "Patient Home" }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("link", { name: "Patient Home" })).toBeHidden();
 
     // But View Profile button should still be visible
     await expect(page.getByRole("link", { name: "View Profile" })).toBeVisible({

--- a/tests/facility/patient/patientRegistration.spec.ts
+++ b/tests/facility/patient/patientRegistration.spec.ts
@@ -286,7 +286,7 @@ test.describe("Patient Registration", () => {
         page
           .locator("li[data-sonner-toast]")
           .getByText(/patient registered successfully/i),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
   });
 
@@ -407,6 +407,6 @@ test.describe("DOB timezone validation", () => {
       page
         .locator("li[data-sonner-toast]")
         .getByText(/patient registered successfully/i),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 });

--- a/tests/facility/queues/queueCreation.spec.ts
+++ b/tests/facility/queues/queueCreation.spec.ts
@@ -20,6 +20,7 @@ async function openQueueEditMenu(page: Page, queueName: string) {
 
 test.describe("Queue Creation & Editing", () => {
   let facilityId: string;
+
   test.beforeEach(async ({ page }) => {
     facilityId = getFacilityId();
     await page.goto(`/facility/${facilityId}/queues`);

--- a/tests/facility/settings/activityDefinition/activityDefinitionList.spec.ts
+++ b/tests/facility/settings/activityDefinition/activityDefinitionList.spec.ts
@@ -296,7 +296,7 @@ test.describe("Activity Definition List", () => {
 
     await expect(
       page.locator('[data-slot="table-row"]', { hasText: testAD.title }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await searchInput.clear();
 

--- a/tests/facility/settings/activityDefinition/categoryList.spec.ts
+++ b/tests/facility/settings/activityDefinition/categoryList.spec.ts
@@ -80,7 +80,7 @@ test.describe("Activity Definition Resource Category List", () => {
 
     await expect(
       page.getByRole("heading", { name: /create category/i }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await expect(page).toHaveURL(
       `/facility/${facilityId}/settings/activity_definitions/categories/f-${facilityId}-${testData.slug}?status=active`,
@@ -118,7 +118,7 @@ test.describe("Activity Definition Resource Category List", () => {
 
     await expect(
       page.getByRole("heading", { name: /create category/i }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await expect(page).toHaveURL(
       `/facility/${facilityId}/settings/activity_definitions/categories/f-${facilityId}-${testData.slug}?status=active`,
@@ -142,7 +142,7 @@ test.describe("Activity Definition Resource Category List", () => {
 
     await expect(
       page.getByRole("heading", { name: /create category/i }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 
   test("should edit category", async ({ page }) => {
@@ -175,10 +175,10 @@ test.describe("Activity Definition Resource Category List", () => {
 
     await expect(
       page.getByRole("heading", { name: /edit category/i }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await expect(page.getByText(updatedData.title)).toBeVisible();
-    await expect(page.getByText(testData.title)).not.toBeVisible();
+    await expect(page.getByText(testData.title)).toBeHidden();
   });
 
   test("should navigate to activity definitions list when clicking on category card", async ({
@@ -223,7 +223,7 @@ test.describe("Activity Definition Resource Category List", () => {
     await searchInput.clear();
     await searchInput.fill(faker.string.uuid());
 
-    await expect(page.getByText(testData.title)).not.toBeVisible();
+    await expect(page.getByText(testData.title)).toBeHidden();
 
     await searchInput.clear();
 

--- a/tests/facility/settings/billing/discount/discountCodeCreate.spec.ts
+++ b/tests/facility/settings/billing/discount/discountCodeCreate.spec.ts
@@ -13,7 +13,6 @@ test.describe("Discount Code Settings", () => {
     await page.goto(
       `/facility/${facilityId}/settings/billing/discount_configuration`,
     );
-    await page.waitForLoadState("networkidle");
 
     // Enter edit mode
     const editButton = page.getByRole("button", { name: /edit/i });
@@ -38,7 +37,6 @@ test.describe("Discount Code Settings", () => {
     const saveButton = page.getByRole("button", { name: /save/i });
     await expect(saveButton).toBeVisible();
     await saveButton.click();
-    await page.waitForLoadState("networkidle");
 
     await expect(
       page.getByText(/discount configuration saved successfully/i),
@@ -52,7 +50,6 @@ test.describe("Discount Code Settings", () => {
     discountName = faker.commerce.productName();
     discountCode = discountName.replace(/\s+/g, "-").slice(0, 20).toLowerCase();
     await page.goto(`/facility/${facilityId}/settings/billing/discount_codes`);
-    await page.waitForLoadState("networkidle");
 
     await expect(
       page.getByRole("button", { name: /create discount code/i }),

--- a/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsCreate.spec.ts
+++ b/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsCreate.spec.ts
@@ -160,7 +160,6 @@ test.describe("Charge Item Definition Creation", () => {
     if (await switchElement.isChecked()) {
       await switchElement.click();
     }
-    await page.waitForLoadState("networkidle");
     await page.getByRole("button", { name: "Add Condition" }).click();
     // To do: make this metric agnostic/otherwise might have to adjust everytime we add a new metric
     await page

--- a/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsDelete.spec.ts
+++ b/tests/facility/settings/chargeItemDefinition/chargeItemDefinitionsDelete.spec.ts
@@ -55,6 +55,6 @@ test.describe("Charge Item Definition Delete operations", () => {
     ).toBeVisible();
 
     await page.getByRole("textbox", { name: /search/i }).fill(title);
-    await expect(page.getByRole("table").getByText(title)).not.toBeVisible();
+    await expect(page.getByRole("table").getByText(title)).toBeHidden();
   });
 });

--- a/tests/facility/settings/departments/departmentCreate.spec.ts
+++ b/tests/facility/settings/departments/departmentCreate.spec.ts
@@ -181,7 +181,7 @@ test.describe("Department/Team Creation", () => {
 
     await expect(
       page.getByRole("row").filter({ hasText: departmentName }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 
   test("Verify cancel button discards department creation", async ({
@@ -202,6 +202,6 @@ test.describe("Department/Team Creation", () => {
 
     await expect(
       page.getByRole("row").filter({ hasText: departmentName }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 });

--- a/tests/facility/settings/departments/preventRootSubDepartment.spec.ts
+++ b/tests/facility/settings/departments/preventRootSubDepartment.spec.ts
@@ -28,7 +28,6 @@ test.describe("Prevent Creating Sub-Department/Team Under Administration", () =>
   }) => {
     // Navigate to Administration department
     await openDepartment(page, "Administration");
-    await page.waitForLoadState("networkidle");
 
     // Click Add Department/Team button
     await page.getByRole("button", { name: "Add Department/Team" }).click();
@@ -55,7 +54,6 @@ test.describe("Prevent Creating Sub-Department/Team Under Administration", () =>
   }) => {
     // Navigate to Administration department
     await openDepartment(page, "Administration");
-    await page.waitForLoadState("networkidle");
 
     // Click Add Department/Team button
     await page.getByRole("button", { name: "Add Department/Team" }).click();

--- a/tests/facility/settings/devices/deviceDelete.spec.ts
+++ b/tests/facility/settings/devices/deviceDelete.spec.ts
@@ -51,9 +51,7 @@ test.describe("Facility Device Delete", () => {
       .fill(deviceName);
 
     // Verify device is not found in the list
-    await expect(
-      page.getByRole("link", { name: deviceName }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("link", { name: deviceName })).toBeHidden();
 
     // Verify "No devices found" message or empty state
     await expect(

--- a/tests/facility/settings/devices/deviceEdit.spec.ts
+++ b/tests/facility/settings/devices/deviceEdit.spec.ts
@@ -237,7 +237,7 @@ test.describe("Facility Device Edit", () => {
     if (originalDeviceName !== newDeviceName) {
       await expect(
         page.getByRole("heading", { name: newDeviceName }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     }
   });
 });

--- a/tests/facility/settings/devices/deviceLocationAssociation.spec.ts
+++ b/tests/facility/settings/devices/deviceLocationAssociation.spec.ts
@@ -86,7 +86,7 @@ test.describe("Device Location Association", () => {
     ).toBeVisible();
 
     // Location should now be displayed
-    await expect(page.getByText("No location associated")).not.toBeVisible();
+    await expect(page.getByText("No location associated")).toBeHidden();
   });
 
   test("should display current location and allow disassociation", async ({

--- a/tests/facility/settings/devices/deviceOrganizationAssociation.spec.ts
+++ b/tests/facility/settings/devices/deviceOrganizationAssociation.spec.ts
@@ -103,9 +103,7 @@ test.describe("Device Organization Association", () => {
     await expect(
       managingOrgSection.getByRole("button", { name: "Change" }),
     ).toBeVisible();
-    await expect(
-      page.getByText("No organization associated"),
-    ).not.toBeVisible();
+    await expect(page.getByText("No organization associated")).toBeHidden();
   });
 
   test("should allow changing organization associated with device", async ({
@@ -130,7 +128,7 @@ test.describe("Device Organization Association", () => {
     await submitAddOrganization(manageOrgSheet);
 
     // After first add, slideover should auto-close.
-    await expect(manageOrgSheet).not.toBeVisible();
+    await expect(manageOrgSheet).toBeHidden();
 
     // Verify default organization is visible beside the Change button.
     await expect(
@@ -185,7 +183,7 @@ test.describe("Device Organization Association", () => {
     }
 
     await submitAddOrganization(manageOrgSheet);
-    await expect(manageOrgSheet).not.toBeVisible();
+    await expect(manageOrgSheet).toBeHidden();
 
     // Final state should show the newly selected organization beside Change.
     await expect(
@@ -194,8 +192,6 @@ test.describe("Device Organization Association", () => {
     await expect(
       managingOrgSection.getByText(selectedDepartment, { exact: false }),
     ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      managingOrgSection.getByText("Administration"),
-    ).not.toBeVisible();
+    await expect(managingOrgSection.getByText("Administration")).toBeHidden();
   });
 });

--- a/tests/facility/settings/observationDefinition/observationDefinition.spec.ts
+++ b/tests/facility/settings/observationDefinition/observationDefinition.spec.ts
@@ -75,7 +75,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
     gender: string = "Male",
   ) {
     await test.step("Add gender condition", async () => {
-      await page.getByTitle(`Condition ${conditionNumber}`);
       const conditionSelector = page.getByTitle(`Condition ${conditionNumber}`);
       const conditionSelectorExists = await conditionSelector.isVisible();
       if (!conditionSelectorExists) {
@@ -113,9 +112,7 @@ test.describe("Observation Definition Form with Interpretation", () => {
     ageType: string = "years",
   ) {
     await test.step("Add age condition", async () => {
-      const conditionSelector = await page.getByTitle(
-        `Condition ${conditionNumber}`,
-      );
+      const conditionSelector = page.getByTitle(`Condition ${conditionNumber}`);
 
       // Select metric type
       await conditionSelector.getByRole("combobox").nth(0).click();
@@ -238,7 +235,7 @@ test.describe("Observation Definition Form with Interpretation", () => {
     // Verify sheet closes
     await expect(
       page.getByRole("heading", { name: "Add/Edit Interpretation" }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     // Verify interpretation appears in list
     await expect(
@@ -271,7 +268,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
 
     // Fill component code
     await page.getByRole("combobox", { name: "Code *", exact: true }).click();
-    await page.waitForLoadState("networkidle");
     await page
       .getByPlaceholder("Search for observation codes")
       .fill("Hemoglobin");
@@ -286,7 +282,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
       .getByRole("combobox")
       .filter({ hasText: "search for units" })
       .click();
-    await page.waitForLoadState("networkidle");
     await page.getByPlaceholder("Search for units").fill(unit);
     await page.getByRole("option", { name: unit }).first().click();
 
@@ -349,7 +344,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
         .click();
 
       await page.getByRole("combobox", { name: "Code *", exact: true }).click();
-      await page.waitForLoadState("networkidle");
       await page.getByRole("option").first().click();
 
       await page.getByRole("combobox", { name: "Data Type" }).nth(1).click();
@@ -359,7 +353,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
         .click();
 
       await page.getByRole("combobox", { name: "Unit" }).nth(1).click();
-      await page.waitForLoadState("networkidle");
       await page.getByRole("option").first().click();
     });
 
@@ -439,7 +432,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
         .click();
 
       await page.getByRole("combobox", { name: "Code *", exact: true }).click();
-      await page.waitForLoadState("networkidle");
       await page.getByRole("option").first().click();
 
       await page.getByRole("combobox", { name: "Data Type" }).nth(1).click();
@@ -449,7 +441,6 @@ test.describe("Observation Definition Form with Interpretation", () => {
         .click();
 
       page.getByRole("combobox", { name: "Unit" }).nth(1).click();
-      await page.waitForLoadState("networkidle");
       await page.getByRole("option").first().click();
 
       // Add component-level interpretation
@@ -623,7 +614,7 @@ test.describe("Observation Definition Form with Interpretation", () => {
       // Verify sheet closes
       await expect(
         page.getByRole("heading", { name: "Add/Edit Interpretation" }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
 
     // Submit form
@@ -808,7 +799,7 @@ test.describe("Observation Definition Form with Interpretation", () => {
       // Verify sheet closes
       await expect(
         page.getByRole("heading", { name: "Add/Edit Interpretation" }),
-      ).not.toBeVisible();
+      ).toBeHidden();
 
       // Verify original values are preserved (should still show "Normal" in summary)
       await expect(

--- a/tests/facility/settings/product/products.spec.ts
+++ b/tests/facility/settings/product/products.spec.ts
@@ -151,7 +151,7 @@ test.describe("Product List", () => {
       // Optionally, check that "No results" is NOT visible
       await expect(
         page.getByText(/no results|not found|no products/i),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
   });
 

--- a/tests/facility/settings/productKnowledge/productKnowledgeDelete.spec.ts
+++ b/tests/facility/settings/productKnowledge/productKnowledgeDelete.spec.ts
@@ -58,6 +58,6 @@ test.describe("Product Knowledge Delete operations", () => {
     ).toBeVisible();
 
     await page.getByRole("textbox", { name: "Search products" }).fill(name);
-    await expect(page.getByRole("table").getByText(name)).not.toBeVisible();
+    await expect(page.getByRole("table").getByText(name)).toBeHidden();
   });
 });

--- a/tests/facility/settings/specimenDefinitions/specimenDefinitionCreate.spec.ts
+++ b/tests/facility/settings/specimenDefinitions/specimenDefinitionCreate.spec.ts
@@ -260,16 +260,11 @@ test.describe("Specimen Definitions Create", () => {
     await page.getByRole("textbox", { name: "Title *" }).blur();
 
     const slugField = page.getByRole("textbox", { name: "Slug *" });
-    const slugValue = await slugField.inputValue();
-    expect(slugValue).toBeTruthy();
-    expect(slugValue.length).toBeGreaterThan(0);
-
     const expectedSlugPattern = definitionTitle
       .toLowerCase()
       .replace(/[^a-z0-9_-]+/g, "-")
       .replace(/^-+|-+$/g, "");
-
-    expect(slugValue).toContain(expectedSlugPattern);
+    await expect(slugField).toHaveValue(new RegExp(expectedSlugPattern));
   });
 
   test("verify slug validation of 5 - 25 character", async ({ page }) => {

--- a/tests/facility/settings/tokenCategory/tokenCategoryCreate.spec.ts
+++ b/tests/facility/settings/tokenCategory/tokenCategoryCreate.spec.ts
@@ -205,7 +205,7 @@ test.describe("Token Category Create - Permission Tests", () => {
         const addButton = page.getByRole("button", {
           name: "Add Token Category",
         });
-        await expect(addButton).not.toBeVisible();
+        await expect(addButton).toBeHidden();
       }
       // If page is not accessible, that's also valid for nurses (access denied)
     });

--- a/tests/facility/settings/tokenCategory/tokenCategoryList.spec.ts
+++ b/tests/facility/settings/tokenCategory/tokenCategoryList.spec.ts
@@ -102,13 +102,13 @@ test.describe("Token Category List - Permission Tests", () => {
 
       // Step 3: Verify table and data are NOT visible
       const table = page.locator("table");
-      await expect(table).not.toBeVisible();
+      await expect(table).toBeHidden();
 
       // Verify action buttons are NOT visible
       const viewButtons = page.getByRole("link", { name: "View", exact: true });
       const editButtons = page.getByRole("link", { name: "Edit", exact: true });
-      expect(await viewButtons.count()).toBe(0);
-      expect(await editButtons.count()).toBe(0);
+      await expect(viewButtons).toHaveCount(0);
+      await expect(editButtons).toHaveCount(0);
 
       // Step 4: Verify Token Category link is NOT visible in sidebar
       const sidebarToggle = page.getByRole("button", {
@@ -125,7 +125,7 @@ test.describe("Token Category List - Permission Tests", () => {
         const tokenCategoryLink = page.getByRole("link", {
           name: "Token Category",
         });
-        await expect(tokenCategoryLink).not.toBeVisible();
+        await expect(tokenCategoryLink).toBeHidden();
       }
       // If Settings section itself isn't visible, Token Category is also not accessible
     });

--- a/tests/facility/users/departmentInfiniteScroll.spec.ts
+++ b/tests/facility/users/departmentInfiniteScroll.spec.ts
@@ -68,9 +68,7 @@ test.describe("Department Selector Infinite Scroll", () => {
         page.getByRole("button", { name: "See Details" }).first(),
       ).toBeVisible();
       await page.getByRole("button", { name: "See Details" }).first().click();
-      await page.waitForLoadState("networkidle");
       await page.getByText("Departments", { exact: true }).click();
-      await page.waitForLoadState("networkidle");
     });
 
     await test.step("Open Link Department sheet and switch to All Organizations", async () => {
@@ -78,7 +76,6 @@ test.describe("Department Selector Infinite Scroll", () => {
       await expect(page.getByText("Link User to Department")).toBeVisible();
       // Switch tab before opening dropdown (clicking tab would close popover)
       await page.getByRole("tab", { name: "All Organizations" }).click();
-      await page.waitForLoadState("networkidle");
     });
 
     await test.step("Open department dropdown", async () => {

--- a/tests/facility/users/userDeletion.spec.ts
+++ b/tests/facility/users/userDeletion.spec.ts
@@ -70,28 +70,29 @@ test.describe("User Deletion Access Control", () => {
 
       // Wait for successful login
       await expect(page).toHaveURL(/(?!.*login)/, { timeout: 15000 });
-      await page.waitForLoadState("networkidle");
 
       // Navigate directly to facility users page
       const facilityId = getFacilityId();
       await page.goto(`/facility/${facilityId}/users`);
-      await page.waitForLoadState("networkidle");
 
-      // Check if staff can see the users list at all
+      // Check if staff can see the users list at all.
       const seeDetailsButton = page
         .getByRole("button", { name: "See Details" })
         .first();
-      const canSeeUsers = await seeDetailsButton
-        .isVisible({ timeout: 10000 })
-        .catch(() => false);
+      // Wait for the users page to settle (user cards or the empty state)
+      // before the permission check — no fixed timeout.
+      await expect(
+        seeDetailsButton.or(page.getByText(/no users found/i)),
+      ).toBeVisible();
+      const canSeeUsers = await seeDetailsButton.isVisible();
 
       if (!canSeeUsers) {
         // Staff cannot access users list — they definitely cannot delete users
         // This is a valid security outcome
-        const deleteButtonCount = await page
-          .getByRole("button", { name: "Delete Account" })
-          .count();
-        expect(deleteButtonCount).toBe(0);
+        const deleteButtonCount = page.getByRole("button", {
+          name: "Delete Account",
+        });
+        await expect(deleteButtonCount).toHaveCount(0);
         return;
       }
 
@@ -101,10 +102,10 @@ test.describe("User Deletion Access Control", () => {
       const deleteButton = page.getByRole("button", { name: "Delete Account" });
       await expect(deleteButton).toBeHidden();
 
-      const deleteButtonCount = await page
-        .getByRole("button", { name: "Delete Account" })
-        .count();
-      expect(deleteButtonCount).toBe(0);
+      const deleteButtonCount = page.getByRole("button", {
+        name: "Delete Account",
+      });
+      await expect(deleteButtonCount).toHaveCount(0);
     });
   });
 });

--- a/tests/facility/users/userScheduleCreation.spec.ts
+++ b/tests/facility/users/userScheduleCreation.spec.ts
@@ -57,7 +57,7 @@ class ScheduleFormPage {
     await expect(nextMonthBtn).toBeVisible();
 
     for (let i = 0; i < monthsToNavigate; i++) {
-      await nextMonthBtn.click({ force: true });
+      await nextMonthBtn.click();
     }
 
     await this.page

--- a/tests/helper/questionnaire.ts
+++ b/tests/helper/questionnaire.ts
@@ -49,7 +49,7 @@ export async function checkVisibility(
   if (shouldBeVisible) {
     await expect(label).toBeVisible();
   } else {
-    await expect(label).not.toBeVisible();
+    await expect(label).toBeHidden();
   }
 }
 
@@ -90,7 +90,6 @@ export async function verifySubmittedValues(
   excludedValues: string[] = [],
 ) {
   await page.waitForURL(/\/encounter\/[^/]+\/updates/);
-  await page.waitForLoadState("networkidle");
 
   for (const val of expectedValues) {
     const locator = page.getByText(val, { exact: true }).first();
@@ -99,7 +98,7 @@ export async function verifySubmittedValues(
   }
 
   for (const val of excludedValues) {
-    await expect(page.getByText(val, { exact: true })).not.toBeVisible();
+    await expect(page.getByText(val, { exact: true })).toBeHidden();
   }
 }
 
@@ -113,7 +112,6 @@ export async function verifyLabelledValues(
   pairs: [label: string, value: string][],
 ) {
   await page.waitForURL(/\/encounter\/[^/]+\/updates/);
-  await page.waitForLoadState("networkidle");
 
   for (const [label, value] of pairs) {
     const row = page

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -106,7 +106,11 @@ export async function selectFromRequirements(
     if (await input.isVisible().catch(() => false)) {
       await input.fill("");
       await input.fill(search);
-      await page.waitForTimeout(500); // Wait for debounced search
+      // Wait for the debounced search to settle before reading options
+      const searching = scope.getByText(/searching/i);
+      if (await searching.isVisible().catch(() => false)) {
+        await searching.waitFor({ state: "hidden" });
+      }
     }
   }
 
@@ -126,9 +130,6 @@ export async function selectFromRequirements(
   // Wait for the plus button and click it
   await plusButton.waitFor({ state: "visible" });
   await plusButton.click();
-
-  // Wait for selection to register (multi-select, so it stays open)
-  await page.waitForTimeout(300);
 }
 
 interface SelectFromValueSetOptions {
@@ -178,7 +179,7 @@ export async function selectFromValueSet(
     const starredTab = scope.getByRole("tab", { name: /starred/i });
     if (await starredTab.isVisible().catch(() => false)) {
       await starredTab.click();
-      await page.waitForTimeout(200);
+      await expect(starredTab).toHaveAttribute("data-state", "active");
     }
   }
 
@@ -265,16 +266,19 @@ export async function selectFromCommand(
     if (isInputVisible) {
       await input.fill("");
       await input.fill(search);
-      // Wait for search results to update
-      await page.waitForTimeout(500);
     } else {
       // Fallback for custom inputs
       const placeholderInput = scope.getByPlaceholder(/search/i).first();
       if (await placeholderInput.isVisible().catch(() => false)) {
         await placeholderInput.fill("");
         await placeholderInput.fill(search);
-        await page.waitForTimeout(500);
       }
+    }
+
+    // Wait for the debounced search to settle before reading options
+    const searching = scope.getByText(/searching/i);
+    if (await searching.isVisible().catch(() => false)) {
+      await searching.waitFor({ state: "hidden" });
     }
   }
 

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -106,11 +106,10 @@ export async function selectFromRequirements(
     if (await input.isVisible().catch(() => false)) {
       await input.fill("");
       await input.fill(search);
-      // Wait for the debounced search to settle before reading options
-      const searching = scope.getByText(/searching/i);
-      if (await searching.isVisible().catch(() => false)) {
-        await searching.waitFor({ state: "hidden" });
-      }
+      // Debounced search (~500ms) clears the current options while loading;
+      // wait for that transition so options reflect the query, not the
+      // pre-search list.
+      await expect(scope.getByRole("option")).toHaveCount(0);
     }
   }
 
@@ -179,7 +178,8 @@ export async function selectFromValueSet(
     const starredTab = scope.getByRole("tab", { name: /starred/i });
     if (await starredTab.isVisible().catch(() => false)) {
       await starredTab.click();
-      await expect(starredTab).toHaveAttribute("data-state", "active");
+      // Wait for the starred panel content to mount, not just the tab state.
+      await scope.getByRole("tabpanel").waitFor({ state: "visible" });
     }
   }
 
@@ -275,11 +275,10 @@ export async function selectFromCommand(
       }
     }
 
-    // Wait for the debounced search to settle before reading options
-    const searching = scope.getByText(/searching/i);
-    if (await searching.isVisible().catch(() => false)) {
-      await searching.waitFor({ state: "hidden" });
-    }
+    // Debounced search (~500ms) clears the current options while loading;
+    // wait for that transition so options reflect the query, not the
+    // pre-search list.
+    await expect(scope.getByRole("option")).toHaveCount(0);
   }
 
   // Wait for options to load

--- a/tests/helper/ui.ts
+++ b/tests/helper/ui.ts
@@ -601,7 +601,6 @@ export async function applyTableFilter(
   await page.locator('[data-slot="table-body"]').waitFor({ state: "visible" });
 
   await selectFromFilterSelect(page, filterLabel, filterValue);
-  await page.waitForLoadState("networkidle");
 
   const tableBody = page.locator('[data-slot="table-body"]');
   await tableBody.waitFor({ state: "visible" });

--- a/tests/organization/facility/facilityCreation.spec.ts
+++ b/tests/organization/facility/facilityCreation.spec.ts
@@ -255,14 +255,12 @@ test.describe("Facility Creation", () => {
     ).toBeVisible();
 
     // Verify "Show on Map" is NOT visible since we didn't provide location
-    await expect(
-      page.getByRole("link", { name: "Show on Map" }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("link", { name: "Show on Map" })).toBeHidden();
 
     // Verify optional fields are NOT visible (description and features)
     // Description should not be displayed if it was not provided
     const descriptionSection = page.locator("text=Description").first();
-    await expect(descriptionSection).not.toBeVisible();
+    await expect(descriptionSection).toBeHidden();
 
     // Open edit form
     await page.getByRole("button", { name: "Edit Facility Details" }).click();
@@ -343,12 +341,12 @@ test.describe("Facility Creation", () => {
       dialog.locator('p[data-slot="form-message"]', {
         hasText: /description/i,
       }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await expect(dialog.getByText("Features").first()).toBeVisible();
     await expect(
       dialog.locator('p[data-slot="form-message"]', { hasText: /feature/i }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 
   test("Edit a facility and verify changes", async ({ page }) => {
@@ -381,7 +379,7 @@ test.describe("Facility Creation", () => {
     await expectToast(page, /Facility updated successfully/i);
 
     // Wait for dialog to close
-    await expect(editDialog).not.toBeVisible();
+    await expect(editDialog).toBeHidden();
 
     // Verify changes on the facility details page
     await expect(page.getByText(description)).toBeVisible();
@@ -461,7 +459,7 @@ test.describe("Facility Creation", () => {
     await expectToast(page, /Facility updated successfully/i);
 
     // Wait for dialog to close
-    await expect(editDialog).not.toBeVisible();
+    await expect(editDialog).toBeHidden();
 
     // Verify "Show on Map" link is now visible
     const mapLink = page.getByRole("link", { name: "Show on Map" });
@@ -514,6 +512,6 @@ test.describe("Facility Creation", () => {
     // Verify the facility is no longer visible in the list
     await expect(
       page.getByRole("link", { name: "View Facility" }),
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 });

--- a/tests/organization/patient/encounter/patientInfoHoverCard.spec.ts
+++ b/tests/organization/patient/encounter/patientInfoHoverCard.spec.ts
@@ -27,9 +27,7 @@ test.describe("PatientInfoHoverCard Conditional Rendering", () => {
       .click();
 
     // Verify that Patient Home button is NOT visible (because facilityId is not available)
-    await expect(
-      page.getByRole("link", { name: "Patient Home" }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("link", { name: "Patient Home" })).toBeHidden();
 
     // But View Profile button should still be visible
     await expect(page.getByRole("link", { name: "View Profile" })).toBeVisible({

--- a/tests/profile/userAvatar.spec.ts
+++ b/tests/profile/userAvatar.spec.ts
@@ -186,7 +186,7 @@ test.describe("User Profile Avatar Modification", () => {
       await expect(dialog).toBeVisible();
 
       await dialog.getByRole("button", { name: /cancel/i }).click();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
     });
   });
 

--- a/tests/setup/patientAccount.setup.ts
+++ b/tests/setup/patientAccount.setup.ts
@@ -13,14 +13,19 @@ test("navigate to an patient - create and save account id", async ({
   const facilityId = getFacilityId();
   const patientId = getPatientId();
 
+  // Wait for the accounts list to load before deciding whether an account
+  // exists (previously covered by networkidle).
+  const accountsLoaded = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/account/") && resp.request().method() === "GET",
+  );
   // Navigate to patient page
   await page.goto(
     `facility/${facilityId}/patient/${patientId}/accounts?status=active`,
   );
+  await accountsLoaded;
 
   try {
-    await page.waitForLoadState("networkidle");
-
     // Check if an account already exists
     const goToAccountButton = page.getByRole("button", {
       name: "Go to account",


### PR DESCRIPTION
## Proposed Changes

Second PR in the QA-39 stack (tracked by **QA-312**). Migrates the `waitForTimeout` sleeps and the `force: true` usage to web-first patterns, then flips their lint rules from `warn` to `error`.

> Stacked on #16759 — review/merge that first. Base branch is `issues/QA-39/enforce-playwright-lint`.

- Replace 5 `page.waitForTimeout()` debounce/animation sleeps in the shared selector helpers (`selectFromRequirements`, `selectFromValueSet`, `selectFromCommand`) with web-first waits — wait for the "Searching…" indicator to disappear, assert tab active state, and rely on auto-waiting for the multi-select register.
- Remove `{ force: true }` from `userScheduleCreation` (Playwright auto-waits actionability; the button is already asserted visible).
- Flip `playwright/no-wait-for-timeout` and `playwright/no-force-option` to `error`.
- Update `PLAYWRIGHT_GUIDE.md` pitfall #7 accordingly.

## Verification

Run against a live backend:
- `activityDefinitionEdit` (exercises all 3 migrated helpers) — passed.
- `deviceOrganizationAssociation` — passed.
- `ServiceRequestCreate` failures reproduce **identically on the base helper** (DB-state on a non-resetting env), so they are unrelated to this change.
- Note: the `starred`-tab branch isn't covered by any test, so that one wait wasn't exercised.

Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [ ] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [ ] Complete QA on mobile devices.
- [ ] Complete QA on desktop devices.
- [x] Add or update Playwright tests for related changes
