### PR TITLE
test(billing): make invoice creation spec test real behavior

### DIFF
--- a/tests/facility/billing/invoiceCreation.spec.ts
+++ b/tests/facility/billing/invoiceCreation.spec.ts
@@ -33,4 +33,60 @@ test.describe("Invoice Creation", () => {
       page.getByRole("button", { name: /create invoice/i }),
     ).toBeDisabled();
   });
+
+  test("should render the account invoices tab", async ({ page }) => {
+    await page.goto(
+      `/facility/${facilityId}/billing/account/${accountId}/invoices`,
+    );
+
+    // The invoices tab owns the invoice search box.
+    await expect(
+      page.getByRole("textbox", { name: /search invoices/i }),
+    ).toBeVisible();
+  });
+
+  test("should render the account charge items tab", async ({ page }) => {
+    await page.goto(
+      `/facility/${facilityId}/billing/account/${accountId}/charge_items`,
+    );
+
+    // "Print charge items" is always rendered by the charge items tab.
+    await expect(
+      page.getByRole("button", { name: /print charge items/i }),
+    ).toBeVisible();
+  });
+
+  test("should render the account payments tab", async ({ page }) => {
+    await page.goto(
+      `/facility/${facilityId}/billing/account/${accountId}/payments`,
+    );
+
+    // Genuine either/or: the payments tab shows its empty state when there are
+    // no reconciliations, or the payments table when there are.
+    await expect(
+      page
+        .getByText(/no payments/i)
+        .or(page.getByRole("table"))
+        .first(),
+    ).toBeVisible();
+  });
+
+  test("should render the facility invoices list", async ({ page }) => {
+    await page.goto(`/facility/${facilityId}/billing/invoices`);
+
+    await expect(
+      page.getByRole("heading", { name: /invoice management/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: /search invoices/i }),
+    ).toBeVisible();
+  });
+
+  test("should render the facility payments list", async ({ page }) => {
+    await page.goto(`/facility/${facilityId}/billing/payments`);
+
+    await expect(
+      page.getByRole("heading", { name: /payment reconciliations/i }),
+    ).toBeVisible();
+  });
 });

--- a/tests/facility/billing/invoiceCreation.spec.ts
+++ b/tests/facility/billing/invoiceCreation.spec.ts
@@ -13,79 +13,24 @@ test.describe("Invoice Creation", () => {
     accountId = getAccountId();
   });
 
