### PR TITLE
test(observations): trim observations spec + relocate cross-tab nav test

### DIFF
--- a/tests/facility/patient/encounter/encounterTabs.spec.ts
+++ b/tests/facility/patient/encounter/encounterTabs.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { openFixtureEncounter } from "tests/helper/ui";
+
+test.use({ storageState: "tests/.auth/user.json" });
+
+test.describe("Encounter Tabs Navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await openFixtureEncounter(page);
+  });
+
+  test("should navigate between encounter tabs without errors", async ({
+    page,
+  }) => {
+    const tabs: [string, RegExp][] = [
+      ["Observations", /\/observations$/],
+      ["Medicines", /\/medicines$/],
+      ["Service Requests", /\/service_requests$/],
+      ["Files", /\/files$/],
+      ["Notes", /\/notes$/],
+      ["Overview", /\/updates$/],
+    ];
+    for (const [tabName, url] of tabs) {
+      await page.getByRole("tab", { name: tabName }).click();
+      await expect(page).toHaveURL(url);
+      await expect(page.getByText(/something went wrong/i)).toBeHidden();
+    }
+  });
+});

--- a/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
+++ b/tests/facility/patient/encounter/observations/encounterObservations.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { expectToast, openFixtureEncounter } from "tests/helper/ui";
+import { openFixtureEncounter } from "tests/helper/ui";
 
 test.use({ storageState: "tests/.auth/user.json" });
 
@@ -15,59 +15,5 @@ test.describe("Encounter Observations Tab", () => {
     await expect(
       page.getByRole("tabpanel", { name: "Observations" }),
     ).toBeVisible();
-  });
-
-  test("should add a symptom via the encounter actions command palette", async ({
-    page,
-  }) => {
-    // NOTE: this test mutates the shared fixture encounter (adds a symptom
-    // observation). It is intentionally NOT run in serial mode: no other test in
-    // this file asserts an empty observations state, so the mutation can't race a
-    // sibling, and cross-run state is reset by the DB snapshot restore.
-    await page
-      .getByRole("button", { name: /encounter actions/i })
-      .first()
-      .click();
-
-    const palette = page.getByRole("dialog", { name: "Command Palette" });
-    await expect(palette).toBeVisible();
-    await palette.getByRole("option", { name: /add symptom/i }).click();
-
-    await page.waitForURL(/\/questionnaire/);
-
-    const combobox = page
-      .getByRole("combobox")
-      .filter({ hasText: /add symptom|add another symptom/i });
-    await combobox.scrollIntoViewIfNeeded();
-    await combobox.click();
-
-    const search = page.getByPlaceholder(/Add (another )?Symptom/i);
-    await search.waitFor({ state: "visible" });
-    await search.fill("Headache");
-    await page
-      .getByRole("option", { name: /headache/i })
-      .first()
-      .click();
-
-    await page.getByRole("button", { name: "Submit", exact: true }).click();
-    await expectToast(page, "Questionnaire submitted successfully");
-  });
-
-  test("should navigate between encounter tabs without errors", async ({
-    page,
-  }) => {
-    const tabs: [string, RegExp][] = [
-      ["Observations", /\/observations$/],
-      ["Medicines", /\/medicines$/],
-      ["Service Requests", /\/service_requests$/],
-      ["Files", /\/files$/],
-      ["Notes", /\/notes$/],
-      ["Overview", /\/updates$/],
-    ];
-    for (const [tabName, url] of tabs) {
-      await page.getByRole("tab", { name: tabName }).click();
-      await expect(page).toHaveURL(url);
-      await expect(page.getByText(/something went wrong/i)).toBeHidden();
-    }
   });
 });


### PR DESCRIPTION
Stacked on top of #15970.

## Changes

### 1. Trim `encounterObservations.spec.ts` to one reliable test
- **Dropped** `add a symptom via the encounter actions command palette` — the symptom questionnaire flow is already covered thoroughly by `structuredQuestions/symptom.spec.ts`, and symptoms aren't measurement observations, so it never populated the Observations tab anyway.
- **Kept** one test: the Observations tab opens (`/observations`) and its tabpanel renders. (Value-in-tab verification is intentionally out of scope — current forms don't surface data into this tab, so there's no deterministic value to assert. Observation value creation+display is covered by `forms/formSubmissionAndDisplay.spec.ts`.)

### 2. Relocate the cross-tab navigation test to its own spec
- **Moved** `navigate between encounter tabs without errors` out of the observations file into a new general `encounterTabs.spec.ts`. It's not observations-specific — it's a cross-tab crash guard (Observations, Medicines, Service Requests, Files, Notes, Overview: each routes and doesn't hit the error boundary). Relocating makes it discoverable as what it is.

Net: observations spec 3 → 1 test; the useful cross-tab smoke test is preserved in a correctly-named home.