### PR TITLE
Remove vite-plugin-checker from the dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,6 @@
         "typescript": "^6.0.3",
         "uuid": "^14.0.0",
         "vite": "^8.0.14",
-        "vite-plugin-checker": "^0.14.1",
         "vite-plugin-pwa": "^1.3.0"
       },
       "optionalDependencies": {
@@ -6060,6 +6059,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -7303,20 +7362,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/class-variance-authority": {
@@ -10869,32 +10914,6 @@
       "version": "1.0.1",
       "license": "BSD-3-Clause"
     },
-    "node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -11485,21 +11504,6 @@
       "version": "16.13.1",
       "license": "MIT"
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -11859,18 +11863,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/recharts": {
       "version": "3.9.2",
       "license": "MIT",
@@ -12081,14 +12073,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/rfdc": {
@@ -13291,17 +13275,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "dev": true,
@@ -13550,60 +13523,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-checker": {
-      "version": "0.14.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "chokidar": "^5.0.0",
-        "npm-run-path": "^6.0.0",
-        "picocolors": "^1.1.1",
-        "picomatch": "^4.0.4",
-        "proper-lockfile": "^4.1.2",
-        "tiny-invariant": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@biomejs/biome": ">=2.4.12",
-        "eslint": ">=9.39.4",
-        "meow": "^13.2.0 || ^14.0.0",
-        "optionator": "^0.9.4",
-        "oxlint": ">=1",
-        "stylelint": ">=16.26.1",
-        "typescript": "*",
-        "vite": ">=5.4.21",
-        "vue-tsc": "~2.2.10 || ^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@biomejs/biome": {
-          "optional": true
-        },
-        "eslint": {
-          "optional": true
-        },
-        "meow": {
-          "optional": true
-        },
-        "optionator": {
-          "optional": true
-        },
-        "oxlint": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "typescript": "^6.0.3",
     "uuid": "^14.0.0",
     "vite": "^8.0.14",
-    "vite-plugin-checker": "^0.14.1",
     "vite-plugin-pwa": "^1.3.0"
   },
   "optionalDependencies": {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -15,7 +15,6 @@ import DOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import { marked } from "marked";
 import path from "path";
-import checker from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
 import { autoRegisterComponents } from "./plugins/autoRegisterComponents";
 import { careConsoleArt } from "./plugins/careConsoleArt";
@@ -452,17 +451,6 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
         ],
       }),
       react(),
-      checker({
-        typescript: true,
-        eslint: {
-          useFlatConfig: true,
-          lintCommand: "eslint ./src",
-          dev: {
-            logLevel: ["error"],
-          },
-        },
-        enableBuild: false,
-      }),
       treeShakeCareIcons({
         iconWhitelist: ["default"],
       }),


### PR DESCRIPTION
Removes `vite-plugin-checker`, which ran `tsc` and a type-aware ESLint program inside the dev server process and kept both resident for the whole session.

Dev server RSS, measured on this branch (same machine, same protocol — cold start, load `/` and `/src/index.tsx`, settle):

| | Dev server RSS |
| --- | --- |
| With `vite-plugin-checker` | 5486 MB |
| Without | 1686 MB |

Memory also grew over the life of a session rather than holding steady — a long-running dev server was observed climbing past 6.5 GB.

### Notes

Type and lint feedback is unchanged everywhere it is actually enforced: editor TS server, husky pre-commit hooks, and CI. The plugin was a fourth copy of checks already covered, and had `enableBuild: false`, so production builds are unaffected.

Run `npm run lint` or `npx tsc --noEmit` directly for a terminal check.

### Verification

- `npx tsc --noEmit` passes
- Dev server starts and serves `/` and `/src/index.tsx` (both 200), no checker output
- `vite-plugin-checker` fully removed from `package.json`, `package-lock.json` and `vite.config.mts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed development-time TypeScript and ESLint checking from the Vite configuration.
  * Removed the associated development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->