### PR TITLE
fix: apply cursor-pointer to entire Date selector clickable area (fixes #16757)

### DIFF
--- a/src/components/ui/multi-filter/selectedFilterBar.tsx
+++ b/src/components/ui/multi-filter/selectedFilterBar.tsx
@@ -95,11 +95,11 @@ export function SelectedFilterBar({
       >
         <DropdownMenuTrigger asChild>
           <div
-            className="flex items-center gap-2 px-3 h-9 border-gray-200 text-sm"
+            className="flex items-center gap-2 px-3 h-9 border-gray-200 text-sm cursor-pointer"
             onClick={onClick}
           >
             {filter?.icon}
-            <span className="truncate text-gray-950 font-medium cursor-pointer">
+            <span className="truncate text-gray-950 font-medium">
               {t(filter.label)}
             </span>
           </div>

--- a/src/components/ui/multi-filter/selectedFilterBar.tsx
+++ b/src/components/ui/multi-filter/selectedFilterBar.tsx
@@ -94,7 +94,8 @@ export function SelectedFilterBar({
         )}
       >
         <DropdownMenuTrigger asChild>
-          <div
+          <Button
+            variant="outline"
             className="flex items-center gap-2 px-3 h-9 border-gray-200 text-sm cursor-pointer"
             onClick={onClick}
           >
@@ -102,7 +103,7 @@ export function SelectedFilterBar({
             <span className="truncate text-gray-950 font-medium">
               {t(filter.label)}
             </span>
-          </div>
+          </Button>
         </DropdownMenuTrigger>
         <SubMenuFilter
           selectedOption={selectedOperation ?? null}


### PR DESCRIPTION
## Proposed Changes

Fixes #16757 
- Removed the `cursor-pointer` class from the inner `span`.
- Added the `cursor-pointer` class to the main Date selector `div` so the pointer cursor is displayed across the entire clickable area.
- No functional behavior of the Date selector is changed.

### Before

https://github.com/user-attachments/assets/0ac26fdf-8a7a-4c13-8295-4a48c2a7a60c



### After


https://github.com/user-attachments/assets/31618ae1-b1c8-4910-872d-5f5aad01d39b


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [ ] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated selected filter controls to use a clearly styled outline button.
  * Extended the pointer cursor across the entire filter trigger area, making the control’s interactive state more apparent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->