### PR TITLE
[ENG-1007] Adds support for plugins to define sub-queue actions

### DIFF
--- a/src/pages/Facility/queues/ManageServicePointSheet.tsx
+++ b/src/pages/Facility/queues/ManageServicePointSheet.tsx
@@ -25,6 +25,7 @@ import { Label } from "@/components/ui/label";
 import RadioInput from "@/components/ui/RadioInput";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { PLUGIN_Component } from "@/PluginEngine";
 import tokenSubQueueApi from "@/types/tokens/tokenSubQueue/tokenSubQueueApi";
 import mutate from "@/Utils/request/mutate";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -206,6 +207,11 @@ function SubQueueCard({
             </div>
 
             <Separator className="my-2" />
+            <PLUGIN_Component
+              __name="SubQueueActions"
+              facilityId={facilityId}
+              subQueue={subQueue}
+            />
             <div className="flex gap-2 justify-end">
               <Button variant="ghost" onClick={() => setEditSubQueue(false)}>
                 {t("cancel")}

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -12,6 +12,7 @@ import {
 } from "@/types/emr/patient/patient";
 import { FacilityRead } from "@/types/facility/facility";
 import { PlugConfigMeta } from "@/types/plugConfig";
+import { TokenSubQueueRead } from "@/types/tokens/tokenSubQueue/tokenSubQueue";
 import { UserReadMinimal } from "@/types/user/user";
 import { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { UseFormReturn } from "react-hook-form";
@@ -127,6 +128,13 @@ export type DeliveryOrderActionsComponentType = React.FC<{
   locationId: string;
 }>;
 
+// Extra actions contributed by plugins to a service point (sub queue) card,
+// rendered in the card's edit state alongside the built-in actions.
+export type SubQueueActionsComponentType = React.FC<{
+  facilityId: string;
+  subQueue: TokenSubQueueRead;
+}>;
+
 // Define supported plugin components
 export type SupportedPluginComponents = {
   DoctorConnectButtons: DoctorConnectButtonComponentType;
@@ -147,6 +155,7 @@ export type SupportedPluginComponents = {
   DiagnosticReportOverride: DiagnosticReportOverrideComponentType;
   PatientHomeQuickActions: PatientHomeActionsComponentType;
   DeliveryOrderActions: DeliveryOrderActionsComponentType;
+  SubQueueActions: SubQueueActionsComponentType;
 };
 
 // Create a type for lazy-loaded components


### PR DESCRIPTION
## Proposed Changes

- ENG-1007

<img width="643" height="429" alt="image" src="https://github.com/user-attachments/assets/e9702d46-5096-4e22-9858-854c1b42a1fd" />


Tagging: @ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [x] Add specs that demonstrate the bug or test the new feature.
- [x] Update [product documentation](https://docs.ohc.network).
- [x] Ensure that UI text is placed in I18n files.
- [x] Prepare a screenshot or demo video for the changelog entry and attach it to the issue.
- [x] Request peer reviews.
- [x] Complete QA on mobile devices.
- [x] Complete QA on desktop devices.
- [ ] Add or update Playwright tests for related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom actions when editing service-point sub-queues.
  * Plugin-provided sub-queue actions can now appear alongside the existing Cancel and Save controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->