-  test("should open the invoice creation form from an active account", async ({
+  test("opens the create-invoice form and blocks submission until an item is billable", async ({
     page,
   }) => {
     await page.goto(`/facility/${facilityId}/billing/account/${accountId}`);
 
-    // The fixture account is active and billable, so the create-invoice action
-    // must be offered. If it's missing (e.g. the account was closed elsewhere),
-    // this fails loudly — which is exactly the regression worth catching.
-    const createInvoice = page.getByRole("button", {
-      name: /create invoice/i,
-    });
-    await expect(createInvoice).toBeVisible();
-    await createInvoice.click();
-
+    // Real user entry point into invoice creation.
+    await page.getByRole("button", { name: /create invoice/i }).click();
     await page.waitForURL(/\/invoices\/create$/);
-    await expect(page).toHaveURL(/\/invoices\/create$/);
-    // A fresh draft invoice is what the create form opens.
+
+    // The create form opens a fresh draft.
     await expect(page.getByText("Draft", { exact: true })).toBeVisible();
-  });
 
-  test("should render the account invoices tab", async ({ page }) => {
-    await page.goto(
-      `/facility/${facilityId}/billing/account/${accountId}/invoices`,
-    );
-
-    // The invoices tab owns the invoice search box.
+    // The account has no billable charge items, so the form shows its empty
+    // state and keeps the submit button disabled — the real guard that stops
+    // empty invoices from being created.
+    await expect(page.getByText(/no billable items found/i)).toBeVisible();
     await expect(
-      page.getByRole("textbox", { name: /search invoices/i }),
-    ).toBeVisible({ timeout: 10000 });
-  });
-
-  test("should render the account charge items tab", async ({ page }) => {
-    await page.goto(
-      `/facility/${facilityId}/billing/account/${accountId}/charge_items`,
-    );
-
-    // "Print charge items" is always rendered by the charge items tab.
-    await expect(
-      page.getByRole("button", { name: /print charge items/i }),
-    ).toBeVisible({ timeout: 10000 });
-  });
-
-  test("should render the account payments tab", async ({ page }) => {
-    await page.goto(
-      `/facility/${facilityId}/billing/account/${accountId}/payments`,
-    );
-
-    // Genuine either/or: the payments tab shows its empty state when there are
-    // no reconciliations, or the payments table when there are.
-    await expect(
-      page
-        .getByText(/no payments/i)
-        .or(page.getByRole("table"))
-        .first(),
-    ).toBeVisible({ timeout: 10000 });
-  });
-
-  test("should render the facility invoices list", async ({ page }) => {
-    await page.goto(`/facility/${facilityId}/billing/invoices`);
-
-    await expect(
-      page.getByRole("heading", { name: /invoice management/i }),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(
-      page.getByRole("textbox", { name: /search invoices/i }),
-    ).toBeVisible();
-  });
-
-  test("should render the facility payments list", async ({ page }) => {
-    await page.goto(`/facility/${facilityId}/billing/payments`);
-
-    await expect(
-      page.getByRole("heading", { name: /payment reconciliations/i }),
-    ).toBeVisible({ timeout: 10000 });
+      page.getByRole("button", { name: /create invoice/i }),
+    ).toBeDisabled();
   });
 });

--- a/tests/facility/billing/invoiceCreation.spec.ts
+++ b/tests/facility/billing/invoiceCreation.spec.ts
@@ -25,9 +25,17 @@ test.describe("Invoice Creation", () => {
     // The create form opens a fresh draft.
     await expect(page.getByText("Draft", { exact: true })).toBeVisible();
 
-    // The account has no billable charge items, so the form shows its empty
-    // state and keeps the submit button disabled — the real guard that stops
-    // empty invoices from being created.
+    // Wait for the charge-items fetch to settle before asserting the guard:
+    // while loading, the form renders a skeleton, so the empty state and the
+    // disabled button below would otherwise pass on the first paint. The table
+    // column headers only render once the query resolves.
+    await expect(
+      page.getByRole("columnheader", { name: /actions/i }),
+    ).toBeVisible();
+
+    // With the fetch settled and no billable charge items, the form shows its
+    // empty state and keeps the submit button disabled — the real guard that
+    // stops empty invoices from being created.
     await expect(page.getByText(/no billable items found/i)).toBeVisible();
     await expect(
       page.getByRole("button", { name: /create invoice/i }),


### PR DESCRIPTION
Stacked on top of #15970.

## What
Strengthens the invoice-creation entry test in `tests/facility/billing/invoiceCreation.spec.ts` and cleans up redundant timeouts, without removing the existing page-render coverage.

## Changes
- **Reworked the first test** (`opens the create-invoice form and blocks submission until an item is billable`): clicks **Create Invoice** on the account → lands on the real create form → asserts a fresh `Draft`, then asserts the **empty-invoice guard** (no billable items ⇒ `No Billable Items Found` + submit button disabled). Dropped the redundant pre-click `toBeVisible` on the same button.
- **Guard anchors on the loaded state**: waits for the charge-items table header (only rendered post-fetch) before the empty-state/disabled assertions, so the guard can't pass on the loading skeleton and correctly fails if the account actually had billable items.
- **Removed redundant `{ timeout: 10000 }`** args across the file — they duplicated the global `expect` timeout in `playwright.config.ts`.

## Kept (unchanged behavior)
The five `should render the ...` page-load smoke tests (account invoices / charge-items / payments tabs, facility invoices + payments lists) are retained for basic route-render coverage.

## Not included (intentional)
Full submit-and-persist coverage is out of scope: the shared fixture account is created empty, so creating an invoice would require seeding a billable charge item (fixture expansion). Left as a follow-up.