### PR TITLE
test(diagnostic-reports): trim to one reliable tab-render test

### DIFF
--- a/tests/facility/patient/encounter/diagnosticReports/encounterDiagnosticReports.spec.ts
+++ b/tests/facility/patient/encounter/diagnosticReports/encounterDiagnosticReports.spec.ts
@@ -8,37 +8,12 @@ test.describe("Encounter Diagnostic Reports Tab", () => {
     await openFixtureEncounter(page);
   });
 
-  test("should display the diagnostic reports tab with its empty state", async ({
-    page,
-  }) => {
+  test("should open the diagnostic reports tab", async ({ page }) => {
     await page.getByRole("tab", { name: "Diagnostic Reports" }).click();
     await expect(page).toHaveURL(/\/diagnostic_reports$/);
 
     await expect(
       page.getByRole("tabpanel", { name: "Diagnostic Reports" }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("heading", { name: "No Diagnostic Reports Found" }),
-    ).toBeVisible();
-  });
-
-  test("should navigate to diagnostic reports from the tab bar", async ({
-    page,
-  }) => {
-    const tab = page.getByRole("tab", { name: "Diagnostic Reports" });
-    await expect(tab).toBeVisible();
-    await tab.click();
-
-    await expect(page).toHaveURL(/\/diagnostic_reports$/);
-  });
-
-  test("should render the responses tab without errors", async ({ page }) => {
-    await page.getByRole("tab", { name: "Responses" }).click();
-    await expect(page).toHaveURL(/\/responses$/);
-
-    await expect(
-      page.getByRole("tabpanel", { name: "Responses" }),
-    ).toBeVisible();
-    await expect(page.getByText(/something went wrong/i)).toBeHidden();
   });
 });


### PR DESCRIPTION
Stacked on top of #15970.

## Problem
`encounterDiagnosticReports.spec.ts` had 3 tests with issues:
1. **Flaky empty-state** — asserted `No Diagnostic Reports Found` on the shared fixture encounter (`getEncounterId()`), but `ServiceRequestCreate.spec.ts` *creates a diagnostic report in that same encounter*. Non-deterministic file order ⇒ this assertion fails when that spec runs first.
2. **Redundant navigation test** — `should navigate to diagnostic reports from the tab bar` just re-did the click+URL assertion already covered by test 1.
3. **Misplaced/weak test** — `should render the responses tab without errors` tested the **Responses** tab (not diagnostic reports) with a hollow `something went wrong` is-hidden assertion.

## Change
Trimmed to a single reliable test: the Diagnostic Reports tab opens (`/diagnostic_reports`) and its tabpanel renders. No dependency on consent/report count, so it coexists with `ServiceRequestCreate` (which already covers real diagnostic-report creation end-to-end).

Net: 3 tests → 1, removing a latent flake and two low-value tests.