### PR TITLE
Adds support for running vite-server using `portless`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,28 @@ Detailed guidance is split into focused files so agents only load what's relevan
 
 ## Quick Commands
 
-- `npm run dev` — Start dev server at http://localhost:4000
+- `portless` — **Preferred** way to start the dev server (see [Dev Servers](#dev-servers-portless))
+- `npm run dev` — Start dev server directly at http://localhost:4000 (only if portless is unavailable)
 - `npm run build` — Production build (takes 2+ minutes, set timeout to 180s+)
 - `npm run lint` — Run ESLint (takes 85s+, set timeout to 120s+)
 - `npm run lint-fix` — ESLint with auto-fix
 - `npm run format` — Prettier formatting
 
 See [`docs/local-development.md`](docs/local-development.md) for the full local setup and [`docs/testing.md`](docs/testing.md) for E2E testing.
+
+## Dev Servers (portless)
+
+Start dev servers with [`portless`](https://www.npmjs.com/package/portless) instead of `npm run dev`. It picks a free port and serves the app at a stable `https://<name>.localhost` URL (namespaced per git worktree), so parallel agents don't clash on ports or share cookies/storage across branches.
+
+```bash
+portless               # start the dev server; prints its URL
+portless list          # show active routes and URLs
+portless prune         # kill orphaned dev servers
+```
+
+- Keep `portless` running in the background; Vite HMR handles changes.
+- For `curl`, pass `--cacert ~/.portless/ca.pem`.
+- If portless is unavailable, fall back to `npm run dev`.
 
 ## Code Style Guidelines
 
@@ -51,12 +66,13 @@ Path-specific rules live in [`.github/instructions/`](.github/instructions/) (au
 When working autonomously on this codebase, follow this sequence:
 
 1. **Before coding:** Read relevant source files and understand existing patterns
-2. **After changes:** Run `npm run lint-fix` and `npm run format` on changed files (pre-commit hooks also run these automatically)
-3. **Verify:** Run relevant Playwright tests against the local backend to validate changes (see [`docs/testing.md`](docs/testing.md))
-4. **For API changes:** Check corresponding backend endpoint in the care backend repo and update both repos if needed
-5. **For new features:** Add Playwright tests in `tests/` following [`tests/PLAYWRIGHT_GUIDE.md`](tests/PLAYWRIGHT_GUIDE.md)
-6. **For i18n:** Add English strings to `public/locale/en.json`
-7. **For writing tests:** Read [`tests/PLAYWRIGHT_GUIDE.md`](tests/PLAYWRIGHT_GUIDE.md) — it contains complete patterns for all form interactions, selectors, assertions, and helpers
+2. **To preview changes:** Start the dev server with `portless` (see [Dev Servers](#dev-servers-portless)) and use the URL it prints for browser tooling
+3. **After changes:** Run `npm run lint-fix` and `npm run format` on changed files (pre-commit hooks also run these automatically)
+4. **Verify:** Run relevant Playwright tests against the local backend to validate changes (see [`docs/testing.md`](docs/testing.md))
+5. **For API changes:** Check corresponding backend endpoint in the care backend repo and update both repos if needed
+6. **For new features:** Add Playwright tests in `tests/` following [`tests/PLAYWRIGHT_GUIDE.md`](tests/PLAYWRIGHT_GUIDE.md)
+7. **For i18n:** Add English strings to `public/locale/en.json`
+8. **For writing tests:** Read [`tests/PLAYWRIGHT_GUIDE.md`](tests/PLAYWRIGHT_GUIDE.md) — it contains complete patterns for all form interactions, selectors, assertions, and helpers
 
 ### Quick verification cycle
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npm run dev
 
 Once the development server has started, open [localhost:4000](http://localhost:4000) in your browser. The page will be automatically reloaded when you make edits and save. You will also see any lint errors in the console.
 
+Alternatively, run [`portless`](https://www.npmjs.com/package/portless) instead of `npm run dev` to serve the app at a stable `https://<name>.localhost` URL on a free port — handy when running multiple branches or git worktrees at once.
+
 #### 🔑 Local Backend Setup and Credentials
 
 First, set up the CARE local backend by following the instructions in the [CARE Backend Documentation](https://care-be-docs.ohc.network/).

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -55,7 +55,8 @@ REACT_CARE_API_URL=http://127.0.0.1:9000
 
 ## Build/Lint Commands
 
-- `npm run dev` — Start dev server at http://localhost:4000
+- `portless` — Preferred way to start the dev server; see [Dev Servers](../AGENTS.md#dev-servers-portless) in `AGENTS.md`
+- `npm run dev` — Start dev server directly at http://localhost:4000
 - `npm run build` — Production build (takes 2+ minutes, set timeout to 180s+)
 - `npm run lint` — Run ESLint (takes 85s+, set timeout to 120s+)
 - `npm run lint-fix` — ESLint with auto-fix

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   ],
   "author": "Open Healthcare Network Contributors",
   "license": "MIT",
+  "portless": {
+    "name": "care",
+    "script": "dev"
+  },
   "scripts": {
     "dev": "npm run build:meta && npm run supported-browsers && vite",
     "local": "npm run supported-browsers && vite --mode docker",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -532,7 +532,8 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
       target: "es2022",
     },
     server: {
-      port: 4000,
+      port: Number(process.env.PORT) || 4000,
+      strictPort: !!process.env.PORT,
       host: "0.0.0.0",
       allowedHosts: true,
       watch: {
@@ -554,7 +555,8 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
           img-src 'self' https://cdn.ohc.network ${cdnUrls};\
           object-src 'self' ${cdnUrls};`,
       },
-      port: 4000,
+      port: Number(process.env.PORT) || 4000,
+      strictPort: !!process.env.PORT,
     },
   };
 });


### PR DESCRIPTION
### Proposed changes

- Adds support for running vite-server using [portless](https://portless.sh/)
- `portless` uses `PORT` env var to set 
- Why/how this helps in development: https://portless.sh/why


<img width="1039" height="1364" alt="image" src="https://github.com/user-attachments/assets/224f8fc3-b4b6-45ef-b867-53984c767426" />

<img width="1068" height="836" alt="image" src="https://github.com/user-attachments/assets/dc3e1f41-97f9-409a-885d-55a299825599" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local development and preview servers now support a configurable port, defaulting to port 4000 when none is specified.
  - Explicitly configured ports are enforced to ensure the application starts on the requested port.
  - Added streamlined startup support for serving the app through a stable local URL on an available port.

- **Documentation**
  - Updated development documentation with instructions for the preferred startup method and the direct localhost fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->