### PR TITLE
Add type check to CI

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate supported browsers
+        run: npm run supported-browsers
+
+      - name: Run type check
+        run: npm run typecheck
+
       - name: Run lint
         run: npm run lint -- --quiet
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "playwright:db-status": "bash scripts/playwright-db.sh status",
     "prepare": "husky",
     "lint": "eslint ./src",
+    "typecheck": "tsc --noEmit",
     "knip": "knip",
     "lint-fix": "eslint ./src --fix",
     "format": "prettier ./src ./tests --write",


### PR DESCRIPTION
> [!NOTE]
> - Follow up of #16788

Adds a `typecheck` script and runs it in the existing lint workflow on PRs to `develop`.

Nothing in CI was running `tsc`. The build transpiles via Rolldown without type checking, and `npm run build` is only invoked by the preview and Playwright workflows, so type errors could reach `develop` without failing a check. The one automated type check was `vite-plugin-checker` in the dev server, removed in #16788.

### Notes

Added to the existing `Lint Code Base` workflow rather than a new one, to reuse its `npm ci`. Runs before lint since it is faster, so failures surface sooner. CI only — not added to pre-commit hooks.

`npm run supported-browsers` runs first because `src/supportedBrowsers.ts` is generated and gitignored; without it `tsc` fails to resolve `@/supportedBrowsers`.

### Verification

Full workflow sequence run locally against current `develop`, all passing: `supported-browsers` → `typecheck` (0 errors, ~25s) → `lint` → `knip`.

Verified the generation step is required: without it, `tsc` fails with `TS2307: Cannot find module '@/supportedBrowsers'`.

