### PR TITLE
[ENG-999] fix: multiselct on iPhone and improve styling

### DIFF
--- a/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
+++ b/src/components/Questionnaire/QuestionTypes/QuestionInput.tsx
@@ -62,7 +62,7 @@ function InputWithNotes({
 
   return (
     <div className="flex items-stretch">
-      <div className="flex-1 min-w-0 [&_input]:border-r-0 [&_input]:rounded-r-none [&_input]:shadow-none [&_input]:focus-visible:ring-0 [&_textarea]:border-r-0 [&_textarea]:rounded-r-none [&_textarea]:shadow-none [&_textarea]:focus-visible:ring-0 [&_button[role=combobox]]:border-r-0 [&_button[role=combobox]]:rounded-r-none [&_button[role=combobox]]:shadow-none">
+      <div className="flex-1 min-w-0 [&_input]:border-r-0 [&_input]:rounded-r-none [&_input]:shadow-none [&_input]:focus-visible:ring-0 [&_textarea]:border-r-0 [&_textarea]:rounded-r-none [&_textarea]:shadow-none [&_textarea]:focus-visible:ring-0 [&_button[role=combobox]]:border-r-0 [&_button[role=combobox]]:rounded-r-none [&_button[role=combobox]]:shadow-none [&_button[role=combobox]+button]:border-r-0 [&_button[role=combobox]+button]:rounded-r-none [&_button[role=combobox]+button]:shadow-none">
         {children}
       </div>
       <Popover open={notesOpen} onOpenChange={setNotesOpen}>

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -212,14 +212,14 @@ export default function Autocomplete({
               role="combobox"
               aria-expanded={open}
               className={cn(
-                "w-full truncate justify-between border-gray-300 shadow-xs py-4.5! font-normal",
+                "w-full min-w-0 justify-between border-gray-300 shadow-xs py-4.5! font-normal",
                 className,
                 selectedOption && "rounded-r-none",
               )}
               disabled={disabled}
               type="button"
             >
-              <span className="overflow-hidden">
+              <span className="overflow-hidden truncate">
                 {value
                   ? freeInput
                     ? inputValue || value

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -212,7 +212,7 @@ export default function Autocomplete({
               role="combobox"
               aria-expanded={open}
               className={cn(
-                "w-full justify-between border-gray-300 shadow-xs py-4.5! font-normal",
+                "w-full truncate justify-between border-gray-300 shadow-xs py-4.5! font-normal",
                 className,
                 selectedOption && "rounded-r-none",
               )}
@@ -245,7 +245,7 @@ export default function Autocomplete({
           <Button
             variant="outline"
             size="icon"
-            className="rounded-l-none border-l-0 text-gray-400 h-auto"
+            className="rounded-l-none border-l-0 text-gray-400 border-gray-300 shadow-none h-auto"
             onClick={handleClear}
             title={t("clear")}
             hidden={disabled}
@@ -304,7 +304,7 @@ export default function Autocomplete({
         <Button
           variant="outline"
           size="icon"
-          className="rounded-l-none border-l-0 text-gray-400 h-auto"
+          className="rounded-l-none border-l-0 text-gray-400 border-gray-300 shadow-none h-auto"
           onClick={handleClear}
           title={t("clear")}
           hidden={disabled}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -230,7 +230,7 @@ export default function Autocomplete({
           </DrawerTrigger>
           <DrawerContent
             aria-describedby={undefined}
-            className="min-h-[50vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
+            className="min-h-[65vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
           >
             <DrawerTitle className="sr-only">
               {t("autocomplete_options")}

--- a/src/components/ui/autocomplete.tsx
+++ b/src/components/ui/autocomplete.tsx
@@ -231,7 +231,7 @@ export default function Autocomplete({
           </DrawerTrigger>
           <DrawerContent
             aria-describedby={undefined}
-            className="min-h-[65vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
+            className="min-h-[50vh] max-h-[85vh] px-0 pt-2 pb-0 rounded-t-lg"
           >
             <DrawerTitle className="sr-only">
               {t("autocomplete_options")}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -25,7 +25,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import useBreakpoints from "@/hooks/useBreakpoints";
-import { isIOSDevice } from "@/Utils/utils";
 
 type ButtonProps = Omit<
   React.ComponentProps<typeof Button>,
@@ -92,7 +91,7 @@ function ListContent({
                 : t("search_options")
             }
             className="outline-hidden text-base sm:text-sm border-none ring-0 shadow-none -ml-3"
-            autoFocus={!isIOSDevice}
+            autoFocus
           />
         </div>
         <CommandList className="max-h-none">
@@ -258,7 +257,7 @@ export function MultiSelect({
               </div>
             </Button>
           </DrawerTrigger>
-          <DrawerContent className="px-0 pt-2 flex flex-col min-h-[60vh]">
+          <DrawerContent className="px-0 pt-2 flex flex-col min-h-[65vh]">
             <div className="mt-3 pb-[env(safe-area-inset-bottom)] flex flex-col flex-1 overflow-hidden">
               <ListContent
                 translationBasekey={translationBasekey}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -25,6 +25,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import useBreakpoints from "@/hooks/useBreakpoints";
+import { isIOSDevice } from "@/Utils/utils";
 
 type ButtonProps = Omit<
   React.ComponentProps<typeof Button>,
@@ -91,7 +92,7 @@ function ListContent({
                 : t("search_options")
             }
             className="outline-hidden text-base sm:text-sm border-none ring-0 shadow-none -ml-3"
-            autoFocus
+            autoFocus={!isIOSDevice}
           />
         </div>
         <CommandList className="max-h-none">
@@ -257,7 +258,7 @@ export function MultiSelect({
               </div>
             </Button>
           </DrawerTrigger>
-          <DrawerContent className="px-0 pt-2 flex flex-col min-h-[65vh]">
+          <DrawerContent className="px-0 pt-2 flex flex-col min-h-[50vh] max-h-[85vh]">
             <div className="mt-3 pb-[env(safe-area-inset-bottom)] flex flex-col flex-1 overflow-hidden">
               <ListContent
                 translationBasekey={translationBasekey}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -25,6 +25,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import useBreakpoints from "@/hooks/useBreakpoints";
+import { isIOSDevice } from "@/Utils/utils";
 
 type ButtonProps = Omit<
   React.ComponentProps<typeof Button>,
@@ -90,8 +91,8 @@ function ListContent({
                 ? t(`search_${translationBasekey}`)
                 : t("search_options")
             }
-            className="outline-hidden border-none ring-0 shadow-none -ml-3"
-            autoFocus
+            className="outline-hidden text-base sm:text-sm border-none ring-0 shadow-none -ml-3"
+            autoFocus={!isIOSDevice}
           />
         </div>
         <CommandList className="max-h-none">
@@ -257,7 +258,7 @@ export function MultiSelect({
               </div>
             </Button>
           </DrawerTrigger>
-          <DrawerContent className="px-0 pt-2 flex flex-col h-[50vh]">
+          <DrawerContent className="px-0 pt-2 flex flex-col min-h-[60vh]">
             <div className="mt-3 pb-[env(safe-area-inset-bottom)] flex flex-col flex-1 overflow-hidden">
               <ListContent
                 translationBasekey={translationBasekey}


### PR DESCRIPTION
## Proposed Changes
fixes few things missed in https://github.com/ohcnetwork/care_fe/pull/16754
fixes: ENG-999

**Before**
<img width="360" height="271" alt="image" src="https://github.com/user-attachments/assets/223da7c4-872b-4ca2-ad64-34bd7d465a5c" />
<img width="301" height="556" alt="phone" src="https://github.com/user-attachments/assets/5569c590-787c-4073-bacd-58b9ce34f292" />



**After**
<img width="360" height="271" alt="image" src="https://github.com/user-attachments/assets/57599418-1465-4ea1-b28e-d320071ce7fd" />
<img width="301" height="541" alt="phone" src="https://github.com/user-attachments/assets/ec4d8093-0420-4bc2-8c13-354382a1ac9b" />




Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate the bug or test the new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved combobox and adjacent button styling for a more seamless appearance.
  * Updated autocomplete clear buttons with gray borders and reduced visual effects.
  * Improved mobile autocomplete text handling to prevent overflow.
  * Added responsive text sizing to multi-select inputs for improved readability across screen sizes.
  * Made mobile drawers more flexible, with 50–85vh height limits.

* **Bug Fixes**
  * Disabled automatic input focus on iOS to provide a smoother mobile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->