### PR TITLE
Show facility-level patient identifiers and add facility identifier config UI

### DIFF
--- a/src/common/Permissions.tsx
+++ b/src/common/Permissions.tsx
@@ -98,6 +98,12 @@ export const PERMISSION_LIST_TOKEN_CATEGORIES = "can_list_token_category";
 export const PERMISSION_WRITE_TOKEN = "can_write_token";
 export const PERMISSION_LIST_TOKENS = "can_list_token";
 
+// Patient Identifier Config Permissions
+export const PERMISSION_WRITE_PATIENT_IDENTIFIER_CONFIG =
+  "can_write_patient_identifier_config";
+export const PERMISSION_READ_PATIENT_IDENTIFIER_CONFIG =
+  "can_read_patient_identifier_config";
+
 // Healthcare Permissions
 export const PERMISSION_WRITE_HEALTHCARE_SERVICE =
   "can_write_healthcare_service";
@@ -257,6 +263,12 @@ export interface Permissions {
   canWriteToken: boolean;
   /** Permission slug: "can_list_token" */
   canListTokens: boolean;
+
+  // Patient Identifier Config Permissions
+  /** Permission slug: "can_write_patient_identifier_config" */
+  canWritePatientIdentifierConfig: boolean;
+  /** Permission slug: "can_read_patient_identifier_config" */
+  canReadPatientIdentifierConfig: boolean;
 
   /** Permission slug: "can_write_healthcare_service" */
   canWriteHealthcareService: boolean;
@@ -475,6 +487,16 @@ export function getPermissions(
     ),
     canWriteToken: hasPermission(PERMISSION_WRITE_TOKEN, permissions),
     canListTokens: hasPermission(PERMISSION_LIST_TOKENS, permissions),
+
+    // Patient Identifier Config
+    canWritePatientIdentifierConfig: hasPermission(
+      PERMISSION_WRITE_PATIENT_IDENTIFIER_CONFIG,
+      permissions,
+    ),
+    canReadPatientIdentifierConfig: hasPermission(
+      PERMISSION_READ_PATIENT_IDENTIFIER_CONFIG,
+      permissions,
+    ),
 
     //Healthcare Services
     canWriteHealthcareService: hasPermission(

--- a/src/components/Facility/ConsultationDetails/PrintAllQuestionnaireResponses.tsx
+++ b/src/components/Facility/ConsultationDetails/PrintAllQuestionnaireResponses.tsx
@@ -14,7 +14,10 @@ import { formatValue } from "@/components/Facility/ConsultationDetails/Questionn
 import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
 import { EncounterRead } from "@/types/emr/encounter/encounter";
 import encounterApi from "@/types/emr/encounter/encounterApi";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  getPatientIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
@@ -170,17 +173,15 @@ export function PrintableEncounterDetails({
               : undefined
           }
         />
-        {patient?.instance_identifiers
-          ?.filter(
-            ({ config }) => config.config.use === PatientIdentifierUse.official,
-          )
-          .map((identifier) => (
-            <DetailRow
-              key={identifier.config.id}
-              label={identifier.config.config.display}
-              value={identifier.value}
-            />
-          ))}
+        {getPatientIdentifiers(patient, {
+          use: PatientIdentifierUse.official,
+        }).map((identifier) => (
+          <DetailRow
+            key={identifier.config.id}
+            label={identifier.config.config.display}
+            value={identifier.value}
+          />
+        ))}
         {patient?.address && (
           <DetailRow label={t("address")} value={patient.address} />
         )}

--- a/src/components/Patient/PatientDetailsTab/Demography.tsx
+++ b/src/components/Patient/PatientDetailsTab/Demography.tsx
@@ -21,6 +21,7 @@ import { formatPatientAge } from "@/Utils/utils";
 import { formatPatientAddress } from "@/components/Patient/utils";
 import { usePermissions } from "@/context/PermissionContext";
 import usePatientExtensionData from "@/hooks/usePatientExtensionData";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import {
   getOrgLabel,
   Organization,
@@ -259,12 +260,10 @@ export const Demography = (props: PatientProps) => {
     {
       id: "identifiers",
       allowEdit: false,
-      details: patientData.instance_identifiers
-        ?.filter(({ config }) => !config.config.auto_maintained)
-        .map((i) => ({
-          label: i.config.config.display,
-          value: i.value,
-        })),
+      details: getPatientIdentifiers(patientData).map((i) => ({
+        label: i.config.config.display,
+        value: i.value,
+      })),
     },
     {
       id: "tags",

--- a/src/components/Patient/PatientHeader.tsx
+++ b/src/components/Patient/PatientHeader.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { PatientHoverCard } from "@/pages/Facility/services/serviceRequests/PatientHoverCard";
 import {
+  getPatientIdentifiers,
   PatientListRead,
   PatientRead,
   PublicPatientRead,
@@ -38,22 +39,17 @@ export function PatientHeader({
           disabled={isPatientPage}
         />
         <div className="flex flex-wrap xl:gap-5 gap-2">
-          {"instance_identifiers" in patient &&
-            patient.instance_identifiers
-              ?.filter(({ config }) => !config.config.auto_maintained)
-              .map((identifier) => (
-                <div
-                  key={identifier.config.id}
-                  className="flex flex-col gap-1 items-start md:hidden xl:flex"
-                >
-                  <span className="text-xs text-gray-700 md:w-auto">
-                    {identifier.config.config.display}:{" "}
-                  </span>
-                  <span className="text-sm font-semibold">
-                    {identifier.value}
-                  </span>
-                </div>
-              ))}
+          {getPatientIdentifiers(patient).map((identifier) => (
+            <div
+              key={identifier.config.id}
+              className="flex flex-col gap-1 items-start md:hidden xl:flex"
+            >
+              <span className="text-xs text-gray-700 md:w-auto">
+                {identifier.config.config.display}:{" "}
+              </span>
+              <span className="text-sm font-semibold">{identifier.value}</span>
+            </div>
+          ))}
           <PatientTagsDisplay patient={patient} className="text-xs flex-1" />
         </div>
       </div>

--- a/src/components/Patient/PatientInfoHoverCard.tsx
+++ b/src/components/Patient/PatientInfoHoverCard.tsx
@@ -6,6 +6,7 @@ import { formatPatientAddress } from "@/components/Patient/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  getPatientIdentifiers,
   PatientListRead,
   PatientRead,
   PublicPatientRead,
@@ -88,20 +89,17 @@ export const PatientInfoHoverCard = ({
       </div>
       <div className="flex flex-col gap-3">
         <div className="grid grid-cols-2 gap-3 border-t border-gray-200 pt-4">
-          {"instance_identifiers" in patient &&
-            patient.instance_identifiers
-              ?.filter(({ config }) => !config.config.auto_maintained)
-              .map((identifier) => (
-                <div
-                  key={identifier.config.id}
-                  className="flex flex-col gap-0.5 text-sm"
-                >
-                  <span className="font-medium text-gray-700">
-                    {identifier.config.config.display}:{" "}
-                  </span>
-                  <span className="font-semibold">{identifier.value}</span>
-                </div>
-              ))}
+          {getPatientIdentifiers(patient).map((identifier) => (
+            <div
+              key={identifier.config.id}
+              className="flex flex-col gap-0.5 text-sm"
+            >
+              <span className="font-medium text-gray-700">
+                {identifier.config.config.display}:{" "}
+              </span>
+              <span className="font-semibold">{identifier.value}</span>
+            </div>
+          ))}
           {patient.phone_number && (
             <div className="flex flex-col gap-1 text-sm font-medium">
               <span className="text-gray-700">{t("contact")}</span>

--- a/src/components/Prescription/PrescriptionPreview.tsx
+++ b/src/components/Prescription/PrescriptionPreview.tsx
@@ -21,6 +21,7 @@ import query from "@/Utils/request/query";
 import { formatDateTime, formatName, formatPatientAge } from "@/Utils/utils";
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
 import { displayMedicationName } from "@/types/emr/medicationRequest/medicationRequest";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import { PrescriptionRead } from "@/types/emr/prescription/prescription";
 import prescriptionApi from "@/types/emr/prescription/prescriptionApi";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
@@ -211,19 +212,16 @@ export const PrescriptionPreview = ({
                 }
                 isStrong
               />
-              {patient.instance_identifiers
-                ?.filter(
-                  ({ config }) =>
-                    config.config.use === PatientIdentifierUse.official,
-                )
-                .map((identifier) => (
-                  <DetailRow
-                    key={identifier.config.id}
-                    label={identifier.config.config.display}
-                    value={identifier.value}
-                    isStrong
-                  />
-                ))}
+              {getPatientIdentifiers(patient, {
+                use: PatientIdentifierUse.official,
+              }).map((identifier) => (
+                <DetailRow
+                  key={identifier.config.id}
+                  label={identifier.config.config.display}
+                  value={identifier.value}
+                  isStrong
+                />
+              ))}
               {prescriptions.length === 1 && (
                 <DetailRow
                   label={t("encounter_date")}

--- a/src/components/ui/sidebar/facility/facility-nav.tsx
+++ b/src/components/ui/sidebar/facility/facility-nav.tsx
@@ -29,6 +29,7 @@ function generateFacilityLinks(
     canCreateEncounter: boolean;
     canReadEncounter: boolean;
     canListTokenCategories: boolean;
+    canReadPatientIdentifierConfig: boolean;
     canListTemplate: boolean;
   },
   pluginLinks: NavigationLink[],
@@ -184,10 +185,11 @@ function generateFacilityLinks(
           url: `${baseUrl}/settings/token_category`,
           visibility: permissions.canListTokenCategories,
         },
-        // {
-        //   name: t("patient_identifier_config"),
-        //   url: `${baseUrl}/settings/patient_identifier_config`,
-        // },
+        {
+          name: t("patient_identifier_config"),
+          url: `${baseUrl}/settings/patient_identifier_config`,
+          visibility: permissions.canReadPatientIdentifierConfig,
+        },
         {
           name: t("tag_config"),
           url: `${baseUrl}/settings/tag_config`,
@@ -231,6 +233,7 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
     canCreateEncounter,
     canReadEncounter,
     canListTokenCategories,
+    canReadPatientIdentifierConfig,
     canListTemplate,
   } = getPermissions(hasPermission, facility?.permissions ?? []);
   const permissions = {
@@ -240,6 +243,7 @@ export function FacilityNav({ selectedFacility }: FacilityNavProps) {
     canCreateEncounter,
     canReadEncounter,
     canListTokenCategories,
+    canReadPatientIdentifierConfig,
     canListTemplate,
   };
   return (

--- a/src/pages/Appointments/AppointmentPrint.tsx
+++ b/src/pages/Appointments/AppointmentPrint.tsx
@@ -39,6 +39,7 @@ import {
   PAYMENT_RECONCILIATION_METHOD_MAP,
   PaymentReconciliationStatus,
 } from "@/types/billing/paymentReconciliation/paymentReconciliation";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import { formatScheduleResourceName } from "@/types/scheduling/schedule";
@@ -234,19 +235,15 @@ export default function AppointmentPrint(props: Props) {
                       : undefined
                   }
                 />
-                {patient?.instance_identifiers
-                  ?.filter(
-                    (identifier) =>
-                      identifier.config.config.use ===
-                      PatientIdentifierUse.official,
-                  )
-                  .map((identifier) => (
-                    <DetailRow
-                      key={identifier.config.id}
-                      label={identifier.config.config.display}
-                      value={identifier.value}
-                    />
-                  ))}
+                {getPatientIdentifiers(patient, {
+                  use: PatientIdentifierUse.official,
+                }).map((identifier) => (
+                  <DetailRow
+                    key={identifier.config.id}
+                    label={identifier.config.config.display}
+                    value={identifier.value}
+                  />
+                ))}
                 {patient?.address?.trim() && (
                   <DetailRow label={t("address")} value={patient.address} />
                 )}

--- a/src/pages/Appointments/components/AppointmentTokenCard.tsx
+++ b/src/pages/Appointments/components/AppointmentTokenCard.tsx
@@ -14,14 +14,17 @@ import { useShortcutSubContext } from "@/context/ShortcutContext";
 import useBreakpoints from "@/hooks/useBreakpoints";
 import usePatientExtensionData from "@/hooks/usePatientExtensionData";
 import { formatSlotTimeRange } from "@/pages/Appointments/utils";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  getPatientIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import { FacilityRead } from "@/types/facility/facility";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import {
   AppointmentRead,
   formatScheduleResourceName,
 } from "@/types/scheduling/schedule";
-import { TokenRead, renderTokenNumber } from "@/types/tokens/token/token";
+import { renderTokenNumber, TokenRead } from "@/types/tokens/token/token";
 import { formatDate } from "date-fns";
 import { PrinterIcon } from "lucide-react";
 import { Link } from "raviger";
@@ -106,22 +109,16 @@ const TokenCard = ({
                     </div>
                   );
                 })}
-                {patientWithIdentifiers?.instance_identifiers
-                  ?.filter(
-                    (identifier) =>
-                      identifier.config.config.use ===
-                      PatientIdentifierUse.official,
-                  )
-                  .map((identifier) => (
-                    <div key={identifier.config.id}>
-                      <Label className="text-gray-600 text-sm">
-                        {identifier.config.config.display}:
-                      </Label>
-                      <p className="font-semibold text-sm">
-                        {identifier.value}
-                      </p>
-                    </div>
-                  ))}
+                {getPatientIdentifiers(patientWithIdentifiers, {
+                  use: PatientIdentifierUse.official,
+                }).map((identifier) => (
+                  <div key={identifier.config.id}>
+                    <Label className="text-gray-600 text-sm">
+                      {identifier.config.config.display}:
+                    </Label>
+                    <p className="font-semibold text-sm">{identifier.value}</p>
+                  </div>
+                ))}
                 {inPrintMode && patient.address?.trim() && (
                   <div>
                     <Label className="text-gray-600 text-sm">

--- a/src/pages/Appointments/components/PrintAppointments.tsx
+++ b/src/pages/Appointments/components/PrintAppointments.tsx
@@ -25,13 +25,13 @@ import {
   formatDateTime,
   formatPatientAge,
 } from "@/Utils/utils";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  getPatientIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
-import {
-  PatientIdentifier,
-  PatientIdentifierUse,
-} from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
+import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import {
   formatScheduleResourceName,
   SchedulableResourceType,
@@ -218,26 +218,17 @@ export function PrintAppointments({
                           <p className="text-sm text-gray-600 flex items-center gap-1">
                             {formatPatientAge(appointment.patient, true)},{" "}
                             {t(`GENDER__${appointment.patient.gender}`)}
-                            {"instance_identifiers" in appointment.patient &&
-                              (
-                                appointment.patient
-                                  .instance_identifiers as PatientIdentifier[]
-                              )
-                                ?.filter(
-                                  ({ config }: PatientIdentifier) =>
-                                    config.config.use ===
-                                      PatientIdentifierUse.official &&
-                                    !config.config.auto_maintained,
-                                )
-                                .map((identifier: PatientIdentifier) => (
-                                  <p
-                                    key={identifier.config.id}
-                                    className="text-xs text-gray-600"
-                                  >
-                                    ({identifier.config.config.display}:{" "}
-                                    {identifier.value}){" "}
-                                  </p>
-                                ))}
+                            {getPatientIdentifiers(appointment.patient, {
+                              use: PatientIdentifierUse.official,
+                            }).map((identifier) => (
+                              <p
+                                key={identifier.config.id}
+                                className="text-xs text-gray-600"
+                              >
+                                ({identifier.config.config.display}:{" "}
+                                {identifier.value}){" "}
+                              </p>
+                            ))}
                           </p>
                         </div>
                       </TableCell>

--- a/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
+++ b/src/pages/Encounters/tabs/overview/summary-panel-details-tab/summary-panel-encounter-details.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/types/billing/account/Account";
 import accountApi from "@/types/billing/account/accountApi";
 import { ENCOUNTER_PRIORITY_COLORS } from "@/types/emr/encounter/encounter";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { Signal, SquarePen } from "lucide-react";
@@ -225,19 +226,17 @@ export const SummaryPanelEncounterDetails = () => {
 
           <div className="flex flex-row gap-2">
             <div className="text-sm text-gray-950 font-semibold flex flex-wrap gap-6">
-              {patient?.instance_identifiers
-                ?.filter(({ config }) => !config.config.auto_maintained)
-                .map((identifier) => (
-                  <div
-                    key={identifier.config.id}
-                    className="flex flex-col items-start"
-                  >
-                    <span className="text-gray-600 md:w-auto">
-                      {identifier.config.config.display}:{" "}
-                    </span>
-                    <span className="font-semibold">{identifier.value}</span>
-                  </div>
-                ))}
+              {getPatientIdentifiers(patient).map((identifier) => (
+                <div
+                  key={identifier.config.id}
+                  className="flex flex-col items-start"
+                >
+                  <span className="text-gray-600 md:w-auto">
+                    {identifier.config.config.display}:{" "}
+                  </span>
+                  <span className="font-semibold">{identifier.value}</span>
+                </div>
+              ))}
             </div>
           </div>
 

--- a/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
+++ b/src/pages/Facility/billing/account/components/PrintChargeItems.tsx
@@ -59,6 +59,7 @@ import { add, multiply, round } from "@/Utils/decimal";
 import query from "@/Utils/request/query";
 import { formatDateTime, formatName, formatPatientAge } from "@/Utils/utils";
 import BackButton from "@/components/Common/BackButton";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 
 interface DetailRowProps {
   label: string;
@@ -487,20 +488,16 @@ export const PrintChargeItems = (props: {
                             value={formatDateTime(new Date(), "DD-MM-YYYY")}
                             width="w-24"
                           />
-                          {account?.patient?.instance_identifiers
-                            ?.filter(
-                              ({ config }) =>
-                                config.config.use ===
-                                PatientIdentifierUse.official,
-                            )
-                            .map((identifier) => (
-                              <DetailRow
-                                key={identifier.config.id}
-                                label={identifier.config.config.display}
-                                value={identifier.value}
-                                width="w-24"
-                              />
-                            ))}
+                          {getPatientIdentifiers(account?.patient, {
+                            use: PatientIdentifierUse.official,
+                          }).map((identifier) => (
+                            <DetailRow
+                              key={identifier.config.id}
+                              label={identifier.config.config.display}
+                              value={identifier.value}
+                              width="w-24"
+                            />
+                          ))}
 
                           {account?.primary_encounter && (
                             <>

--- a/src/pages/Facility/billing/invoice/InvoiceShow.tsx
+++ b/src/pages/Facility/billing/invoice/InvoiceShow.tsx
@@ -80,7 +80,10 @@ import { ACCOUNT_STATUS_COLORS } from "@/types/billing/account/Account";
 import chargeItemApi from "@/types/billing/chargeItem/chargeItemApi";
 import invoiceApi from "@/types/billing/invoice/invoiceApi";
 import { PAYMENT_RECONCILIATION_METHOD_MAP } from "@/types/billing/paymentReconciliation/paymentReconciliation";
-import { getPartialId } from "@/types/emr/patient/patient";
+import {
+  getPartialId,
+  getPatientIdentifiers,
+} from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import facilityApi from "@/types/facility/facilityApi";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
@@ -754,24 +757,17 @@ function InvoiceShow({
                         invoice.account.patient.phone_number,
                       )}
                     </p>
-                    {verifiedPatient &&
-                      "instance_identifiers" in verifiedPatient &&
-                      verifiedPatient.instance_identifiers
-                        .filter(
-                          ({ config }) =>
-                            config.config.use ===
-                              PatientIdentifierUse.official &&
-                            !config.config.auto_maintained,
-                        )
-                        .map((identifier) => (
-                          <p
-                            key={identifier.config.id}
-                            className="font-medium text-gray-700 text-sm ml-2"
-                          >
-                            <span>{identifier.config.config.display}: </span>
-                            <span>{identifier.value}</span>
-                          </p>
-                        ))}
+                    {getPatientIdentifiers(verifiedPatient, {
+                      use: PatientIdentifierUse.official,
+                    }).map((identifier) => (
+                      <p
+                        key={identifier.config.id}
+                        className="font-medium text-gray-700 text-sm ml-2"
+                      >
+                        <span>{identifier.config.config.display}: </span>
+                        <span>{identifier.value}</span>
+                      </p>
+                    ))}
                   </div>
                   <div className="mt-2">
                     {invoice.note && <p>{invoice.note}</p>}

--- a/src/pages/Facility/billing/invoice/PrintInvoice.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoice.tsx
@@ -37,7 +37,10 @@ import {
   PAYMENT_RECONCILIATION_METHOD_MAP,
   PaymentReconciliationStatus,
 } from "@/types/billing/paymentReconciliation/paymentReconciliation";
-import { getPartialId } from "@/types/emr/patient/patient";
+import {
+  getPartialId,
+  getPatientIdentifiers,
+} from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
@@ -180,25 +183,19 @@ export function PrintInvoiceBase({ facilityId, invoiceId }: PrintInvoiceProps) {
                     {formatPatientAge(invoice.account.patient, true)})
                   </span>
                 </p>
-                {verifiedPatient &&
-                  "instance_identifiers" in verifiedPatient &&
-                  verifiedPatient.instance_identifiers
-                    .filter(
-                      ({ config }) =>
-                        config.config.use === PatientIdentifierUse.official &&
-                        !config.config.auto_maintained,
-                    )
-                    .map((identifier) => (
-                      <div
-                        key={identifier.config.id}
-                        className="text-base text-gray-700"
-                      >
-                        <span>{identifier.config.config.display}: </span>
-                        <span className="ml-2 font-semibold">
-                          {identifier.value}
-                        </span>
-                      </div>
-                    ))}
+                {getPatientIdentifiers(verifiedPatient, {
+                  use: PatientIdentifierUse.official,
+                }).map((identifier) => (
+                  <div
+                    key={identifier.config.id}
+                    className="text-base text-gray-700"
+                  >
+                    <span>{identifier.config.config.display}: </span>
+                    <span className="ml-2 font-semibold">
+                      {identifier.value}
+                    </span>
+                  </div>
+                ))}
                 <div className="flex gap-1 font-medium text-gray-700 text-sm mt-1">
                   <span>{t("address")}:</span>
                   <span className="whitespace-pre-wrap">

--- a/src/pages/Facility/billing/invoice/PrintInvoices.tsx
+++ b/src/pages/Facility/billing/invoice/PrintInvoices.tsx
@@ -36,7 +36,10 @@ import {
   PAYMENT_RECONCILIATION_METHOD_MAP,
   PaymentReconciliationStatus,
 } from "@/types/billing/paymentReconciliation/paymentReconciliation";
-import { getPartialId } from "@/types/emr/patient/patient";
+import {
+  getPartialId,
+  getPatientIdentifiers,
+} from "@/types/emr/patient/patient";
 import patientApi from "@/types/emr/patient/patientApi";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
@@ -98,6 +101,7 @@ function PrintInvoices({ facilityId, invoiceIds }: PrintInvoicesProps) {
           phone_number: patient.phone_number ?? "",
           year_of_birth: patient.year_of_birth?.toString() ?? "",
           partial_id: getPartialId(patient),
+          facility: facilityId,
         },
       }),
       enabled: true,
@@ -195,25 +199,19 @@ function PrintInvoices({ facilityId, invoiceIds }: PrintInvoicesProps) {
                       {formatPatientAge(firstInvoice.account.patient, true)})
                     </span>
                   </p>
-                  {verifiedPatient &&
-                    "instance_identifiers" in verifiedPatient &&
-                    verifiedPatient.instance_identifiers
-                      .filter(
-                        ({ config }) =>
-                          config.config.use === PatientIdentifierUse.official &&
-                          !config.config.auto_maintained,
-                      )
-                      .map((identifier) => (
-                        <div
-                          key={identifier.config.id}
-                          className="text-base text-gray-700"
-                        >
-                          <span>{identifier.config.config.display}: </span>
-                          <span className="ml-2 font-semibold">
-                            {identifier.value}
-                          </span>
-                        </div>
-                      ))}
+                  {getPatientIdentifiers(verifiedPatient, {
+                    use: PatientIdentifierUse.official,
+                  }).map((identifier) => (
+                    <div
+                      key={identifier.config.id}
+                      className="text-base text-gray-700"
+                    >
+                      <span>{identifier.config.config.display}: </span>
+                      <span className="ml-2 font-semibold">
+                        {identifier.value}
+                      </span>
+                    </div>
+                  ))}
                   <div className="flex gap-1 font-medium text-gray-700 text-sm mt-1">
                     <span>{t("address")}:</span>
                     <span className="whitespace-pre-wrap">

--- a/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
+++ b/src/pages/Facility/billing/paymentReconciliation/PrintPaymentReconciliation.tsx
@@ -27,6 +27,7 @@ import {
   PaymentReconciliationStatus,
 } from "@/types/billing/paymentReconciliation/paymentReconciliation";
 import paymentReconciliationApi from "@/types/billing/paymentReconciliation/paymentReconciliationApi";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import query from "@/Utils/request/query";
@@ -162,20 +163,17 @@ function PrintPaymentReconciliation({
                 value={payment.id}
                 width="w-24"
               />
-              {payment.account.patient?.instance_identifiers
-                ?.filter(
-                  ({ config }) =>
-                    config.config.use === PatientIdentifierUse.official,
-                )
-                .map((identifier) => (
-                  <DetailRow
-                    key={identifier.config.id}
-                    label={identifier.config.config.display}
-                    value={identifier.value}
-                    width="w-24"
-                    isStrong
-                  />
-                ))}
+              {getPatientIdentifiers(payment.account.patient, {
+                use: PatientIdentifierUse.official,
+              }).map((identifier) => (
+                <DetailRow
+                  key={identifier.config.id}
+                  label={identifier.config.config.display}
+                  value={identifier.value}
+                  width="w-24"
+                  isStrong
+                />
+              ))}
               <DetailRow
                 label={t("payment_method")}
                 value={PAYMENT_RECONCILIATION_METHOD_MAP[payment.method]}

--- a/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
+++ b/src/pages/Facility/services/diagnosticReports/DiagnosticReportPrint.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { Document, Page } from "react-pdf";
 
 import { ObservationStatus } from "@/types/emr/observation/observation";
+import { getPatientIdentifiers } from "@/types/emr/patient/patient";
 import { DiagnosticReportResultsTable } from "./components/DiagnosticReportResultsTable";
 
 // TODO: Replace with PDFViewer or extract this to a component
@@ -226,27 +227,20 @@ export default function DiagnosticReportPrint({
                 {report.encounter?.patient?.name}
               </span>
             </div>
-            {report.encounter?.patient &&
-              "instance_identifiers" in report.encounter.patient &&
-              report.encounter.patient.instance_identifiers
-                .filter(
-                  ({ config }) =>
-                    config.config.use === PatientIdentifierUse.official,
-                )
-                .map((identifier) => (
-                  <div
-                    key={identifier.config.id}
-                    className="grid grid-cols-[6rem_auto_1fr] items-center"
-                  >
-                    <span className="text-gray-600">
-                      {identifier.config.config.display}
-                    </span>
-                    <span className="text-gray-600">:</span>
-                    <span className="font-semibold ml-2">
-                      {identifier.value}
-                    </span>
-                  </div>
-                ))}
+            {getPatientIdentifiers(report.encounter?.patient, {
+              use: PatientIdentifierUse.official,
+            }).map((identifier) => (
+              <div
+                key={identifier.config.id}
+                className="grid grid-cols-[6rem_auto_1fr] items-center"
+              >
+                <span className="text-gray-600">
+                  {identifier.config.config.display}
+                </span>
+                <span className="text-gray-600">:</span>
+                <span className="font-semibold ml-2">{identifier.value}</span>
+              </div>
+            ))}
             <div className="grid grid-cols-[6rem_auto_1fr] items-center">
               <span className="text-gray-600">
                 {t("age")} / {t("sex")}

--- a/src/pages/Facility/services/pharmacy/PrintDispenseOrder.tsx
+++ b/src/pages/Facility/services/pharmacy/PrintDispenseOrder.tsx
@@ -19,7 +19,10 @@ import { DispenseOrderRead } from "@/types/emr/dispenseOrder/dispenseOrder";
 import dispenseOrderApi from "@/types/emr/dispenseOrder/dispenseOrderApi";
 import { MedicationDispenseRead } from "@/types/emr/medicationDispense/medicationDispense";
 import medicationDispenseApi from "@/types/emr/medicationDispense/medicationDispenseApi";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  getPatientIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { PatientIdentifierUse } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 
@@ -153,19 +156,16 @@ const DispenseOrderPreview = ({
               }
               isStrong
             />
-            {patient?.instance_identifiers
-              ?.filter(
-                ({ config }) =>
-                  config.config.use === PatientIdentifierUse.official,
-              )
-              .map((identifier) => (
-                <DetailRow
-                  key={identifier.config.id}
-                  label={identifier.config.config.display}
-                  value={identifier.value}
-                  isStrong
-                />
-              ))}
+            {getPatientIdentifiers(patient, {
+              use: PatientIdentifierUse.official,
+            }).map((identifier) => (
+              <DetailRow
+                key={identifier.config.id}
+                label={identifier.config.config.display}
+                value={identifier.value}
+                isStrong
+              />
+            ))}
           </div>
           <div className="space-y-2">
             <DetailRow

--- a/src/pages/Facility/services/pharmacy/PrintMedicationReturn.tsx
+++ b/src/pages/Facility/services/pharmacy/PrintMedicationReturn.tsx
@@ -10,7 +10,10 @@ import PrintFooter from "@/components/Common/PrintFooter";
 import PrintTable from "@/components/Common/PrintTable";
 
 import useCurrentFacility from "@/pages/Facility/utils/useCurrentFacility";
-import { PatientRead } from "@/types/emr/patient/patient";
+import {
+  getPatientIdentifiers,
+  PatientRead,
+} from "@/types/emr/patient/patient";
 import { PrintTemplateType } from "@/types/facility/printTemplate";
 import { DeliveryOrderRetrieve } from "@/types/inventory/deliveryOrder/deliveryOrder";
 import deliveryOrderApi from "@/types/inventory/deliveryOrder/deliveryOrderApi";
@@ -148,19 +151,16 @@ const MedicationReturnPreview = ({
               }
               isStrong
             />
-            {patient?.instance_identifiers
-              ?.filter(
-                ({ config }) =>
-                  config.config.use === PatientIdentifierUse.official,
-              )
-              .map((identifier) => (
-                <DetailRow
-                  key={identifier.config.id}
-                  label={identifier.config.config.display}
-                  value={identifier.value}
-                  isStrong
-                />
-              ))}
+            {getPatientIdentifiers(patient, {
+              use: PatientIdentifierUse.official,
+            }).map((identifier) => (
+              <DetailRow
+                key={identifier.config.id}
+                label={identifier.config.config.display}
+                value={identifier.value}
+                isStrong
+              />
+            ))}
           </div>
           <div className="space-y-2">
             <DetailRow

--- a/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
+++ b/src/pages/settings/patientIdentifierConfig/PatientIdentifierConfigList.tsx
@@ -35,6 +35,11 @@ import {
 
 import useFilters from "@/hooks/useFilters";
 
+import { getPermissions } from "@/common/Permissions";
+
+import { usePermissions } from "@/context/PermissionContext";
+import { useCurrentFacilitySilently } from "@/pages/Facility/utils/useCurrentFacility";
+
 import query from "@/Utils/request/query";
 import {
   PATIENT_IDENTIFIER_CONFIG_STATUS_COLORS,
@@ -49,9 +54,11 @@ import PatientIdentifierConfigForm from "./PatientIdentifierConfigForm";
 
 function PatientIdentifierConfigCard({
   config,
+  canEdit,
   onEdit,
 }: {
   config: PatientIdentifierConfig;
+  canEdit: boolean;
   onEdit: (config: PatientIdentifierConfig) => void;
 }) {
   const { t } = useTranslation();
@@ -76,10 +83,12 @@ function PatientIdentifierConfigCard({
               </p>
             )}
           </div>
-          <Button variant="outline" size="sm" onClick={() => onEdit(config)}>
-            <CareIcon icon="l-edit" className="size-4" />
-            {t("edit")}
-          </Button>
+          {canEdit && (
+            <Button variant="outline" size="sm" onClick={() => onEdit(config)}>
+              <CareIcon icon="l-edit" className="size-4" />
+              {t("edit")}
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>
@@ -92,6 +101,15 @@ export default function PatientIdentifierConfigList({
   facilityId?: string;
 }) {
   const { t } = useTranslation();
+  const { hasPermission } = usePermissions();
+  const { facility } = useCurrentFacilitySilently();
+  const { canWritePatientIdentifierConfig } = getPermissions(
+    hasPermission,
+    facility?.permissions ?? [],
+  );
+  // Instance-level configs are managed from the admin panel, which is only
+  // reachable by superusers; facility-level configs follow facility permissions.
+  const canWrite = !facilityId || canWritePatientIdentifierConfig;
   const { qParams, updateQuery, Pagination, resultsPerPage } = useFilters({
     limit: 15,
     disableCache: true,
@@ -149,66 +167,68 @@ export default function PatientIdentifierConfigList({
                   : t("manage_instance_patient_identifier_config")}
               </p>
             </div>
-            <Sheet
-              open={!!selectedConfig}
-              onOpenChange={(open) => {
-                if (!open) {
-                  setSelectedConfig(null);
-                } else {
-                  setSelectedConfig({
-                    config: {
-                      use: PatientIdentifierUse.usual,
-                      description: "",
-                      system: "",
-                      required: false,
-                      unique: false,
-                      regex: "",
-                      display: "",
-                      auto_maintained: false,
-                      retrieve_config: {
-                        retrieve_with_dob: false,
-                        retrieve_with_year_of_birth: false,
-                        retrieve_with_otp: false,
+            {canWrite && (
+              <Sheet
+                open={!!selectedConfig}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    setSelectedConfig(null);
+                  } else {
+                    setSelectedConfig({
+                      config: {
+                        use: PatientIdentifierUse.usual,
+                        description: "",
+                        system: "",
+                        required: false,
+                        unique: false,
+                        regex: "",
+                        display: "",
+                        auto_maintained: false,
+                        retrieve_config: {
+                          retrieve_with_dob: false,
+                          retrieve_with_year_of_birth: false,
+                          retrieve_with_otp: false,
+                        },
                       },
-                    },
-                    status: PatientIdentifierConfigStatus.draft,
-                    facility: facilityId || undefined,
-                  });
-                }
-              }}
-            >
-              <SheetTrigger asChild>
-                <Button onClick={handleAdd} className="w-full md:w-auto">
-                  <CareIcon icon="l-plus" className="mr-2" />
-                  {t("add_patient_identifier_config")}
-                </Button>
-              </SheetTrigger>
-              <SheetContent className="overflow-y-auto">
-                <SheetHeader>
-                  <SheetTitle>
-                    {selectedConfig && "id" in selectedConfig
-                      ? t("edit_patient_identifier_config")
-                      : t("add_patient_identifier_config")}
-                  </SheetTitle>
-                  <SheetDescription>
-                    {selectedConfig && "id" in selectedConfig
-                      ? t("manage_patient_identifier_config")
-                      : t("manage_instance_patient_identifier_config")}
-                  </SheetDescription>
-                </SheetHeader>
-                <div className="mt-6 pb-6">
-                  <PatientIdentifierConfigForm
-                    facilityId={facilityId}
-                    configId={
-                      selectedConfig && "id" in selectedConfig
-                        ? selectedConfig.id
-                        : undefined
-                    }
-                    onSuccess={handleSheetClose}
-                  />
-                </div>
-              </SheetContent>
-            </Sheet>
+                      status: PatientIdentifierConfigStatus.draft,
+                      facility: facilityId || undefined,
+                    });
+                  }
+                }}
+              >
+                <SheetTrigger asChild>
+                  <Button onClick={handleAdd} className="w-full md:w-auto">
+                    <CareIcon icon="l-plus" className="mr-2" />
+                    {t("add_patient_identifier_config")}
+                  </Button>
+                </SheetTrigger>
+                <SheetContent className="overflow-y-auto">
+                  <SheetHeader>
+                    <SheetTitle>
+                      {selectedConfig && "id" in selectedConfig
+                        ? t("edit_patient_identifier_config")
+                        : t("add_patient_identifier_config")}
+                    </SheetTitle>
+                    <SheetDescription>
+                      {selectedConfig && "id" in selectedConfig
+                        ? t("manage_patient_identifier_config")
+                        : t("manage_instance_patient_identifier_config")}
+                    </SheetDescription>
+                  </SheetHeader>
+                  <div className="mt-6 pb-6">
+                    <PatientIdentifierConfigForm
+                      facilityId={facilityId}
+                      configId={
+                        selectedConfig && "id" in selectedConfig
+                          ? selectedConfig.id
+                          : undefined
+                      }
+                      onSuccess={handleSheetClose}
+                    />
+                  </div>
+                </SheetContent>
+              </Sheet>
+            )}
           </div>
 
           <div className="flex flex-col md:flex-row justify-between items-start gap-4 mb-4">
@@ -266,6 +286,7 @@ export default function PatientIdentifierConfigList({
                 <PatientIdentifierConfigCard
                   key={config.id}
                   config={config}
+                  canEdit={canWrite}
                   onEdit={handleEdit}
                 />
               ))}
@@ -303,14 +324,16 @@ export default function PatientIdentifierConfigList({
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleEdit(config)}
-                          >
-                            <CareIcon icon="l-edit" className="size-4" />
-                            {t("edit")}
-                          </Button>
+                          {canWrite && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleEdit(config)}
+                            >
+                              <CareIcon icon="l-edit" className="size-4" />
+                              {t("edit")}
+                            </Button>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/types/emr/patient/patient.ts
+++ b/src/types/emr/patient/patient.ts
@@ -1,7 +1,10 @@
 import { Permissions } from "@/types/emr/permission/permission";
 import { TagConfig } from "@/types/emr/tagConfig/tagConfig";
 import { Organization } from "@/types/organization/organization";
-import { PatientIdentifier } from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
+import {
+  PatientIdentifier,
+  PatientIdentifierUse,
+} from "@/types/patient/patientIdentifierConfig/patientIdentifierConfig";
 import { UserReadMinimal } from "@/types/user/user";
 
 export enum BloodGroupChoices {
@@ -98,6 +101,48 @@ export function getPartialId(patient: PartialPatientModel | PatientListRead) {
     return patient.partial_id;
   }
   return patient.id.slice(0, 5);
+}
+
+/**
+ * Identifiers to display for a patient: instance-level ones followed by
+ * facility-level ones. Auto-maintained identifiers are never included.
+ *
+ * `facility_identifiers` is only populated by the backend when the patient was
+ * fetched with a facility in context (e.g. `?facility=<id>`), so callers that
+ * need facility identifiers must fetch the patient that way.
+ *
+ * The backend can list the same config in both arrays (its instance cache is
+ * not filtered by facility), so entries are de-duplicated by config id.
+ */
+export function getPatientIdentifiers(
+  patient:
+    | Partial<
+        Pick<PatientRead, "instance_identifiers" | "facility_identifiers">
+      >
+    | PatientListRead
+    | PublicPatientRead
+    | null
+    | undefined,
+  options: { use?: PatientIdentifierUse } = {},
+): PatientIdentifier[] {
+  if (!patient) return [];
+  const instanceIdentifiers =
+    "instance_identifiers" in patient
+      ? (patient.instance_identifiers ?? [])
+      : [];
+  const facilityIdentifiers =
+    "facility_identifiers" in patient
+      ? (patient.facility_identifiers ?? [])
+      : [];
+  const byConfigId = new Map<string, PatientIdentifier>();
+  for (const identifier of [...instanceIdentifiers, ...facilityIdentifiers]) {
+    byConfigId.set(identifier.config.id, identifier);
+  }
+  return [...byConfigId.values()].filter(
+    ({ config }) =>
+      !config.config.auto_maintained &&
+      (!options.use || config.config.use === options.use),
+  );
 }
 
 export interface PublicPatientRead {

--- a/tests/facility/patient/patientDetails/facilityIdentifierDisplay.spec.ts
+++ b/tests/facility/patient/patientDetails/facilityIdentifierDisplay.spec.ts
@@ -22,6 +22,10 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 }
 
 test.describe("Facility Patient Identifier - Display", () => {
+  // Both tests share one identifier created in beforeAll; run them in a single
+  // worker so parallel workers don't race on the same patient's identifiers.
+  test.describe.configure({ mode: "serial" });
+
   let facilityId: string;
   let patientId: string;
   let encounterId: string;

--- a/tests/facility/patient/patientDetails/facilityIdentifierDisplay.spec.ts
+++ b/tests/facility/patient/patientDetails/facilityIdentifierDisplay.spec.ts
@@ -1,0 +1,85 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import { getApiHeaders, getApiUrl } from "tests/helper/utils";
+import { getEncounterId } from "tests/support/encounterId";
+import { getFacilityId } from "tests/support/facilityId";
+import { getPatientId } from "tests/support/patientId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${getApiUrl()}${path}`, {
+    method: "POST",
+    headers: getApiHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `POST ${path} failed: ${response.status} — ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+test.describe("Facility Patient Identifier - Display", () => {
+  let facilityId: string;
+  let patientId: string;
+  let encounterId: string;
+  let displayName: string;
+  let value: string;
+
+  test.beforeAll(async () => {
+    facilityId = getFacilityId();
+    patientId = getPatientId();
+    encounterId = getEncounterId();
+    displayName = `Facility MRN ${faker.string.alphanumeric(6)}`;
+    value = faker.string.alphanumeric(10).toUpperCase();
+
+    // Create a facility-level identifier config and set a value for the patient.
+    const config = await post<{ id: string }>(
+      "/api/v1/patient_identifier_config/",
+      {
+        facility: facilityId,
+        status: "active",
+        config: {
+          use: "official",
+          description: "Facility level identifier",
+          system: `https://example.org/${faker.string.uuid()}`,
+          required: false,
+          unique: false,
+          regex: "",
+          display: displayName,
+          retrieve_config: {
+            retrieve_with_dob: false,
+            retrieve_with_year_of_birth: false,
+            retrieve_with_otp: false,
+          },
+        },
+      },
+    );
+    await post(`/api/v1/patient/${patientId}/update_identifier/`, {
+      config: config.id,
+      value,
+    });
+  });
+
+  test("shows the facility identifier on the patient profile", async ({
+    page,
+  }) => {
+    await page.goto(`/facility/${facilityId}/patient/${patientId}/demography`);
+
+    await expect(page.getByText(displayName).first()).toBeVisible();
+    await expect(page.getByText(value).first()).toBeVisible();
+  });
+
+  test("shows the facility identifier in the encounter header", async ({
+    page,
+  }) => {
+    await page.goto(
+      `/facility/${facilityId}/patient/${patientId}/encounter/${encounterId}/updates`,
+    );
+
+    await expect(page.getByText(displayName).first()).toBeVisible();
+    await expect(page.getByText(value).first()).toBeVisible();
+  });
+});

--- a/tests/facility/settings/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
+++ b/tests/facility/settings/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts
@@ -1,0 +1,102 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import { getFacilityId } from "tests/support/facilityId";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Facility Patient Identifier Config - Create", () => {
+  let facilityId: string;
+  let displayName: string;
+  let description: string;
+  let systemUrl: string;
+
+  test.beforeEach(async ({ page }) => {
+    facilityId = getFacilityId();
+    displayName = faker.lorem.words(2);
+    description = faker.lorem.sentence();
+    systemUrl = faker.internet.url();
+
+    await page.goto(
+      `/facility/${facilityId}/settings/patient_identifier_config`,
+    );
+  });
+
+  test("should create a facility-level patient identifier config", async ({
+    page,
+  }) => {
+    await test.step("Open the create form", async () => {
+      await page
+        .getByRole("button", { name: "Add patient identifier config" })
+        .click();
+    });
+
+    await test.step("Fill and submit the form", async () => {
+      await page.getByRole("combobox").filter({ hasText: "usual" }).click();
+      await page.getByRole("option", { name: "official" }).click();
+
+      await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+      await page
+        .getByRole("textbox", { name: "Description" })
+        .fill(description);
+      await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+
+      await page.getByRole("combobox").filter({ hasText: "Draft" }).click();
+      await page.getByRole("option", { name: "Active", exact: true }).click();
+
+      await page.getByRole("button", { name: "Create" }).click();
+    });
+
+    await test.step("Verify the config is listed for the facility", async () => {
+      await page
+        .getByRole("textbox", { name: "Search configs" })
+        .fill(displayName);
+
+      const tableBody = page.locator('[data-slot="table-body"]');
+      await expect(tableBody).toContainText(displayName);
+      await expect(tableBody).toContainText(systemUrl);
+      await expect(tableBody).toContainText("official");
+      await expect(tableBody).toContainText("Active");
+    });
+
+    await test.step("Verify the config is not listed at instance level", async () => {
+      await page.goto("/admin/patient_identifier_config");
+      await page
+        .getByRole("textbox", { name: "Search configs" })
+        .fill(displayName);
+      await expect(page.getByText("No configs found")).toBeVisible();
+    });
+  });
+
+  test("should not allow a system already used at instance level", async ({
+    page,
+  }) => {
+    await test.step("Read an instance-level system URL", async () => {
+      await page.goto("/admin/patient_identifier_config");
+      const firstRow = page.locator('[data-slot="table-body"] tr').first();
+      await expect(firstRow).toBeVisible();
+      systemUrl = (await firstRow.locator("td").nth(1).innerText()).trim();
+      expect(systemUrl).not.toBe("");
+    });
+
+    await test.step("Try to reuse it for the facility", async () => {
+      await page.goto(
+        `/facility/${facilityId}/settings/patient_identifier_config`,
+      );
+      await page
+        .getByRole("button", { name: "Add patient identifier config" })
+        .click();
+      await page.getByRole("textbox", { name: "Display" }).fill(displayName);
+      await page
+        .getByRole("textbox", { name: "Description" })
+        .fill(description);
+      await page.getByRole("textbox", { name: "System" }).fill(systemUrl);
+      await page.getByRole("button", { name: "Create" }).click();
+
+      await expect(
+        page.getByText(
+          "A patient identifier config with this system already exists",
+        ),
+      ).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Facility-level patient identifier configs already existed on the backend (`patient_identifier_config` with a `facility`, and `facility_identifiers` on the patient retrieve payload when a facility is in context), but the frontend only ever rendered `instance_identifiers` and the facility settings page for the config was wired but hidden. This PR:

**Display**
- Adds `getPatientIdentifiers(patient, { use? })` in `src/types/emr/patient/patient.ts`, which returns instance identifiers followed by facility identifiers, excludes auto-maintained ones, and optionally filters by `use`.
- Switches every place that rendered `instance_identifiers` to the helper, so facility identifiers now show alongside instance ones with the same filtering each site already used: patient header, patient info hover card, demography tab, encounter summary panel, appointment token card / print / print list, prescription preview, questionnaire responses print, dispense order print, medication return print, diagnostic report print, charge items print, payment reconciliation print, invoice show / print / bulk print.
- `PrintInvoices` now passes `facility` when verifying patients so the response includes facility identifiers (the single-invoice pages already did).

**Configuration**
- Enables the `Settings → Patient Identifier Config` link for facilities, gated on `can_read_patient_identifier_config`.
- Adds `canReadPatientIdentifierConfig` / `canWritePatientIdentifierConfig` to `Permissions.tsx`.
- The shared config list hides Add/Edit for facility users without `can_write_patient_identifier_config` (the backend rejects those writes).

**Tests**
- `tests/facility/settings/patientIdentifierConfig/patientIdentifierConfigCreate.spec.ts`: creates a facility-level config through the UI, checks it is listed for the facility and not at instance level, and that an instance-level system cannot be reused.
- `tests/facility/patient/patientDetails/facilityIdentifierDisplay.spec.ts`: creates a facility config and value via API and asserts it renders on the patient profile and encounter header.

## Notes

- Nested patient payloads only carry `facility_identifiers` when the backend serializer passes a facility. Encounter, account, diagnostic report, service request, booking and payment reconciliation already do; the dispense order retrieve serializer does not, which is fixed in the companion backend PR (https://github.com/ohcnetwork/care/pull/3750). Delivery orders embed the patient list spec, which has no identifiers at all, so the medication return print keeps its existing behaviour there.
- Entering values for facility identifiers still has no UI (patient registration only handles instance-level identifiers); this PR covers display and configuration as requested.

## Verification

- `npx tsc --noEmit`, `eslint` on changed files, `npm run build`: clean.
- Playwright (local backend): the two new specs plus `tests/admin/patientIdentifierConfig/*` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added facility-level patient identifier configuration with permission-based viewing, creation, and editing controls.
  * Patient identifiers now appear consistently across patient profiles, encounter views, appointments, prescriptions, billing, and printed documents.
  * Official and facility-configured identifiers can be displayed together where applicable.
* **Bug Fixes**
  * Improved identifier handling to combine and de-duplicate identifiers consistently across screens.
  * Added validation to prevent duplicate identifier systems across instance and facility configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->